### PR TITLE
Add automated test suite with Vitest, TypeScript 5, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+
+      - name: Type-check
+        run: yarn typecheck
+
+      - name: Test
+        run: yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .vscode
+coverage
 dist
 node_modules
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ import * as ml from 'machine-learning';
 const inputs = new ml.Matrix([[0, 0], [0, 1], [1, 0], [1, 1], [1, 1], [2, 2]]);
 const targets = new ml.Matrix([[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1]]);
 
-const nearestNeighbors = new ml.NearestNeighbors(inputs, targets);
+const nearestNeighbors = new ml.NearestNeighbors();
 nearestNeighbors.setNumberOfNeighbors(1);
+
+nearestNeighbors.train(inputs, targets);
 
 const unknowns = new ml.Matrix([[0.5, 0.5], [1.5, 1.5], [1.75, 1.75]]);
 
@@ -109,4 +111,18 @@ const predictions = nearestNeighbors.predict(unknowns);
 console.log(predictions.toArray());
 // [ [ 0.4, 0.2, 0.2, 0.2 ], [ 0.6666666666666666, 0, 0, 0.3333333333333333 ], [ 0, 0, 0, 1 ] ]
 
+```
+
+## Development
+
+This project is written in TypeScript and tested with [Vitest](https://vitest.dev/).
+
+```bash
+yarn install        # install dependencies
+yarn test           # run the test suite
+yarn test:watch     # run the tests in watch mode
+yarn coverage       # run the tests with a coverage report
+yarn typecheck      # type-check without emitting
+yarn build          # compile the library to dist/lib
+yarn demo           # run the runnable examples in examples/demo.ts
 ```

--- a/compile.sh
+++ b/compile.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-clear
-
-# Compile TypeScript to JavaScript
-rm -rf dist
-echo "Compiling TypeScript";
-tsc
-echo "Done Compiling TypeScript";

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -1,4 +1,4 @@
-import * as ml from '../lib/index';
+import * as ml from '../src/lib';
 
 {
     // Feedforward neural network: solve XNOR problem (opposite of XOR)

--- a/package.json
+++ b/package.json
@@ -4,8 +4,17 @@
   "description": "TypeScript & JavaScript machine learning library",
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index",
+  "files": [
+    "dist/lib"
+  ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "coverage": "vitest run --coverage",
+    "demo": "tsx examples/demo.ts",
+    "prepublishOnly": "yarn build"
   },
   "repository": {
     "type": "git",
@@ -35,8 +44,11 @@
     "chance": "^1.0.4"
   },
   "devDependencies": {
-    "@types/node": "^7.0.5",
-    "typescript": "^2.1.6"
+    "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^4.1.8",
+    "tsx": "^4.22.4",
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.8"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/test/FeedforwardNeuralNetwork.test.ts
+++ b/src/test/FeedforwardNeuralNetwork.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import FeedforwardNeuralNetwork from '../lib/machine-learning/supervised/FeedforwardNeuralNetwork';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+import { XNOR_INPUTS, XNOR_TARGETS, FIXED_SEED } from './helpers/fixtures';
+
+describe('FeedforwardNeuralNetwork', () => {
+
+    describe('checkGradients', () => {
+        // Numerically verifies analytic backprop against finite differences (tolerance 1e-4).
+        // The math is correct, so this is deterministic in outcome despite using unseeded weights.
+        it('confirms analytic gradients match numeric gradients for a small network', () => {
+            expect(new FeedforwardNeuralNetwork([2, 5, 1]).checkGradients()).toBe(true);
+        });
+
+        it('confirms gradients for a deeper network', () => {
+            expect(new FeedforwardNeuralNetwork([3, 4, 4, 2]).checkGradients()).toBe(true);
+        });
+    });
+
+    describe('learning XNOR', () => {
+        const trainXnor = (seed: number) => {
+            const network = new FeedforwardNeuralNetwork([2, 5, 1], seed);
+            network.setNumberOfEpochs(1000);
+            network.setLearningRate(1);
+            network.train(new Matrix(XNOR_INPUTS), new Matrix(XNOR_TARGETS));
+            return network;
+        };
+
+        it('classifies all four XNOR cases correctly with a fixed seed', () => {
+            const predictions = trainXnor(FIXED_SEED).predict(new Matrix(XNOR_INPUTS)).toArray();
+
+            // XNOR targets are [1, 0, 0, 1]; assert each prediction lands on the correct side of 0.5.
+            expect(predictions[0][0]).toBeGreaterThan(0.5);
+            expect(predictions[1][0]).toBeLessThan(0.5);
+            expect(predictions[2][0]).toBeLessThan(0.5);
+            expect(predictions[3][0]).toBeGreaterThan(0.5);
+        });
+
+        it('is reproducible: the same seed yields identical predictions', () => {
+            const first = trainXnor(FIXED_SEED).predict(new Matrix(XNOR_INPUTS)).toArray();
+            const second = trainXnor(FIXED_SEED).predict(new Matrix(XNOR_INPUTS)).toArray();
+
+            expect(first).toEqual(second);
+        });
+    });
+
+    describe('parameter accessors', () => {
+        it('round-trips the configurable hyperparameters', () => {
+            const network = new FeedforwardNeuralNetwork([2, 2, 1]);
+
+            network.setLearningRate(0.5);
+            network.setNumberOfEpochs(250);
+            network.setBatchSize(4);
+
+            expect(network.getLearningRate()).toBe(0.5);
+            expect(network.getNumberOfEpochs()).toBe(250);
+            expect(network.getBatchSize()).toBe(4);
+        });
+    });
+});

--- a/src/test/LinearRegression.test.ts
+++ b/src/test/LinearRegression.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import LinearRegression from '../lib/machine-learning/supervised/LinearRegression';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+import { LINEAR_INPUTS, LINEAR_TARGETS } from './helpers/fixtures';
+
+describe('LinearRegression', () => {
+
+    it('converges to the underlying linear relationship (y = 1000 + 200x)', () => {
+        const regression = new LinearRegression();
+        regression.setNumberOfEpochs(10000).setLearningRate(0.02);
+
+        regression.train(new Matrix(LINEAR_INPUTS), new Matrix(LINEAR_TARGETS));
+        const predictions = regression.predict(new Matrix(LINEAR_INPUTS)).toArray();
+
+        predictions.forEach((row, i) => {
+            expect(Math.abs(row[0] - LINEAR_TARGETS[i][0])).toBeLessThan(1);
+        });
+    });
+
+    it('predict applies the bias-enriched hypothesis directly', () => {
+        const regression = new LinearRegression();
+        // Hypothesis is [intercept, slope] against inputs enriched with a leading bias column.
+        regression.setHypothesis(new Matrix([[1000], [200]]));
+
+        const predictions = regression.predict(new Matrix([[5], [7]])).toArray();
+
+        expect(predictions).toEqual([[2000], [2400]]);
+    });
+
+    it('resetHypothesis clears the learned weights', () => {
+        const regression = new LinearRegression();
+        regression.setNumberOfEpochs(100).train(new Matrix(LINEAR_INPUTS), new Matrix(LINEAR_TARGETS));
+
+        expect(regression.getHypothesis()).toBeDefined();
+
+        regression.resetHypothesis();
+
+        expect(regression.getHypothesis()).toBeUndefined();
+    });
+
+    it('exposes its hyperparameters', () => {
+        const regression = new LinearRegression();
+        regression.setLearningRate(0.05).setNumberOfEpochs(42);
+
+        expect(regression.getLearningRate()).toBe(0.05);
+        expect(regression.getNumberOfEpochs()).toBe(42);
+    });
+});

--- a/src/test/LogisticRegression.test.ts
+++ b/src/test/LogisticRegression.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import LogisticRegression from '../lib/machine-learning/supervised/LogisticRegression';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+import { LOGISTIC_INPUTS, LOGISTIC_TARGETS, LOGISTIC_EXPECTED_CLASSES } from './helpers/fixtures';
+
+describe('LogisticRegression', () => {
+
+    it('classifies the training set correctly', () => {
+        const regression = new LogisticRegression();
+        regression.setNumberOfEpochs(1000).setLearningRate(0.01);
+
+        regression.train(new Matrix(LOGISTIC_INPUTS), new Matrix(LOGISTIC_TARGETS));
+        const predictions = regression.predict(new Matrix(LOGISTIC_INPUTS)).toArray();
+
+        predictions.forEach((row, i) => {
+            const predictedClass = row[0] >= 0.5 ? 1 : 0;
+            expect(predictedClass).toBe(LOGISTIC_EXPECTED_CLASSES[i]);
+        });
+    });
+
+    it('produces probabilities in the (0, 1] range', () => {
+        const regression = new LogisticRegression();
+        regression.setNumberOfEpochs(1000).setLearningRate(0.01);
+
+        regression.train(new Matrix(LOGISTIC_INPUTS), new Matrix(LOGISTIC_TARGETS));
+        const values = regression.predict(new Matrix(LOGISTIC_INPUTS)).toArray().flat();
+
+        for (const value of values) {
+            expect(value).toBeGreaterThanOrEqual(0);
+            expect(value).toBeLessThanOrEqual(1);
+        }
+    });
+
+    it('applies the sigmoid of the bias-enriched hypothesis in predict', () => {
+        const regression = new LogisticRegression();
+        regression.setHypothesis(new Matrix([[0], [0]]));
+
+        // With a zero hypothesis every sigmoid output is exactly 0.5.
+        const predictions = regression.predict(new Matrix([[10], [-10]])).toArray();
+
+        expect(predictions).toEqual([[0.5], [0.5]]);
+    });
+});

--- a/src/test/Matrix.test.ts
+++ b/src/test/Matrix.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect } from 'vitest';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+import { expectMatrixClose } from './helpers/matrix-assert';
+
+describe('Matrix', () => {
+
+    describe('construction', () => {
+        it('builds from a 2D array and round-trips through toArray', () => {
+            const matrix = new Matrix([[1, 2, 3], [4, 5, 6]]);
+
+            expect(matrix.getRowCount()).toBe(2);
+            expect(matrix.getColumnCount()).toBe(3);
+            expect(matrix.toArray()).toEqual([[1, 2, 3], [4, 5, 6]]);
+        });
+
+        it('builds from a Float64Array with explicit dimensions', () => {
+            const matrix = new Matrix(new Float64Array([1, 2, 3, 4]), 2, 2);
+
+            expect(matrix.toArray()).toEqual([[1, 2], [3, 4]]);
+        });
+
+        it('treats an empty array as a 0x0 matrix', () => {
+            const matrix = new Matrix([]);
+
+            expect(matrix.getRowCount()).toBe(0);
+            expect(matrix.getColumnCount()).toBe(0);
+        });
+    });
+
+    describe('factory methods', () => {
+        it('ones / zeros fill the requested shape', () => {
+            expect(Matrix.ones(2, 3).toArray()).toEqual([[1, 1, 1], [1, 1, 1]]);
+            expect(Matrix.zeros(2, 2).toArray()).toEqual([[0, 0], [0, 0]]);
+        });
+
+        it('identity has ones on the diagonal', () => {
+            expect(Matrix.identity(3).toArray()).toEqual([
+                [1, 0, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+            ]);
+        });
+
+        it('columnVector turns a flat array into a column', () => {
+            expect(Matrix.columnVector([1, 2, 3]).toArray()).toEqual([[1], [2], [3]]);
+        });
+
+        describe('rand', () => {
+            it('is deterministic for the same seed', () => {
+                const a = Matrix.rand(3, 4, 1, 42);
+                const b = Matrix.rand(3, 4, 1, 42);
+
+                expect(a.toArray()).toEqual(b.toArray());
+            });
+
+            it('produces different output for different seeds', () => {
+                const a = Matrix.rand(3, 4, 1, 1);
+                const b = Matrix.rand(3, 4, 1, 2);
+
+                expect(a.toArray()).not.toEqual(b.toArray());
+            });
+
+            it('keeps every value within [-epsilon, epsilon)', () => {
+                const epsilon = 0.25;
+                const values = Matrix.rand(10, 10, epsilon, 7).toArray().flat();
+
+                for (const value of values) {
+                    expect(value).toBeGreaterThanOrEqual(-epsilon);
+                    expect(value).toBeLessThan(epsilon);
+                }
+            });
+        });
+    });
+
+    describe('arithmetic', () => {
+        it('adds two matrices', () => {
+            const result = Matrix.add(new Matrix([[1, 2], [3, 4]]), new Matrix([[10, 20], [30, 40]]));
+
+            expect(result.toArray()).toEqual([[11, 22], [33, 44]]);
+        });
+
+        it('adds a scalar to every element', () => {
+            expect(Matrix.add(new Matrix([[1, 2], [3, 4]]), 1).toArray()).toEqual([[2, 3], [4, 5]]);
+        });
+
+        it('subtracts matrices and scalars', () => {
+            expect(Matrix.subtract(new Matrix([[5, 5]]), new Matrix([[1, 2]])).toArray()).toEqual([[4, 3]]);
+            expect(Matrix.subtract(new Matrix([[5, 5]]), 2).toArray()).toEqual([[3, 3]]);
+        });
+
+        it('multiplies two matrices (2x3 · 3x2)', () => {
+            const a = new Matrix([[1, 2, 3], [4, 5, 6]]);
+            const b = new Matrix([[7, 8], [9, 10], [11, 12]]);
+
+            expect(Matrix.multiply(a, b).toArray()).toEqual([[58, 64], [139, 154]]);
+        });
+
+        it('multiplies by a scalar', () => {
+            expect(Matrix.multiply(new Matrix([[1, 2], [3, 4]]), 2).toArray()).toEqual([[2, 4], [6, 8]]);
+        });
+
+        it('multiplies element-wise (Hadamard)', () => {
+            const a = new Matrix([[1, 2], [3, 4]]);
+            const b = new Matrix([[5, 6], [7, 8]]);
+
+            expect(a.multiplyElementWise(b).toArray()).toEqual([[5, 12], [21, 32]]);
+        });
+
+        it('transposes', () => {
+            expect(Matrix.transpose(new Matrix([[1, 2, 3], [4, 5, 6]])).toArray()).toEqual([[1, 4], [2, 5], [3, 6]]);
+        });
+
+        it('transform applies a function with row and column indices', () => {
+            const matrix = new Matrix([[1, 2], [3, 4]]);
+
+            const result = Matrix.transform(matrix, (value, row, column) => value * 10 + row + column);
+
+            expect(result.toArray()).toEqual([[10, 21], [31, 42]]);
+        });
+    });
+
+    describe('mutation semantics', () => {
+        it('static operations return a clone and leave the operand unchanged', () => {
+            const original = new Matrix([[1, 2], [3, 4]]);
+
+            const result = Matrix.add(original, 100);
+
+            expect(result.toArray()).toEqual([[101, 102], [103, 104]]);
+            expect(original.toArray()).toEqual([[1, 2], [3, 4]]);
+        });
+
+        it('instance operations mutate the receiver in place', () => {
+            const matrix = new Matrix([[1, 2], [3, 4]]);
+
+            const returned = matrix.add(100);
+
+            expect(returned).toBe(matrix);
+            expect(matrix.toArray()).toEqual([[101, 102], [103, 104]]);
+        });
+
+        it('getClone produces an independent deep copy', () => {
+            const original = new Matrix([[1, 2], [3, 4]]);
+            const clone = original.getClone();
+
+            clone.setElement(0, 0, 99);
+
+            expect(clone.getElement(0, 0)).toBe(99);
+            expect(original.getElement(0, 0)).toBe(1);
+        });
+    });
+
+    describe('appending', () => {
+        it('appends rows on the bottom and top', () => {
+            expect(Matrix.appendBottom(new Matrix([[1, 2]]), new Matrix([[3, 4]])).toArray()).toEqual([[1, 2], [3, 4]]);
+            expect(Matrix.appendTop(new Matrix([[1, 2]]), new Matrix([[3, 4]])).toArray()).toEqual([[3, 4], [1, 2]]);
+        });
+
+        it('appends columns on the left and right', () => {
+            expect(Matrix.appendRight(new Matrix([[1], [2]]), new Matrix([[3], [4]])).toArray()).toEqual([[1, 3], [2, 4]]);
+            expect(Matrix.appendLeft(new Matrix([[1], [2]]), new Matrix([[3], [4]])).toArray()).toEqual([[3, 1], [4, 2]]);
+        });
+
+        it('appending onto an empty matrix copies the operand', () => {
+            expect(new Matrix([]).appendBottom(new Matrix([[1, 2]])).toArray()).toEqual([[1, 2]]);
+            expect(new Matrix([]).appendRight(new Matrix([[1], [2]])).toArray()).toEqual([[1], [2]]);
+        });
+    });
+
+    describe('accessors and slicing', () => {
+        const matrix = () => new Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
+
+        it('reads and writes individual elements', () => {
+            const m = matrix();
+
+            expect(m.getElement(1, 2)).toBe(6);
+            m.setElement(1, 2, 60);
+            expect(m.getElement(1, 2)).toBe(60);
+        });
+
+        it('extracts a single row and a range of rows', () => {
+            expect(matrix().getRow(1).toArray()).toEqual([[4, 5, 6]]);
+            expect(matrix().getRows(0, 1).toArray()).toEqual([[1, 2, 3], [4, 5, 6]]);
+            expect(matrix().getRows(1).toArray()).toEqual([[4, 5, 6], [7, 8, 9]]); // default end = last row
+        });
+
+        it('extracts a single column and a range of columns', () => {
+            expect(matrix().getColumn(0).toArray()).toEqual([[1], [4], [7]]);
+            expect(matrix().getColumns(1, 2).toArray()).toEqual([[2, 3], [5, 6], [8, 9]]);
+            expect(matrix().getColumns(1).toArray()).toEqual([[2, 3], [5, 6], [8, 9]]); // default end = last column
+        });
+    });
+
+    describe('aggregates', () => {
+        const matrix = new Matrix([[1, 5, 2], [9, 4, 6]]);
+
+        it('sums all elements', () => {
+            expect(matrix.getSum()).toBe(27);
+        });
+
+        it('reports the maximum and minimum values', () => {
+            expect(matrix.getMaximumValue()).toBe(9);
+            expect(matrix.getMinimumValue()).toBe(1);
+        });
+
+        it('returns the column index of the per-row maximum, breaking ties toward the first', () => {
+            const tied = new Matrix([[1, 3, 2], [5, 4, 6], [9, 9, 1]]);
+
+            expect(tied.getMaximumRowIndeces().toArray()).toEqual([[1], [2], [0]]);
+        });
+    });
+
+    describe('determinant and inverse', () => {
+        it('computes the determinant for 1x1, 2x2 and 3x3 matrices', () => {
+            expect(new Matrix([[7]]).getDeterminant()).toBe(7);
+            expect(new Matrix([[4, 7], [2, 6]]).getDeterminant()).toBe(10);
+            expect(new Matrix([[1, 2, 3], [0, 1, 4], [5, 6, 0]]).getDeterminant()).toBeCloseTo(1, 9);
+        });
+
+        it('inverts a 2x2 matrix', () => {
+            expectMatrixClose(new Matrix([[4, 7], [2, 6]]).getInverse(), [[0.6, -0.7], [-0.2, 0.4]]);
+        });
+
+        it('A · A⁻¹ ≈ identity for a 3x3 matrix', () => {
+            const a = new Matrix([[1, 2, 3], [0, 1, 4], [5, 6, 0]]);
+
+            expectMatrixClose(Matrix.multiply(a, a.getInverse()), Matrix.identity(3).toArray());
+        });
+    });
+
+    describe('error handling', () => {
+        it('throws when adding matrices of mismatched shape', () => {
+            expect(() => new Matrix([[1, 2]]).add(new Matrix([[1], [2]]))).toThrow(/different number of rows/);
+            expect(() => new Matrix([[1, 2]]).add(new Matrix([[1, 2, 3]]))).toThrow(/different number of columns/);
+        });
+
+        it('throws when subtracting matrices of mismatched shape', () => {
+            expect(() => new Matrix([[1, 2]]).subtract(new Matrix([[1, 2, 3]]))).toThrow(/Cannot subtract/);
+        });
+
+        it('throws when inner dimensions do not match for multiplication', () => {
+            expect(() => new Matrix([[1, 2]]).multiply(new Matrix([[1, 2]]))).toThrow(/Cannot multiply/);
+        });
+
+        it('throws on element-wise multiplication of mismatched shapes', () => {
+            expect(() => new Matrix([[1, 2]]).multiplyElementWise(new Matrix([[1, 2, 3]]))).toThrow(/element-wise/);
+        });
+
+        it('throws when appending mismatched dimensions', () => {
+            expect(() => new Matrix([[1, 2]]).appendBottom(new Matrix([[1, 2, 3]]))).toThrow(/appendBottom/);
+            expect(() => new Matrix([[1, 2]]).appendTop(new Matrix([[1, 2, 3]]))).toThrow(/appendTop/);
+            expect(() => new Matrix([[1], [2]]).appendLeft(new Matrix([[1]]))).toThrow(/appendLeft/);
+            expect(() => new Matrix([[1], [2]]).appendRight(new Matrix([[1]]))).toThrow(/appendRight/);
+        });
+
+        it('throws when computing the determinant or inverse of a non-square matrix', () => {
+            expect(() => new Matrix([[1, 2, 3]]).getDeterminant()).toThrow(/non-square/);
+            expect(() => new Matrix([[1, 2, 3]]).getInverse()).toThrow(/must be square/);
+        });
+
+        it('throws when inverting a singular matrix', () => {
+            expect(() => new Matrix([[1, 2], [2, 4]]).getInverse()).toThrow(/zero determinant/);
+        });
+    });
+});

--- a/src/test/MulticlassLogisticRegression.test.ts
+++ b/src/test/MulticlassLogisticRegression.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import MulticlassLogisticRegression from '../lib/machine-learning/supervised/MulticlassLogisticRegression';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+import { MULTICLASS_INPUTS, MULTICLASS_TARGETS, MULTICLASS_EXPECTED_CLASSES } from './helpers/fixtures';
+
+describe('MulticlassLogisticRegression', () => {
+
+    it('predicts the correct class (argmax) for every training example', () => {
+        const regression = new MulticlassLogisticRegression();
+        regression.setNumberOfEpochs(10000);
+        regression.setLearningRate(0.1);
+
+        regression.train(new Matrix(MULTICLASS_INPUTS), new Matrix(MULTICLASS_TARGETS));
+        const predictions = regression.predict(new Matrix(MULTICLASS_INPUTS));
+
+        expect(predictions.getMaximumRowIndeces().toArray()).toEqual(MULTICLASS_EXPECTED_CLASSES);
+    });
+
+    it('produces one prediction column per class', () => {
+        const regression = new MulticlassLogisticRegression();
+        regression.setNumberOfEpochs(100);
+        regression.setLearningRate(0.1);
+
+        regression.train(new Matrix(MULTICLASS_INPUTS), new Matrix(MULTICLASS_TARGETS));
+        const predictions = regression.predict(new Matrix(MULTICLASS_INPUTS));
+
+        expect(predictions.getRowCount()).toBe(MULTICLASS_INPUTS.length);
+        expect(predictions.getColumnCount()).toBe(MULTICLASS_TARGETS[0].length);
+    });
+
+    it('exposes one hypothesis per class after training', () => {
+        const regression = new MulticlassLogisticRegression();
+        regression.setNumberOfEpochs(100);
+
+        regression.train(new Matrix(MULTICLASS_INPUTS), new Matrix(MULTICLASS_TARGETS));
+
+        expect(regression.getHypothesis()).toHaveLength(MULTICLASS_TARGETS[0].length);
+    });
+});

--- a/src/test/NearestNeighbors.test.ts
+++ b/src/test/NearestNeighbors.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import NearestNeighbors from '../lib/machine-learning/supervised/NearestNeighbors';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+import { expectMatrixClose } from './helpers/matrix-assert';
+import { KNN_INPUTS, KNN_TARGETS, KNN_QUERIES, KNN_EXPECTED } from './helpers/fixtures';
+
+describe('NearestNeighbors', () => {
+
+    it('reproduces the documented k=1 predictions on equidistant data', () => {
+        const knn = new NearestNeighbors();
+        knn.setNumberOfNeighbors(1);
+        knn.train(new Matrix(KNN_INPUTS), new Matrix(KNN_TARGETS));
+
+        expectMatrixClose(knn.predict(new Matrix(KNN_QUERIES)), KNN_EXPECTED);
+    });
+
+    it('returns a point\'s own target when the query matches it exactly', () => {
+        const knn = new NearestNeighbors();
+        knn.train(new Matrix([[0, 0], [10, 10]]), new Matrix([[1, 0], [0, 1]]));
+
+        expect(knn.predict(new Matrix([[0, 0]])).toArray()).toEqual([[1, 0]]);
+    });
+
+    it('averages the k nearest neighbours when k > 1', () => {
+        const knn = new NearestNeighbors();
+        knn.setNumberOfNeighbors(2);
+        knn.train(new Matrix([[0], [10], [20]]), new Matrix([[2], [4], [100]]));
+
+        // Query 1 is closest to inputs 0 and 10 → average of targets 2 and 4 = 3.
+        expect(knn.predict(new Matrix([[1]])).toArray()).toEqual([[3]]);
+    });
+
+    it('uses the configured distance function', () => {
+        const train = () => {
+            const knn = new NearestNeighbors();
+            knn.train(new Matrix([[0], [10]]), new Matrix([[1, 0], [0, 1]]));
+            return knn;
+        };
+
+        // Default (euclidean-squared): query 3 is nearest to input 0 → first target.
+        expect(train().predict(new Matrix([[3]])).toArray()).toEqual([[1, 0]]);
+
+        // Negated distance inverts "nearest" → the farthest point (input 10) wins.
+        const inverted = train();
+        inverted.setDistanceFunction((x, y) => -Matrix.subtract(x, y).transform(v => v * v).getSum());
+        expect(inverted.predict(new Matrix([[3]])).toArray()).toEqual([[0, 1]]);
+    });
+
+    it('exposes its configuration', () => {
+        const knn = new NearestNeighbors();
+        const distance = (x: Matrix, y: Matrix) => Math.abs(x.getElement(0, 0) - y.getElement(0, 0));
+
+        knn.setNumberOfNeighbors(3);
+        knn.setDistanceFunction(distance);
+
+        expect(knn.getNumberOfNeighbors()).toBe(3);
+        expect(knn.getDistanceFunction()).toBe(distance);
+    });
+});

--- a/src/test/helpers/fixtures.ts
+++ b/src/test/helpers/fixtures.ts
@@ -1,0 +1,35 @@
+// Canonical datasets shared across the model test suites, mirroring examples/demo.ts.
+// Keeping them here lets each test assert against the same inputs the demo documents.
+
+/** XNOR (the opposite of XOR) — the classic non-linearly-separable problem. */
+export const XNOR_INPUTS = [[0, 0], [0, 1], [1, 0], [1, 1]];
+export const XNOR_TARGETS = [[1], [0], [0], [1]];
+
+/** A perfectly linear relationship: y = 1000 + 200 * x. */
+export const LINEAR_INPUTS = [[5], [7], [9], [11], [13]];
+export const LINEAR_TARGETS = [[2000], [2400], [2800], [3200], [3600]];
+
+/** Binary classification: is the second feature greater than the first? */
+export const LOGISTIC_INPUTS = [[1000, 1100], [4500, 3000], [700, 1300], [1150, 700], [1300, 1200], [600, 650]];
+export const LOGISTIC_TARGETS = [[1], [0], [1], [0], [0], [1]];
+/** Expected class per row (argmax / threshold), independent of saturation. */
+export const LOGISTIC_EXPECTED_CLASSES = [1, 0, 1, 0, 0, 1];
+
+/** Multiclass: which of the three features is the largest? (one-hot targets) */
+export const MULTICLASS_INPUTS = [[4500, 1200, 3000], [700, 890, 800], [700, 1200, 1300], [1150, 600, 700], [600, 1500, 1650], [400, 401, 400]];
+export const MULTICLASS_TARGETS = [[1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 0, 0], [0, 0, 1], [0, 1, 0]];
+/** Expected winning class index per row (argmax of the one-hot targets). */
+export const MULTICLASS_EXPECTED_CLASSES = [[0], [1], [2], [0], [2], [1]];
+
+/** k-NN with equidistant examples; demo breaks ties via multiple neighbors. */
+export const KNN_INPUTS = [[0, 0], [0, 1], [1, 0], [1, 1], [1, 1], [2, 2]];
+export const KNN_TARGETS = [[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1]];
+export const KNN_QUERIES = [[0.5, 0.5], [1.5, 1.5], [1.75, 1.75]];
+export const KNN_EXPECTED = [
+    [0.4, 0.2, 0.2, 0.2],
+    [0.6666666666666666, 0, 0, 0.3333333333333333],
+    [0, 0, 0, 1],
+];
+
+/** A fixed seed makes seeded models (Matrix.rand, FeedforwardNeuralNetwork) reproducible. */
+export const FIXED_SEED = 0;

--- a/src/test/helpers/matrix-assert.ts
+++ b/src/test/helpers/matrix-assert.ts
@@ -1,0 +1,21 @@
+import { expect } from 'vitest';
+import Matrix from '../../lib/math/linear-algebra/Matrix';
+
+/**
+ * Assert that a Matrix has the expected shape and element values (within a
+ * floating-point tolerance). `precision` is the number of decimal digits passed
+ * to Vitest's `toBeCloseTo` (default 9 ≈ exact for our deterministic math).
+ */
+export function expectMatrixClose(actual: Matrix, expected: number[][], precision = 9): void {
+    const rows = actual.toArray();
+
+    expect(rows.length).toBe(expected.length);
+
+    for (let i = 0; i < rows.length; i++) {
+        expect(rows[i].length).toBe(expected[i].length);
+
+        for (let j = 0; j < rows[i].length; j++) {
+            expect(rows[i][j]).toBeCloseTo(expected[i][j], precision);
+        }
+    }
+}

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-./compile.sh
-node dist/test/test

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "src"
+    },
+    "include": ["src/lib/**/*.ts"],
+    "exclude": ["node_modules", "dist", "src/test", "examples"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "lib": ["es7"],
+        "lib": ["es2017"],
         "module": "commonjs",
         "moduleResolution": "node",
         "noImplicitAny": true,
@@ -8,14 +8,11 @@
         "preserveConstEnums": true,
         "removeComments": true,
         "sourceMap": true,
-        "target": "es6",
-        "baseUrl": "src/types",
-        "typeRoots": ["src/types"],
-        "declaration": true
+        "target": "es2017",
+        "declaration": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true
     },
-    "files": [
-        "src/lib/index.ts",
-        "src/test/test.ts",
-        "node_modules/@types/node/index.d.ts"
-    ]
+    "include": ["src/**/*.ts", "examples/**/*.ts"],
+    "exclude": ["node_modules", "dist"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        include: ['src/test/**/*.test.ts'],
+        coverage: {
+            provider: 'v8',
+            include: ['src/lib/**'],
+        },
+    },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,18 +2,825 @@
 # yarn lockfile v1
 
 
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
+
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
+
+"@babel/parser@^7.29.3":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.7.tgz#837b87387cbf5ec5530cb634b3c622f68edb9334"
+  integrity sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==
+  dependencies:
+    "@babel/types" "^7.29.7"
+
+"@babel/types@^7.29.0", "@babel/types@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.7.tgz#8005e31d82712ee7adaef6e23c63b71a62770a92"
+  integrity sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==
+  dependencies:
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+
+"@bcoe/v8-coverage@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz#bbe12dca5b4ef983a0d0af4b07b9bc90ea0ababa"
+  integrity sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==
+
+"@emnapi/core@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"
+  integrity sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==
+  dependencies:
+    "@emnapi/wasi-threads" "1.2.1"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.10.0.tgz#4b260c0d3534204e98c6110b8db1a987d26ec87c"
+  integrity sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz#28fed21a1ba1ce797c44a070abc94d42f3ae8548"
+  integrity sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==
+  dependencies:
+    tslib "^2.4.0"
+
+"@esbuild/aix-ppc64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz#7a289c158e29cbf59ea0afc83cc80f06d1c89402"
+  integrity sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==
+
+"@esbuild/android-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz#b8828d9edfa3a92660644eb8de6e4f3c203d7b17"
+  integrity sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==
+
+"@esbuild/android-arm@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.28.0.tgz#5ec1847605e05b5dbe5df90db9ff7e3e4c58dca7"
+  integrity sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==
+
+"@esbuild/android-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.28.0.tgz#390642175b88ef82bad4cce03f8ab13fe9b1912e"
+  integrity sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==
+
+"@esbuild/darwin-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz#ae45325960d5950cd6951e4f97396f4e1ff7d8d3"
+  integrity sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==
+
+"@esbuild/darwin-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz#c079247d589b6b99449659d94f06951b84bff2e4"
+  integrity sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==
+
+"@esbuild/freebsd-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz#45c456215a486593c94900297202dc11c880a37a"
+  integrity sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==
+
+"@esbuild/freebsd-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz#0399494c1c85e4388e9b7040bd60d48f2a5b0d2c"
+  integrity sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==
+
+"@esbuild/linux-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz#d6d9f09ef0de54116bf459a4d53cac7e0952fe39"
+  integrity sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==
+
+"@esbuild/linux-arm@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz#7b42ffa84c288ae94fdc431c1b28a89e3c3b9278"
+  integrity sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==
+
+"@esbuild/linux-ia32@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz#deb15d112ed8dd605346b6b953d23a21ff81253f"
+  integrity sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==
+
+"@esbuild/linux-loong64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz#81fb89d07eecc79b157dea61033757726fce0ca4"
+  integrity sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==
+
+"@esbuild/linux-mips64el@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz#d0e42691b3ff7af9fb2217b70fc01f343bdb62bb"
+  integrity sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==
+
+"@esbuild/linux-ppc64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz#389f3e5e98f17d477c467cc87136e1a076eead87"
+  integrity sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==
+
+"@esbuild/linux-riscv64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz#763bd60d59b242be12da1e67d5729f3024c605fa"
+  integrity sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==
+
+"@esbuild/linux-s390x@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz#aac6061634872e4677de693bce8030d73b1fd055"
+  integrity sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==
+
+"@esbuild/linux-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz#4f2917747188fe77632bcec65b2d84b422419779"
+  integrity sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==
+
+"@esbuild/netbsd-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz#814df0ae57a0c386814491b8397eeba82094a947"
+  integrity sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==
+
+"@esbuild/netbsd-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz#e01bdf7e60fa1a08e46d46d960b0d9bb8ac210af"
+  integrity sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==
+
+"@esbuild/openbsd-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz#4a15c36aacca68d2d5a4c90b710c06759f4c1ffa"
+  integrity sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==
+
+"@esbuild/openbsd-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz#475e6101498a8ecce3008d7c388111d7a27c17bd"
+  integrity sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==
+
+"@esbuild/openharmony-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz#cfdc3957f0b7a69f1bde129aad17fcc2f6fa033e"
+  integrity sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==
+
+"@esbuild/sunos-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz#a013c856fecacd1c3aec985c8afe1d1cb017497d"
+  integrity sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==
+
+"@esbuild/win32-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz#eae05e0f35271cad3898b43168d3e9a3bbaf47e5"
+  integrity sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==
+
+"@esbuild/win32-ia32@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz#06161ebc5bf75c08d69feb3c6b22560515913998"
+  integrity sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==
+
+"@esbuild/win32-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz#04d90d5752b4ce65d2b6ac25eba08ff7624fe07c"
+  integrity sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==
+
+"@jridgewell/resolve-uri@^3.1.0":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
+
+"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.5":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
+"@jridgewell/trace-mapping@^0.3.31":
+  version "0.3.31"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@napi-rs/wasm-runtime@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz#a46bbfedc29751b7170c5d23bc1d8ee8c7e3c1e1"
+  integrity sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==
+  dependencies:
+    "@tybys/wasm-util" "^0.10.1"
+
+"@oxc-project/types@=0.133.0":
+  version "0.133.0"
+  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.133.0.tgz#2e282ef9e1d26e06b68ccd14b73f310a3b2cf7f8"
+  integrity sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==
+
+"@rolldown/binding-android-arm64@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz#54ce8f8382213f4a314a0c2f7ba83f81ffeae592"
+  integrity sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==
+
+"@rolldown/binding-darwin-arm64@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz#388fca1566c14c00c4b446fc3928630e7f0d95fc"
+  integrity sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==
+
+"@rolldown/binding-darwin-x64@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz#53f57de1f599ecf1db13823cfc88c18fb80954ad"
+  integrity sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==
+
+"@rolldown/binding-freebsd-x64@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz#6f3fdda1b7aeaac9d268a526804b4fb96e4e35f1"
+  integrity sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==
+
+"@rolldown/binding-linux-arm-gnueabihf@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz#d87a454bf585cc9676849377e91d6e375297326f"
+  integrity sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==
+
+"@rolldown/binding-linux-arm64-gnu@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz#419fd6bf612cf348f10528cbcd94ebab9607d8d1"
+  integrity sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==
+
+"@rolldown/binding-linux-arm64-musl@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz#fcc6918696bb76844877e1e4930a18fd0d374069"
+  integrity sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==
+
+"@rolldown/binding-linux-ppc64-gnu@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz#32aecb7c8dae5d4f2a8cde57a058ec86991542f8"
+  integrity sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==
+
+"@rolldown/binding-linux-s390x-gnu@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz#bed9346ea81e6bb8b93cf11f5d88b77db890b763"
+  integrity sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==
+
+"@rolldown/binding-linux-x64-gnu@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz#64c2d26f75dffd9b5a1f97557a00ae77250c8cb7"
+  integrity sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==
+
+"@rolldown/binding-linux-x64-musl@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz#5a45132e8a47659eeaaf3b540c2954a97c860ff3"
+  integrity sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==
+
+"@rolldown/binding-openharmony-arm64@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz#290513068c55e849dc8457a32afee1d7b0acb309"
+  integrity sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==
+
+"@rolldown/binding-wasm32-wasi@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz#3d9972dbf1a953d3c7afaa4a0f20ef2b2e39f31b"
+  integrity sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==
+  dependencies:
+    "@emnapi/core" "1.10.0"
+    "@emnapi/runtime" "1.10.0"
+    "@napi-rs/wasm-runtime" "^1.1.4"
+
+"@rolldown/binding-win32-arm64-msvc@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz#a004ab607a16d6f03bcb555728ff888af75773ad"
+  integrity sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==
+
+"@rolldown/binding-win32-x64-msvc@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz#e2a25b34691a1cc8a1209d7de709063026dd0cdb"
+  integrity sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==
+
+"@rolldown/pluginutils@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz#e3fcee093fbb5ce765e1ad088ff4de2889f6f9be"
+  integrity sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==
+
+"@standard-schema/spec@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
+
+"@tybys/wasm-util@^0.10.1":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.2.tgz#12b3a1b33db1f9cad4ddff1f604ab7dd00bf464e"
+  integrity sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==
+  dependencies:
+    tslib "^2.4.0"
+
+"@types/chai@^5.2.2":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
+  dependencies:
+    "@types/deep-eql" "*"
+    assertion-error "^2.0.1"
+
 "@types/chance@^0.7.31":
   version "0.7.31"
   resolved "https://registry.yarnpkg.com/@types/chance/-/chance-0.7.31.tgz#8dcd812456a261bb4d832243b85ebc5c68e28c80"
 
-"@types/node@^7.0.5":
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.5.tgz#96a0f0a618b7b606f1ec547403c00650210bfbb7"
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
+
+"@types/estree@^1.0.0":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.9.tgz#cf3f0e876d7bee15a93ab925b82bf570a3904a24"
+  integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
+
+"@types/node@^22.0.0":
+  version "22.19.20"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.19.20.tgz#243823634b177312895dab14a7fb1d0103094313"
+  integrity sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==
+  dependencies:
+    undici-types "~6.21.0"
+
+"@vitest/coverage-v8@^4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz#6a5dd34552840a0ace0396d0e94c7459beb80d14"
+  integrity sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==
+  dependencies:
+    "@bcoe/v8-coverage" "^1.0.2"
+    "@vitest/utils" "4.1.8"
+    ast-v8-to-istanbul "^1.0.0"
+    istanbul-lib-coverage "^3.2.2"
+    istanbul-lib-report "^3.0.1"
+    istanbul-reports "^3.2.0"
+    magicast "^0.5.2"
+    obug "^2.1.1"
+    std-env "^4.0.0-rc.1"
+    tinyrainbow "^3.1.0"
+
+"@vitest/expect@4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-4.1.8.tgz#45154f1f8559f55c5281eb0dcb1ac37b581a87d8"
+  integrity sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==
+  dependencies:
+    "@standard-schema/spec" "^1.1.0"
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "4.1.8"
+    "@vitest/utils" "4.1.8"
+    chai "^6.2.2"
+    tinyrainbow "^3.1.0"
+
+"@vitest/mocker@4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-4.1.8.tgz#d006bfc5894a1af51e74deddef2535d6bd436b16"
+  integrity sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==
+  dependencies:
+    "@vitest/spy" "4.1.8"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.21"
+
+"@vitest/pretty-format@4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-4.1.8.tgz#d9d2e248b900d7ad9556c4374fcdf1871c615193"
+  integrity sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==
+  dependencies:
+    tinyrainbow "^3.1.0"
+
+"@vitest/runner@4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-4.1.8.tgz#4631808f3996359b74ccc3ca262990e14c295d50"
+  integrity sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==
+  dependencies:
+    "@vitest/utils" "4.1.8"
+    pathe "^2.0.3"
+
+"@vitest/snapshot@4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-4.1.8.tgz#37470135d64ea11bb2a839b1c6b7f5de7018f6ee"
+  integrity sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==
+  dependencies:
+    "@vitest/pretty-format" "4.1.8"
+    "@vitest/utils" "4.1.8"
+    magic-string "^0.30.21"
+    pathe "^2.0.3"
+
+"@vitest/spy@4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-4.1.8.tgz#3abfe9301d25c39f808dcaa9f10fec0dd370e564"
+  integrity sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==
+
+"@vitest/utils@4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-4.1.8.tgz#099ea5255cec08735410cf707edaba2c158c5ad9"
+  integrity sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==
+  dependencies:
+    "@vitest/pretty-format" "4.1.8"
+    convert-source-map "^2.0.0"
+    tinyrainbow "^3.1.0"
+
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
+ast-v8-to-istanbul@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz#ba858c396a3d45f36a6963594fdfcd4675dfd445"
+  integrity sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.31"
+    estree-walker "^3.0.3"
+    js-tokens "^10.0.0"
+
+chai@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
+  integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
 
 chance@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/chance/-/chance-1.0.4.tgz#2dbc3ea6ad0541f7f965bd0af25d1ca275c853c4"
 
-typescript@^2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.1.6.tgz#40c7e6e9e5da7961b7718b55505f9cac9487a607"
+convert-source-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
+  integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+detect-libc@^2.0.3:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
+
+es-module-lexer@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-2.1.0.tgz#1dfcbb5ea3bbfb63f28e1fc3676c3676d1c9624c"
+  integrity sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==
+
+esbuild@~0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.28.0.tgz#5dee347ffb3e3874212a35a69836b077b1ce6d96"
+  integrity sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.28.0"
+    "@esbuild/android-arm" "0.28.0"
+    "@esbuild/android-arm64" "0.28.0"
+    "@esbuild/android-x64" "0.28.0"
+    "@esbuild/darwin-arm64" "0.28.0"
+    "@esbuild/darwin-x64" "0.28.0"
+    "@esbuild/freebsd-arm64" "0.28.0"
+    "@esbuild/freebsd-x64" "0.28.0"
+    "@esbuild/linux-arm" "0.28.0"
+    "@esbuild/linux-arm64" "0.28.0"
+    "@esbuild/linux-ia32" "0.28.0"
+    "@esbuild/linux-loong64" "0.28.0"
+    "@esbuild/linux-mips64el" "0.28.0"
+    "@esbuild/linux-ppc64" "0.28.0"
+    "@esbuild/linux-riscv64" "0.28.0"
+    "@esbuild/linux-s390x" "0.28.0"
+    "@esbuild/linux-x64" "0.28.0"
+    "@esbuild/netbsd-arm64" "0.28.0"
+    "@esbuild/netbsd-x64" "0.28.0"
+    "@esbuild/openbsd-arm64" "0.28.0"
+    "@esbuild/openbsd-x64" "0.28.0"
+    "@esbuild/openharmony-arm64" "0.28.0"
+    "@esbuild/sunos-x64" "0.28.0"
+    "@esbuild/win32-arm64" "0.28.0"
+    "@esbuild/win32-ia32" "0.28.0"
+    "@esbuild/win32-x64" "0.28.0"
+
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
+expect-type@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
+  integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
+
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
+
+fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
+  integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
+
+istanbul-lib-report@^3.0.0, istanbul-lib-report@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^4.0.0"
+    supports-color "^7.1.0"
+
+istanbul-reports@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
+
+js-tokens@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-10.0.0.tgz#dffe7599b4a8bb7fe30aff8d0235234dffb79831"
+  integrity sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==
+
+lightningcss-android-arm64@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz#f033885116dfefd9c6f54787523e3514b61e1968"
+  integrity sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==
+
+lightningcss-darwin-arm64@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz#50b71871b01c8199584b649e292547faea7af9b5"
+  integrity sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==
+
+lightningcss-darwin-x64@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz#35f3e97332d130b9ca181e11b568ded6aebc6d5e"
+  integrity sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==
+
+lightningcss-freebsd-x64@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz#9777a76472b64ed6ff94342ad64c7bafd794a575"
+  integrity sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==
+
+lightningcss-linux-arm-gnueabihf@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz#13ae652e1ab73b9135d7b7da172f666c410ad53d"
+  integrity sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==
+
+lightningcss-linux-arm64-gnu@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz#417858795a94592f680123a1b1f9da8a0e1ef335"
+  integrity sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==
+
+lightningcss-linux-arm64-musl@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz#6be36692e810b718040802fd809623cffe732133"
+  integrity sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==
+
+lightningcss-linux-x64-gnu@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz#0b7803af4eb21cfd38dd39fe2abbb53c7dd091f6"
+  integrity sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==
+
+lightningcss-linux-x64-musl@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz#88dc8ba865ddddb1ac5ef04b0f161804418c163b"
+  integrity sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==
+
+lightningcss-win32-arm64-msvc@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz#4f30ba3fa5e925f5b79f945e8cc0d176c3b1ab38"
+  integrity sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==
+
+lightningcss-win32-x64-msvc@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz#141aa5605645064928902bb4af045fa7d9f4220a"
+  integrity sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==
+
+lightningcss@^1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.32.0.tgz#b85aae96486dcb1bf49a7c8571221273f4f1e4a9"
+  integrity sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==
+  dependencies:
+    detect-libc "^2.0.3"
+  optionalDependencies:
+    lightningcss-android-arm64 "1.32.0"
+    lightningcss-darwin-arm64 "1.32.0"
+    lightningcss-darwin-x64 "1.32.0"
+    lightningcss-freebsd-x64 "1.32.0"
+    lightningcss-linux-arm-gnueabihf "1.32.0"
+    lightningcss-linux-arm64-gnu "1.32.0"
+    lightningcss-linux-arm64-musl "1.32.0"
+    lightningcss-linux-x64-gnu "1.32.0"
+    lightningcss-linux-x64-musl "1.32.0"
+    lightningcss-win32-arm64-msvc "1.32.0"
+    lightningcss-win32-x64-msvc "1.32.0"
+
+magic-string@^0.30.21:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
+
+magicast@^0.5.2:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.5.3.tgz#1800f6e76dd8b0dbe7257438a2c336aefabbd905"
+  integrity sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==
+  dependencies:
+    "@babel/parser" "^7.29.3"
+    "@babel/types" "^7.29.0"
+    source-map-js "^1.2.1"
+
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
+  dependencies:
+    semver "^7.5.3"
+
+nanoid@^3.3.12:
+  version "3.3.12"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
+  integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
+
+obug@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.2.tgz#024d704dceae438ef875556ebf9e22e47fd951c2"
+  integrity sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==
+
+pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
+picomatch@^4.0.3, picomatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+
+postcss@^8.5.15:
+  version "8.5.15"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.15.tgz#d1eaf677a324e9ec02196da2d3fecf4a0b9a735c"
+  integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==
+  dependencies:
+    nanoid "^3.3.12"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
+rolldown@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.0.3.tgz#db88a3008fb0e28230a00423727ce75ba32121ac"
+  integrity sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==
+  dependencies:
+    "@oxc-project/types" "=0.133.0"
+    "@rolldown/pluginutils" "^1.0.0"
+  optionalDependencies:
+    "@rolldown/binding-android-arm64" "1.0.3"
+    "@rolldown/binding-darwin-arm64" "1.0.3"
+    "@rolldown/binding-darwin-x64" "1.0.3"
+    "@rolldown/binding-freebsd-x64" "1.0.3"
+    "@rolldown/binding-linux-arm-gnueabihf" "1.0.3"
+    "@rolldown/binding-linux-arm64-gnu" "1.0.3"
+    "@rolldown/binding-linux-arm64-musl" "1.0.3"
+    "@rolldown/binding-linux-ppc64-gnu" "1.0.3"
+    "@rolldown/binding-linux-s390x-gnu" "1.0.3"
+    "@rolldown/binding-linux-x64-gnu" "1.0.3"
+    "@rolldown/binding-linux-x64-musl" "1.0.3"
+    "@rolldown/binding-openharmony-arm64" "1.0.3"
+    "@rolldown/binding-wasm32-wasi" "1.0.3"
+    "@rolldown/binding-win32-arm64-msvc" "1.0.3"
+    "@rolldown/binding-win32-x64-msvc" "1.0.3"
+
+semver@^7.5.3:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.2.tgz#194bd65723a28cf82542d2bf176b91c26b343be1"
+  integrity sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==
+
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
+std-env@^4.0.0-rc.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.1.0.tgz#45899abc590d86d682e87f0acd1033a75084cd3f"
+  integrity sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^1.0.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.2.4.tgz#ae45bb2edebda94c70f4ea897e0f1243e470db71"
+  integrity sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==
+
+tinyglobby@^0.2.15, tinyglobby@^0.2.17:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
+
+tinyrainbow@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.1.0.tgz#1d8a623893f95cf0a2ddb9e5d11150e191409421"
+  integrity sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==
+
+tslib@^2.4.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
+tsx@^4.22.4:
+  version "4.22.4"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.22.4.tgz#0ab3b7fb4ec7feeee74e5b1f26337caa71e44700"
+  integrity sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==
+  dependencies:
+    esbuild "~0.28.0"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+typescript@^5.0.0:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+"vite@^6.0.0 || ^7.0.0 || ^8.0.0":
+  version "8.0.16"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-8.0.16.tgz#ae073866c06563d6634a90169a496e11bd84f1a6"
+  integrity sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==
+  dependencies:
+    lightningcss "^1.32.0"
+    picomatch "^4.0.4"
+    postcss "^8.5.15"
+    rolldown "1.0.3"
+    tinyglobby "^0.2.17"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vitest@^4.1.8:
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-4.1.8.tgz#9fed17277bf7350497e54338898a7afd46dfd509"
+  integrity sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==
+  dependencies:
+    "@vitest/expect" "4.1.8"
+    "@vitest/mocker" "4.1.8"
+    "@vitest/pretty-format" "4.1.8"
+    "@vitest/runner" "4.1.8"
+    "@vitest/snapshot" "4.1.8"
+    "@vitest/spy" "4.1.8"
+    "@vitest/utils" "4.1.8"
+    es-module-lexer "^2.0.0"
+    expect-type "^1.3.0"
+    magic-string "^0.30.21"
+    obug "^2.1.1"
+    pathe "^2.0.3"
+    picomatch "^4.0.3"
+    std-env "^4.0.0-rc.1"
+    tinybench "^2.9.0"
+    tinyexec "^1.0.2"
+    tinyglobby "^0.2.15"
+    tinyrainbow "^3.1.0"
+    vite "^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running "^2.3.0"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"


### PR DESCRIPTION
The library previously had no automated tests — only a manual console.log demo. This adds a real, green, CI-enforced suite.

Toolchain:
- Upgrade typescript ^2.1.6 -> ^5 and @types/node ^7 -> ^22
- Add vitest, @vitest/coverage-v8, and tsx
- Modernize tsconfig (es2017, include/exclude, skipLibCheck); add tsconfig.build.json that publishes only dist/lib
- Add vitest.config.ts and test/coverage/build/typecheck/demo scripts
- Add "files": ["dist/lib"] so tests/examples never ship

Tests (src/test/, 59 cases):
- Matrix: construction, factories, seeded rand determinism, arithmetic with static-clone vs instance-mutate semantics, append/slice/accessors, determinant + inverse, and error cases
- FeedforwardNeuralNetwork: checkGradients(), seeded XNOR classification, reproducibility
- LinearRegression, LogisticRegression, MulticlassLogisticRegression, NearestNeighbors: convergence / argmax correctness on canonical datasets

CI:
- .github/workflows/ci.yml runs typecheck + tests on push/PR (yarn, Node 22)

Cleanups:
- Move the console.log demo to examples/demo.ts (runnable via `yarn demo`)
- Remove compile.sh/test.sh; gitignore coverage/
- README: add a Development section; fix the Nearest Neighbors example (wrong constructor, missing train() call)