### PR TITLE
Complete the interactive playground — all five algorithms

### DIFF
--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -5,6 +5,7 @@ import { Landing } from './pages/Landing';
 import { NotFound } from './pages/NotFound';
 import NeuralNetworkTutorial from './content/neural-network.mdx';
 import LinearRegressionTutorial from './content/linear-regression.mdx';
+import LogisticRegressionTutorial from './content/logistic-regression.mdx';
 
 export function App() {
     return (
@@ -24,6 +25,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <LinearRegressionTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="logistic-regression"
+                    element={
+                        <TutorialPage>
+                            <LogisticRegressionTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -4,6 +4,7 @@ import { TutorialPage } from './components/TutorialPage';
 import { Landing } from './pages/Landing';
 import { NotFound } from './pages/NotFound';
 import NeuralNetworkTutorial from './content/neural-network.mdx';
+import LinearRegressionTutorial from './content/linear-regression.mdx';
 
 export function App() {
     return (
@@ -15,6 +16,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <NeuralNetworkTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="linear-regression"
+                    element={
+                        <TutorialPage>
+                            <LinearRegressionTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -6,6 +6,8 @@ import { NotFound } from './pages/NotFound';
 import NeuralNetworkTutorial from './content/neural-network.mdx';
 import LinearRegressionTutorial from './content/linear-regression.mdx';
 import LogisticRegressionTutorial from './content/logistic-regression.mdx';
+import MulticlassLogisticRegressionTutorial from './content/multiclass-logistic-regression.mdx';
+import NearestNeighborsTutorial from './content/nearest-neighbors.mdx';
 
 export function App() {
     return (
@@ -33,6 +35,22 @@ export function App() {
                     element={
                         <TutorialPage>
                             <LogisticRegressionTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="multiclass-logistic-regression"
+                    element={
+                        <TutorialPage>
+                            <MulticlassLogisticRegressionTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="nearest-neighbors"
+                    element={
+                        <TutorialPage>
+                            <NearestNeighborsTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -2,6 +2,8 @@ import type { ComponentType } from 'react';
 import { NeuralNetworkPlayground } from './components/NeuralNetworkPlayground';
 import { LinearRegressionPlayground } from './components/LinearRegressionPlayground';
 import { LogisticRegressionPlayground } from './components/LogisticRegressionPlayground';
+import { MulticlassLogisticRegressionPlayground } from './components/MulticlassLogisticRegressionPlayground';
+import { NearestNeighborsPlayground } from './components/NearestNeighborsPlayground';
 
 /**
  * The catalog of algorithms the site covers. The neural network is live (flagship); the rest
@@ -47,13 +49,15 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         path: '/multiclass-logistic-regression',
         title: 'Multiclass Logistic',
         tagline: 'One-vs-rest classifiers carve up many classes.',
-        status: 'soon',
+        status: 'live',
+        Playground: MulticlassLogisticRegressionPlayground,
     },
     {
         id: 'nearest-neighbors',
         path: '/nearest-neighbors',
         title: 'Nearest Neighbors',
         tagline: 'Classifies each point by the company it keeps.',
-        status: 'soon',
+        status: 'live',
+        Playground: NearestNeighborsPlayground,
     },
 ];

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -1,5 +1,6 @@
 import type { ComponentType } from 'react';
 import { NeuralNetworkPlayground } from './components/NeuralNetworkPlayground';
+import { LinearRegressionPlayground } from './components/LinearRegressionPlayground';
 
 /**
  * The catalog of algorithms the site covers. The neural network is live (flagship); the rest
@@ -29,7 +30,8 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         path: '/linear-regression',
         title: 'Linear Regression',
         tagline: 'Fits the best straight line through a cloud of points.',
-        status: 'soon',
+        status: 'live',
+        Playground: LinearRegressionPlayground,
     },
     {
         id: 'logistic-regression',

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from 'react';
 import { NeuralNetworkPlayground } from './components/NeuralNetworkPlayground';
 import { LinearRegressionPlayground } from './components/LinearRegressionPlayground';
+import { LogisticRegressionPlayground } from './components/LogisticRegressionPlayground';
 
 /**
  * The catalog of algorithms the site covers. The neural network is live (flagship); the rest
@@ -38,7 +39,8 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         path: '/logistic-regression',
         title: 'Logistic Regression',
         tagline: 'Splits two classes with a straight decision boundary.',
-        status: 'soon',
+        status: 'live',
+        Playground: LogisticRegressionPlayground,
     },
     {
         id: 'multiclass-logistic-regression',

--- a/site/src/components/LinearRegressionPlayground.module.css
+++ b/site/src/components/LinearRegressionPlayground.module.css
@@ -7,12 +7,12 @@
 
 .stage {
     display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(280px, 1fr);
+    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
     gap: 20px;
     align-items: start;
 }
 
-.boundaryWrap {
+.plotWrap {
     position: relative;
     border-radius: var(--radius);
     overflow: hidden;
@@ -21,12 +21,12 @@
     aspect-ratio: 1 / 1;
 }
 
-.boundary {
+.plot {
     width: 100%;
     height: 100%;
 }
 
-.activation {
+.legend {
     position: absolute;
     bottom: 10px;
     left: 12px;
@@ -45,16 +45,17 @@
     gap: 16px;
 }
 
-.diagramCanvas {
+.equation {
     display: block;
-    width: 100%;
-    height: 200px;
+    font-size: 16px;
+    color: #aee1ff;
+    padding: 4px 0;
 }
 
 .lossCanvas {
     display: block;
     width: 100%;
-    height: 140px;
+    height: 150px;
 }
 
 @media (max-width: 900px) {

--- a/site/src/components/LinearRegressionPlayground.tsx
+++ b/site/src/components/LinearRegressionPlayground.tsx
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { LinearRegression, Matrix } from 'machine-learning';
+import { REGRESSION_DATASETS } from '../ml/regressionDatasets';
+import type { Domain } from '../ml/datasets';
+import { mse } from '../ml/metrics';
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+import { fitCanvas } from '../viz/canvas';
+import { drawRegression } from '../viz/regressionLine';
+import { drawLossCurve } from '../viz/lossCurve';
+import {
+    Card,
+    ControlPanel,
+    Hint,
+    Metric,
+    MetricsRow,
+    NumberField,
+    RunControls,
+    Select,
+    Slider,
+} from './controls/Controls';
+import styles from './LinearRegressionPlayground.module.css';
+
+const POINTS = 80;
+
+const sliderToLr = (slider: number) => Math.pow(10, -3 + 4 * (slider / 1000));
+const lrToSlider = (lr: number) => Math.round(((Math.log10(lr) + 3) / 4) * 1000);
+
+interface TrainingData {
+    inputs: number[][];
+    targets: number[][];
+    inputMatrix: Matrix;
+    targetMatrix: Matrix;
+}
+
+export function LinearRegressionPlayground() {
+    const [datasetId, setDatasetId] = useState(REGRESSION_DATASETS[0].id);
+    const [sliderLR, setSliderLR] = useState(lrToSlider(REGRESSION_DATASETS[0].recommendedLr));
+    const [seed, setSeed] = useState(0);
+    const [stepsPerFrame, setStepsPerFrame] = useState(3);
+    const [running, setRunning] = useState(false);
+    const [metrics, setMetrics] = useState({ epoch: 0, loss: 0, slope: 0, intercept: 0 });
+
+    const learningRate = sliderToLr(sliderLR);
+
+    const lrRef = useRef(learningRate);
+    const stepsRef = useRef(stepsPerFrame);
+    lrRef.current = learningRate;
+    stepsRef.current = stepsPerFrame;
+
+    const modelRef = useRef<LinearRegression | null>(null);
+    const dataRef = useRef<TrainingData | null>(null);
+    const domainRef = useRef<Domain>(REGRESSION_DATASETS[0].domain);
+    const lossRef = useRef<number[]>([]);
+    const epochRef = useRef(0);
+    const frameRef = useRef(0);
+
+    const plotCanvasRef = useRef<HTMLCanvasElement | null>(null);
+    const lossCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const readModel = () => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        const domain = domainRef.current;
+        if (!model || !data) return null;
+
+        const predicted = model.predict(data.inputMatrix).toArray().map(row => row[0]);
+        const ends = model.predict(new Matrix([[domain.xMin], [domain.xMax]])).toArray();
+        const line: [[number, number], [number, number]] = [
+            [domain.xMin, ends[0][0]],
+            [domain.xMax, ends[1][0]],
+        ];
+        const [[intercept], [slope]] = model.getHypothesis().toArray();
+        return { predicted, line, slope, intercept };
+    };
+
+    const drawAll = useCallback(() => {
+        const data = dataRef.current;
+        const read = readModel();
+        if (!data || !read) return;
+
+        const plotCanvas = plotCanvasRef.current;
+        if (plotCanvas) {
+            const { ctx, width, height } = fitCanvas(plotCanvas);
+            drawRegression(ctx, width, height, domainRef.current, data.inputs, data.targets, read.predicted, read.line);
+        }
+
+        const lossCanvas = lossCanvasRef.current;
+        if (lossCanvas) {
+            const { ctx, width, height } = fitCanvas(lossCanvas);
+            drawLossCurve(ctx, width, height, lossRef.current);
+        }
+    }, []);
+
+    const rebuild = useCallback(() => {
+        const dataset = REGRESSION_DATASETS.find(d => d.id === datasetId) ?? REGRESSION_DATASETS[0];
+        const { inputs, targets } = dataset.generate(seed, POINTS);
+        const inputMatrix = new Matrix(inputs);
+        const targetMatrix = new Matrix(targets);
+
+        const model = new LinearRegression();
+        model.setNumberOfEpochs(1); // one epoch per train() call → epochs driven by the loop
+        model.setLearningRate(lrRef.current);
+        // Start from a flat line at zero (intercept 0, slope 0); inputs are bias-enriched to 2 cols.
+        model.setHypothesis(Matrix.zeros(2, 1));
+
+        modelRef.current = model;
+        dataRef.current = { inputs, targets, inputMatrix, targetMatrix };
+        domainRef.current = dataset.domain;
+        epochRef.current = 0;
+        lossRef.current = [mse(model.predict(inputMatrix).toArray(), targets)];
+
+        setMetrics({ epoch: 0, loss: lossRef.current[0], slope: 0, intercept: 0 });
+        drawAll();
+    }, [datasetId, seed, drawAll]);
+
+    useEffect(() => {
+        rebuild();
+    }, [rebuild]);
+
+    useEffect(() => {
+        modelRef.current?.setLearningRate(learningRate);
+    }, [learningRate]);
+
+    const step = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        if (!model || !data) return;
+
+        const steps = stepsRef.current;
+        for (let i = 0; i < steps; i++) model.train(data.inputMatrix, data.targetMatrix);
+        epochRef.current += steps;
+
+        const loss = mse(model.predict(data.inputMatrix).toArray(), data.targets);
+        lossRef.current.push(loss);
+        if (lossRef.current.length > 1200) lossRef.current.shift();
+
+        drawAll();
+
+        frameRef.current += 1;
+        if (frameRef.current % 4 === 0) {
+            const read = readModel();
+            setMetrics({
+                epoch: epochRef.current,
+                loss,
+                slope: read?.slope ?? 0,
+                intercept: read?.intercept ?? 0,
+            });
+        }
+    }, [drawAll]);
+
+    useAnimationFrame(step, running);
+
+    const handleStep = () => {
+        if (!running) step();
+    };
+    const handleReset = () => {
+        setRunning(false);
+        rebuild();
+    };
+    const handleDataset = (id: string) => {
+        const next = REGRESSION_DATASETS.find(d => d.id === id);
+        if (!next) return;
+        setDatasetId(next.id);
+        setSliderLR(lrToSlider(next.recommendedLr));
+    };
+
+    const dataset = REGRESSION_DATASETS.find(d => d.id === datasetId);
+    const sign = metrics.intercept >= 0 ? '+' : '−';
+    const equation = `y = ${metrics.slope.toFixed(2)} · x ${sign} ${Math.abs(metrics.intercept).toFixed(2)}`;
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <RunControls
+                    running={running}
+                    onToggle={() => setRunning(r => !r)}
+                    onStep={handleStep}
+                    onReset={handleReset}
+                />
+                <Select
+                    label="Dataset"
+                    value={datasetId}
+                    options={REGRESSION_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={handleDataset}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Slider
+                    label="Learning rate"
+                    value={sliderLR}
+                    display={learningRate.toFixed(3)}
+                    min={0}
+                    max={1000}
+                    onChange={setSliderLR}
+                />
+                <Slider
+                    label="Speed"
+                    value={stepsPerFrame}
+                    display={`${stepsPerFrame} epochs / frame`}
+                    min={1}
+                    max={20}
+                    onChange={setStepsPerFrame}
+                />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.plotWrap}>
+                    <canvas ref={plotCanvasRef} className={styles.plot} />
+                    <div className={styles.legend}>
+                        <span style={{ color: 'var(--accent)' }}>● data</span>
+                        <span style={{ color: 'var(--accent-2)' }}>— fit</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Epoch" value={String(metrics.epoch)} />
+                        <Metric label="MSE" value={metrics.loss.toFixed(4)} />
+                        <Metric label="Slope" value={metrics.slope.toFixed(2)} />
+                    </MetricsRow>
+
+                    <Card title="Fitted line" subtitle="intercept + slope · x">
+                        <code className={styles.equation}>{equation}</code>
+                    </Card>
+
+                    <Card title="Loss" subtitle="mean squared error per epoch">
+                        <canvas ref={lossCanvasRef} className={styles.lossCanvas} />
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/components/LogisticRegressionPlayground.module.css
+++ b/site/src/components/LogisticRegressionPlayground.module.css
@@ -1,0 +1,69 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.boundaryWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 1 / 1;
+}
+
+.boundary {
+    width: 100%;
+    height: 100%;
+}
+
+.activation {
+    position: absolute;
+    bottom: 10px;
+    left: 12px;
+    display: flex;
+    gap: 14px;
+    font-size: 12px;
+    background: rgba(11, 17, 32, 0.6);
+    padding: 4px 10px;
+    border-radius: 999px;
+    backdrop-filter: blur(4px);
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+.lossCanvas {
+    display: block;
+    width: 100%;
+    height: 150px;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/LogisticRegressionPlayground.tsx
+++ b/site/src/components/LogisticRegressionPlayground.tsx
@@ -1,0 +1,226 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { LogisticRegression, Matrix } from 'machine-learning';
+import { DATASETS, type Domain } from '../ml/datasets';
+import { accuracy, crossEntropy } from '../ml/metrics';
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+import { fitCanvas } from '../viz/canvas';
+import { drawPoints, makeGrid, paintBoundary, type Grid } from '../viz/decisionBoundary';
+import { drawLossCurve } from '../viz/lossCurve';
+import {
+    Card,
+    ControlPanel,
+    Hint,
+    Metric,
+    MetricsRow,
+    NumberField,
+    RunControls,
+    Select,
+    Slider,
+} from './controls/Controls';
+import styles from './LogisticRegressionPlayground.module.css';
+
+const POINTS = 240;
+
+// A curated subset that tells the linear-boundary story: clean → partial → impossible.
+const LOGISTIC_DATASETS = ['blobs', 'moons', 'circles', 'xnor']
+    .map(id => DATASETS.find(d => d.id === id))
+    .filter((d): d is (typeof DATASETS)[number] => Boolean(d));
+
+const sliderToLr = (slider: number) => Math.pow(10, -3 + 4 * (slider / 1000));
+const lrToSlider = (lr: number) => Math.round(((Math.log10(lr) + 3) / 4) * 1000);
+
+interface TrainingData {
+    inputs: number[][];
+    targets: number[][];
+    inputMatrix: Matrix;
+    targetMatrix: Matrix;
+}
+
+export function LogisticRegressionPlayground() {
+    const [datasetId, setDatasetId] = useState(LOGISTIC_DATASETS[0].id);
+    const [sliderLR, setSliderLR] = useState(lrToSlider(1));
+    const [seed, setSeed] = useState(0);
+    const [stepsPerFrame, setStepsPerFrame] = useState(8);
+    const [running, setRunning] = useState(false);
+    const [metrics, setMetrics] = useState({ epoch: 0, loss: 0, acc: 0 });
+
+    const learningRate = sliderToLr(sliderLR);
+    const lrRef = useRef(learningRate);
+    const stepsRef = useRef(stepsPerFrame);
+    lrRef.current = learningRate;
+    stepsRef.current = stepsPerFrame;
+
+    const modelRef = useRef<LogisticRegression | null>(null);
+    const dataRef = useRef<TrainingData | null>(null);
+    const gridRef = useRef<Grid | null>(null);
+    const domainRef = useRef<Domain>(LOGISTIC_DATASETS[0].domain);
+    const lossRef = useRef<number[]>([]);
+    const epochRef = useRef(0);
+    const offscreenRef = useRef<HTMLCanvasElement | null>(null);
+    const frameRef = useRef(0);
+
+    const boundaryCanvasRef = useRef<HTMLCanvasElement | null>(null);
+    const lossCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const drawAll = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        const grid = gridRef.current;
+        if (!model || !data || !grid) return;
+
+        const boundaryCanvas = boundaryCanvasRef.current;
+        if (boundaryCanvas) {
+            const { ctx, width, height } = fitCanvas(boundaryCanvas);
+            ctx.fillStyle = '#0b1120';
+            ctx.fillRect(0, 0, width, height);
+
+            const values = model.predict(grid.matrix).toArray().map(row => row[0]);
+            if (!offscreenRef.current) offscreenRef.current = document.createElement('canvas');
+            paintBoundary(offscreenRef.current, values, grid.size);
+            ctx.imageSmoothingEnabled = true;
+            ctx.drawImage(offscreenRef.current, 0, 0, width, height);
+            drawPoints(ctx, data.inputs, data.targets, domainRef.current, width, height);
+        }
+
+        const lossCanvas = lossCanvasRef.current;
+        if (lossCanvas) {
+            const { ctx, width, height } = fitCanvas(lossCanvas);
+            drawLossCurve(ctx, width, height, lossRef.current);
+        }
+    }, []);
+
+    const rebuild = useCallback(() => {
+        const dataset = LOGISTIC_DATASETS.find(d => d.id === datasetId) ?? LOGISTIC_DATASETS[0];
+        const { inputs, targets } = dataset.generate(seed, POINTS);
+        const inputMatrix = new Matrix(inputs);
+        const targetMatrix = new Matrix(targets);
+
+        const model = new LogisticRegression();
+        model.setNumberOfEpochs(1); // one epoch per train() call → epochs driven by the loop
+        model.setLearningRate(lrRef.current);
+        model.setHypothesis(Matrix.zeros(3, 1)); // 2 features + bias → start at 0.5 everywhere
+
+        modelRef.current = model;
+        dataRef.current = { inputs, targets, inputMatrix, targetMatrix };
+        gridRef.current = makeGrid(dataset.domain);
+        domainRef.current = dataset.domain;
+        epochRef.current = 0;
+        lossRef.current = [crossEntropy(model.predict(inputMatrix).toArray(), targets)];
+
+        setMetrics({
+            epoch: 0,
+            loss: lossRef.current[0],
+            acc: accuracy(model.predict(inputMatrix).toArray(), targets),
+        });
+        drawAll();
+    }, [datasetId, seed, drawAll]);
+
+    useEffect(() => {
+        rebuild();
+    }, [rebuild]);
+
+    useEffect(() => {
+        modelRef.current?.setLearningRate(learningRate);
+    }, [learningRate]);
+
+    const step = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        if (!model || !data) return;
+
+        const steps = stepsRef.current;
+        for (let i = 0; i < steps; i++) model.train(data.inputMatrix, data.targetMatrix);
+        epochRef.current += steps;
+
+        const preds = model.predict(data.inputMatrix).toArray();
+        const loss = crossEntropy(preds, data.targets);
+        lossRef.current.push(loss);
+        if (lossRef.current.length > 1200) lossRef.current.shift();
+
+        drawAll();
+
+        frameRef.current += 1;
+        if (frameRef.current % 4 === 0) {
+            setMetrics({ epoch: epochRef.current, loss, acc: accuracy(preds, data.targets) });
+        }
+    }, [drawAll]);
+
+    useAnimationFrame(step, running);
+
+    const handleStep = () => {
+        if (!running) step();
+    };
+    const handleReset = () => {
+        setRunning(false);
+        rebuild();
+    };
+
+    const dataset = LOGISTIC_DATASETS.find(d => d.id === datasetId);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <RunControls
+                    running={running}
+                    onToggle={() => setRunning(r => !r)}
+                    onStep={handleStep}
+                    onReset={handleReset}
+                />
+                <Select
+                    label="Dataset"
+                    value={datasetId}
+                    options={LOGISTIC_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={setDatasetId}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Slider
+                    label="Learning rate"
+                    value={sliderLR}
+                    display={learningRate.toFixed(3)}
+                    min={0}
+                    max={1000}
+                    onChange={setSliderLR}
+                />
+                <Slider
+                    label="Speed"
+                    value={stepsPerFrame}
+                    display={`${stepsPerFrame} epochs / frame`}
+                    min={1}
+                    max={30}
+                    onChange={setStepsPerFrame}
+                />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.boundaryWrap}>
+                    <canvas ref={boundaryCanvasRef} className={styles.boundary} />
+                    <div className={styles.activation}>
+                        <span style={{ color: 'var(--accent)' }}>● class 0</span>
+                        <span style={{ color: 'var(--accent-2)' }}>● class 1</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Epoch" value={String(metrics.epoch)} />
+                        <Metric label="Loss" value={metrics.loss.toFixed(4)} />
+                        <Metric label="Accuracy" value={`${(metrics.acc * 100).toFixed(0)}%`} />
+                    </MetricsRow>
+
+                    <Card title="Decision boundary" subtitle="always a straight line">
+                        <p className={styles.note}>
+                            Logistic regression can only split the plane with one straight line. It
+                            nails linearly separable data — and visibly fails when the classes curve
+                            around each other.
+                        </p>
+                    </Card>
+
+                    <Card title="Loss" subtitle="cross-entropy per epoch">
+                        <canvas ref={lossCanvasRef} className={styles.lossCanvas} />
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/components/MulticlassLogisticRegressionPlayground.tsx
+++ b/site/src/components/MulticlassLogisticRegressionPlayground.tsx
@@ -1,0 +1,231 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { MulticlassLogisticRegression, Matrix } from 'machine-learning';
+import { MULTICLASS_DATASETS } from '../ml/multiclassDatasets';
+import type { Domain } from '../ml/datasets';
+import { argmaxAccuracy, crossEntropyMulticlass } from '../ml/metrics';
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+import { fitCanvas } from '../viz/canvas';
+import { makeGrid, type Grid } from '../viz/decisionBoundary';
+import { CLASS_HEX, drawClassPoints, paintMulticlass } from '../viz/multiclass';
+import { drawLossCurve } from '../viz/lossCurve';
+import {
+    Card,
+    ControlPanel,
+    Hint,
+    Metric,
+    MetricsRow,
+    NumberField,
+    RunControls,
+    Select,
+    Slider,
+} from './controls/Controls';
+import styles from './LogisticRegressionPlayground.module.css';
+
+const POINTS = 240;
+
+const sliderToLr = (slider: number) => Math.pow(10, -3 + 4 * (slider / 1000));
+const lrToSlider = (lr: number) => Math.round(((Math.log10(lr) + 3) / 4) * 1000);
+
+interface TrainingData {
+    inputs: number[][];
+    targets: number[][];
+    inputMatrix: Matrix;
+    targetMatrix: Matrix;
+    trueClass: number[];
+}
+
+export function MulticlassLogisticRegressionPlayground() {
+    const [datasetId, setDatasetId] = useState(MULTICLASS_DATASETS[0].id);
+    const [sliderLR, setSliderLR] = useState(lrToSlider(MULTICLASS_DATASETS[0].recommendedLr));
+    const [seed, setSeed] = useState(0);
+    const [stepsPerFrame, setStepsPerFrame] = useState(8);
+    const [running, setRunning] = useState(false);
+    const [metrics, setMetrics] = useState({ epoch: 0, loss: 0, acc: 0 });
+
+    const learningRate = sliderToLr(sliderLR);
+    const lrRef = useRef(learningRate);
+    const stepsRef = useRef(stepsPerFrame);
+    lrRef.current = learningRate;
+    stepsRef.current = stepsPerFrame;
+
+    const modelRef = useRef<MulticlassLogisticRegression | null>(null);
+    const dataRef = useRef<TrainingData | null>(null);
+    const gridRef = useRef<Grid | null>(null);
+    const domainRef = useRef<Domain>(MULTICLASS_DATASETS[0].domain);
+    const lossRef = useRef<number[]>([]);
+    const epochRef = useRef(0);
+    const offscreenRef = useRef<HTMLCanvasElement | null>(null);
+    const frameRef = useRef(0);
+
+    const boundaryCanvasRef = useRef<HTMLCanvasElement | null>(null);
+    const lossCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const drawAll = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        const grid = gridRef.current;
+        if (!model || !data || !grid) return;
+
+        const boundaryCanvas = boundaryCanvasRef.current;
+        if (boundaryCanvas) {
+            const { ctx, width, height } = fitCanvas(boundaryCanvas);
+            ctx.fillStyle = '#0b1120';
+            ctx.fillRect(0, 0, width, height);
+
+            const values = model.predict(grid.matrix).toArray();
+            if (!offscreenRef.current) offscreenRef.current = document.createElement('canvas');
+            paintMulticlass(offscreenRef.current, values, grid.size);
+            ctx.imageSmoothingEnabled = true;
+            ctx.drawImage(offscreenRef.current, 0, 0, width, height);
+            drawClassPoints(ctx, data.inputs, data.trueClass, domainRef.current, width, height);
+        }
+
+        const lossCanvas = lossCanvasRef.current;
+        if (lossCanvas) {
+            const { ctx, width, height } = fitCanvas(lossCanvas);
+            drawLossCurve(ctx, width, height, lossRef.current);
+        }
+    }, []);
+
+    const rebuild = useCallback(() => {
+        const dataset = MULTICLASS_DATASETS.find(d => d.id === datasetId) ?? MULTICLASS_DATASETS[0];
+        const { inputs, targets } = dataset.generate(seed, POINTS);
+        const inputMatrix = new Matrix(inputs);
+        const targetMatrix = new Matrix(targets);
+        const trueClass = targetMatrix.getMaximumRowIndeces().toArray().map(row => row[0]);
+
+        const model = new MulticlassLogisticRegression();
+        model.setNumberOfEpochs(1); // one epoch per train() call → epochs driven by the loop
+        model.setLearningRate(lrRef.current);
+        // The first train() lazily creates the per-class classifiers (so predict() is valid).
+        model.train(inputMatrix, targetMatrix);
+
+        modelRef.current = model;
+        dataRef.current = { inputs, targets, inputMatrix, targetMatrix, trueClass };
+        gridRef.current = makeGrid(dataset.domain);
+        domainRef.current = dataset.domain;
+        epochRef.current = 0;
+
+        const predictions = model.predict(inputMatrix);
+        lossRef.current = [crossEntropyMulticlass(predictions.toArray(), targets)];
+        const predClass = predictions.getMaximumRowIndeces().toArray().map(row => row[0]);
+        setMetrics({ epoch: 0, loss: lossRef.current[0], acc: argmaxAccuracy(predClass, trueClass) });
+        drawAll();
+    }, [datasetId, seed, drawAll]);
+
+    useEffect(() => {
+        rebuild();
+    }, [rebuild]);
+
+    useEffect(() => {
+        modelRef.current?.setLearningRate(learningRate);
+    }, [learningRate]);
+
+    const step = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        if (!model || !data) return;
+
+        const steps = stepsRef.current;
+        for (let i = 0; i < steps; i++) model.train(data.inputMatrix, data.targetMatrix);
+        epochRef.current += steps;
+
+        const predictions = model.predict(data.inputMatrix);
+        const loss = crossEntropyMulticlass(predictions.toArray(), data.targets);
+        lossRef.current.push(loss);
+        if (lossRef.current.length > 1200) lossRef.current.shift();
+
+        drawAll();
+
+        frameRef.current += 1;
+        if (frameRef.current % 4 === 0) {
+            const predClass = predictions.getMaximumRowIndeces().toArray().map(row => row[0]);
+            setMetrics({ epoch: epochRef.current, loss, acc: argmaxAccuracy(predClass, data.trueClass) });
+        }
+    }, [drawAll]);
+
+    useAnimationFrame(step, running);
+
+    const handleStep = () => {
+        if (!running) step();
+    };
+    const handleReset = () => {
+        setRunning(false);
+        rebuild();
+    };
+    const handleDataset = (id: string) => {
+        const next = MULTICLASS_DATASETS.find(d => d.id === id);
+        if (!next) return;
+        setDatasetId(next.id);
+        setSliderLR(lrToSlider(next.recommendedLr));
+    };
+
+    const dataset = MULTICLASS_DATASETS.find(d => d.id === datasetId);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <RunControls
+                    running={running}
+                    onToggle={() => setRunning(r => !r)}
+                    onStep={handleStep}
+                    onReset={handleReset}
+                />
+                <Select
+                    label="Dataset"
+                    value={datasetId}
+                    options={MULTICLASS_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={handleDataset}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Slider
+                    label="Learning rate"
+                    value={sliderLR}
+                    display={learningRate.toFixed(3)}
+                    min={0}
+                    max={1000}
+                    onChange={setSliderLR}
+                />
+                <Slider
+                    label="Speed"
+                    value={stepsPerFrame}
+                    display={`${stepsPerFrame} epochs / frame`}
+                    min={1}
+                    max={30}
+                    onChange={setStepsPerFrame}
+                />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.boundaryWrap}>
+                    <canvas ref={boundaryCanvasRef} className={styles.boundary} />
+                    <div className={styles.activation}>
+                        <span style={{ color: CLASS_HEX[0] }}>● class 0</span>
+                        <span style={{ color: CLASS_HEX[1] }}>● class 1</span>
+                        <span style={{ color: CLASS_HEX[2] }}>● class 2</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Epoch" value={String(metrics.epoch)} />
+                        <Metric label="Loss" value={metrics.loss.toFixed(3)} />
+                        <Metric label="Accuracy" value={`${(metrics.acc * 100).toFixed(0)}%`} />
+                    </MetricsRow>
+
+                    <Card title="One-vs-rest" subtitle="3 binary classifiers">
+                        <p className={styles.note}>
+                            One logistic classifier is trained per class — "this class vs. everything
+                            else" — and each point is given to whichever classifier is most confident.
+                        </p>
+                    </Card>
+
+                    <Card title="Loss" subtitle="cross-entropy per epoch">
+                        <canvas ref={lossCanvasRef} className={styles.lossCanvas} />
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/components/NearestNeighborsPlayground.tsx
+++ b/site/src/components/NearestNeighborsPlayground.tsx
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { NearestNeighbors, Matrix } from 'machine-learning';
+import { DATASETS, type Domain } from '../ml/datasets';
+import { accuracy } from '../ml/metrics';
+import { fitCanvas } from '../viz/canvas';
+import { drawPoints, makeGrid, paintBoundary, type Grid } from '../viz/decisionBoundary';
+import { Card, ControlPanel, Hint, Metric, MetricsRow, NumberField, Select, Slider } from './controls/Controls';
+import styles from './LogisticRegressionPlayground.module.css';
+
+// k-NN over a grid is O(cells × points); 70² keeps each recompute well under ~150ms.
+const GRID = 70;
+const POINTS = 200;
+
+// k-NN shines exactly where a straight line fails — show the curved datasets.
+const KNN_DATASETS = ['moons', 'circles', 'spiral', 'blobs']
+    .map(id => DATASETS.find(d => d.id === id))
+    .filter((d): d is (typeof DATASETS)[number] => Boolean(d));
+
+interface TrainingData {
+    inputs: number[][];
+    targets: number[][];
+    inputMatrix: Matrix;
+}
+
+export function NearestNeighborsPlayground() {
+    const [datasetId, setDatasetId] = useState(KNN_DATASETS[0].id);
+    const [k, setK] = useState(1);
+    const [seed, setSeed] = useState(0);
+    const [acc, setAcc] = useState(0);
+
+    const kRef = useRef(k);
+    kRef.current = k;
+
+    const modelRef = useRef<NearestNeighbors | null>(null);
+    const dataRef = useRef<TrainingData | null>(null);
+    const gridRef = useRef<Grid | null>(null);
+    const domainRef = useRef<Domain>(KNN_DATASETS[0].domain);
+    const offscreenRef = useRef<HTMLCanvasElement | null>(null);
+    const boundaryCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    // k-NN has no training loop: it just stores the data and votes. So we recompute the whole
+    // boundary on demand (dataset / k / seed) rather than animating epochs.
+    const recompute = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        const grid = gridRef.current;
+        if (!model || !data || !grid) return;
+
+        model.setNumberOfNeighbors(kRef.current);
+
+        const boundaryCanvas = boundaryCanvasRef.current;
+        if (boundaryCanvas) {
+            const { ctx, width, height } = fitCanvas(boundaryCanvas);
+            ctx.fillStyle = '#0b1120';
+            ctx.fillRect(0, 0, width, height);
+
+            const values = model.predict(grid.matrix).toArray().map(row => row[0]);
+            if (!offscreenRef.current) offscreenRef.current = document.createElement('canvas');
+            paintBoundary(offscreenRef.current, values, grid.size);
+            ctx.imageSmoothingEnabled = true;
+            ctx.drawImage(offscreenRef.current, 0, 0, width, height);
+            drawPoints(ctx, data.inputs, data.targets, domainRef.current, width, height);
+        }
+
+        setAcc(accuracy(model.predict(data.inputMatrix).toArray(), data.targets));
+    }, []);
+
+    const rebuild = useCallback(() => {
+        const dataset = KNN_DATASETS.find(d => d.id === datasetId) ?? KNN_DATASETS[0];
+        const { inputs, targets } = dataset.generate(seed, POINTS);
+        const inputMatrix = new Matrix(inputs);
+
+        const model = new NearestNeighbors();
+        model.setNumberOfNeighbors(kRef.current);
+        model.train(inputMatrix, new Matrix(targets)); // "training" = memorising the examples
+
+        modelRef.current = model;
+        dataRef.current = { inputs, targets, inputMatrix };
+        gridRef.current = makeGrid(dataset.domain, GRID);
+        domainRef.current = dataset.domain;
+        recompute();
+    }, [datasetId, seed, recompute]);
+
+    useEffect(() => {
+        rebuild();
+    }, [rebuild]);
+
+    // Recompute when k changes, debounced so dragging the slider stays smooth.
+    useEffect(() => {
+        const timer = setTimeout(() => recompute(), 60);
+        return () => clearTimeout(timer);
+    }, [k, recompute]);
+
+    const dataset = KNN_DATASETS.find(d => d.id === datasetId);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <Select
+                    label="Dataset"
+                    value={datasetId}
+                    options={KNN_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={setDatasetId}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Slider
+                    label="Neighbours (k)"
+                    value={k}
+                    display={String(k)}
+                    min={1}
+                    max={25}
+                    onChange={setK}
+                />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+                <Hint>No training to run — k-NN classifies straight from the stored points.</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.boundaryWrap}>
+                    <canvas ref={boundaryCanvasRef} className={styles.boundary} />
+                    <div className={styles.activation}>
+                        <span style={{ color: 'var(--accent)' }}>● class 0</span>
+                        <span style={{ color: 'var(--accent-2)' }}>● class 1</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Neighbours" value={String(k)} />
+                        <Metric label="Train acc" value={`${(acc * 100).toFixed(0)}%`} />
+                        <Metric label="Points" value={String(POINTS)} />
+                    </MetricsRow>
+
+                    <Card title="Lazy learning" subtitle="no model, just data">
+                        <p className={styles.note}>
+                            k-NN draws no equation and runs no gradient descent — it simply keeps every
+                            example and labels each new point by a vote of its <strong>k</strong> nearest
+                            neighbours. Small <strong>k</strong> gives jagged, overfit regions; larger
+                            <strong> k</strong> smooths the boundary. Unlike a straight-line classifier,
+                            it bends around moons, rings, and spirals with ease.
+                        </p>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/components/NeuralNetworkPlayground.tsx
+++ b/site/src/components/NeuralNetworkPlayground.tsx
@@ -7,6 +7,18 @@ import { fitCanvas } from '../viz/canvas';
 import { drawPoints, makeGrid, paintBoundary, type Grid } from '../viz/decisionBoundary';
 import { drawNetwork } from '../viz/network';
 import { drawLossCurve } from '../viz/lossCurve';
+import {
+    Badge,
+    Card,
+    ControlPanel,
+    Hint,
+    Metric,
+    MetricsRow,
+    NumberField,
+    RunControls,
+    Select,
+    Slider,
+} from './controls/Controls';
 import styles from './NeuralNetworkPlayground.module.css';
 
 const POINTS = 240;
@@ -182,101 +194,68 @@ export function NeuralNetworkPlayground() {
         setRunning(false);
         rebuild();
     };
+    const handleDataset = (id: string) => {
+        const next = DATASETS.find(d => d.id === id);
+        if (!next) return;
+        // Selecting a dataset applies a known-good architecture + learning rate so it converges
+        // impressively out of the box (still fully tweakable afterwards).
+        setDatasetId(next.id);
+        setHidden(next.recommendedHidden);
+        setSliderLR(lrToSlider(next.recommendedLr));
+    };
+    const handleHidden = (value: string) => {
+        const preset = HIDDEN_PRESETS.find(p => p.layers.join('-') === value);
+        if (preset) setHidden(preset.layers);
+    };
+
+    const dataset = DATASETS.find(d => d.id === datasetId);
 
     return (
         <div className={styles.playground}>
-            <aside className={styles.controls}>
-                <div className={styles.transport}>
-                    <button
-                        className={`${styles.btn} ${styles.primary}`}
-                        onClick={() => setRunning(r => !r)}
-                    >
-                        {running ? '❚❚ Pause' : '▶ Train'}
-                    </button>
-                    <button className={styles.btn} onClick={handleStep} disabled={running}>
-                        Step
-                    </button>
-                    <button className={styles.btn} onClick={handleReset}>
-                        Reset
-                    </button>
-                </div>
-
-                <label className={styles.field}>
-                    <span>Dataset</span>
-                    <select
-                        value={datasetId}
-                        onChange={e => {
-                            const next = DATASETS.find(d => d.id === e.target.value);
-                            if (!next) return;
-                            // Selecting a dataset applies a known-good architecture + learning rate
-                            // so it converges impressively out of the box (still fully tweakable).
-                            setDatasetId(next.id);
-                            setHidden(next.recommendedHidden);
-                            setSliderLR(lrToSlider(next.recommendedLr));
-                        }}
-                    >
-                        {DATASETS.map(d => (
-                            <option key={d.id} value={d.id}>{d.label}</option>
-                        ))}
-                    </select>
-                </label>
-                <p className={styles.blurb}>{DATASETS.find(d => d.id === datasetId)?.blurb}</p>
-
-                <label className={styles.field}>
-                    <span>Hidden layers</span>
-                    <select
-                        value={hidden.join('-')}
-                        onChange={e => {
-                            const preset = HIDDEN_PRESETS.find(p => p.layers.join('-') === e.target.value);
-                            if (preset) setHidden(preset.layers);
-                        }}
-                    >
-                        {HIDDEN_PRESETS.map(p => (
-                            <option key={p.label} value={p.layers.join('-')}>{p.label}</option>
-                        ))}
-                    </select>
-                </label>
-
-                <label className={styles.field}>
-                    <span>Learning rate <em>{learningRate.toFixed(3)}</em></span>
-                    <input
-                        type="range"
-                        min={0}
-                        max={1000}
-                        value={sliderLR}
-                        onChange={e => setSliderLR(Number(e.target.value))}
-                    />
-                </label>
-
-                <label className={styles.field}>
-                    <span>Speed <em>{stepsPerFrame} epochs / frame</em></span>
-                    <input
-                        type="range"
-                        min={1}
-                        max={30}
-                        value={stepsPerFrame}
-                        onChange={e => setStepsPerFrame(Number(e.target.value))}
-                    />
-                </label>
-
-                <label className={styles.field}>
-                    <span>Gradient descent</span>
-                    <select value={batchSize} onChange={e => setBatchSize(Number(e.target.value))}>
-                        {BATCH_MODES.map(m => (
-                            <option key={m.label} value={m.value}>{m.label}</option>
-                        ))}
-                    </select>
-                </label>
-
-                <label className={styles.field}>
-                    <span>Random seed</span>
-                    <input
-                        type="number"
-                        value={seed}
-                        onChange={e => setSeed(Number(e.target.value))}
-                    />
-                </label>
-            </aside>
+            <ControlPanel>
+                <RunControls
+                    running={running}
+                    onToggle={() => setRunning(r => !r)}
+                    onStep={handleStep}
+                    onReset={handleReset}
+                />
+                <Select
+                    label="Dataset"
+                    value={datasetId}
+                    options={DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={handleDataset}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Select
+                    label="Hidden layers"
+                    value={hidden.join('-')}
+                    options={HIDDEN_PRESETS.map(p => ({ value: p.layers.join('-'), label: p.label }))}
+                    onChange={handleHidden}
+                />
+                <Slider
+                    label="Learning rate"
+                    value={sliderLR}
+                    display={learningRate.toFixed(3)}
+                    min={0}
+                    max={1000}
+                    onChange={setSliderLR}
+                />
+                <Slider
+                    label="Speed"
+                    value={stepsPerFrame}
+                    display={`${stepsPerFrame} epochs / frame`}
+                    min={1}
+                    max={30}
+                    onChange={setStepsPerFrame}
+                />
+                <Select
+                    label="Gradient descent"
+                    value={String(batchSize)}
+                    options={BATCH_MODES.map(m => ({ value: String(m.value), label: m.label }))}
+                    onChange={v => setBatchSize(Number(v))}
+                />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+            </ControlPanel>
 
             <div className={styles.stage}>
                 <div className={styles.boundaryWrap}>
@@ -288,36 +267,21 @@ export function NeuralNetworkPlayground() {
                 </div>
 
                 <div className={styles.side}>
-                    <div className={styles.metrics}>
-                        <div className={styles.metric}>
-                            <span className={styles.metricLabel}>Epoch</span>
-                            <span className={styles.metricValue}>{metrics.epoch}</span>
-                        </div>
-                        <div className={styles.metric}>
-                            <span className={styles.metricLabel}>Loss</span>
-                            <span className={styles.metricValue}>{metrics.loss.toFixed(4)}</span>
-                        </div>
-                        <div className={styles.metric}>
-                            <span className={styles.metricLabel}>Accuracy</span>
-                            <span className={styles.metricValue}>{(metrics.acc * 100).toFixed(0)}%</span>
-                        </div>
-                    </div>
+                    <MetricsRow>
+                        <Metric label="Epoch" value={String(metrics.epoch)} />
+                        <Metric label="Loss" value={metrics.loss.toFixed(4)} />
+                        <Metric label="Accuracy" value={`${(metrics.acc * 100).toFixed(0)}%`} />
+                    </MetricsRow>
 
-                    {gradOk && (
-                        <div className={styles.badge} title="Backprop verified against finite-difference gradients">
-                            ✓ Gradients verified
-                        </div>
-                    )}
+                    {gradOk && <Badge>✓ Gradients verified</Badge>}
 
-                    <div className={styles.card}>
-                        <h3>Network <span>weights pulse as it learns</span></h3>
+                    <Card title="Network" subtitle="weights pulse as it learns">
                         <canvas ref={netCanvasRef} className={styles.diagramCanvas} />
-                    </div>
+                    </Card>
 
-                    <div className={styles.card}>
-                        <h3>Loss <span>cross-entropy per epoch</span></h3>
+                    <Card title="Loss" subtitle="cross-entropy per epoch">
                         <canvas ref={lossCanvasRef} className={styles.lossCanvas} />
-                    </div>
+                    </Card>
                 </div>
             </div>
         </div>

--- a/site/src/components/controls/Controls.module.css
+++ b/site/src/components/controls/Controls.module.css
@@ -1,0 +1,156 @@
+.panel {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    position: sticky;
+    top: 76px;
+}
+
+.transport {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 8px;
+}
+
+.btn {
+    appearance: none;
+    border: 1px solid var(--border);
+    background: var(--panel-2);
+    color: var(--text);
+    font: inherit;
+    font-size: 13px;
+    padding: 9px 6px;
+    border-radius: 9px;
+    cursor: pointer;
+    transition: border-color 0.15s, transform 0.05s;
+}
+
+.btn:hover {
+    border-color: var(--accent);
+}
+
+.btn:active {
+    transform: translateY(1px);
+}
+
+.btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.primary {
+    background: linear-gradient(180deg, #0ea5e9, #0284c7);
+    border-color: transparent;
+    color: #04121f;
+    font-weight: 600;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 13px;
+    color: var(--muted);
+}
+
+.field span {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
+.field em {
+    color: var(--text);
+    font-style: normal;
+    font-family: var(--mono);
+    font-size: 12px;
+}
+
+.field select,
+.field input[type='number'] {
+    appearance: none;
+    background: var(--panel-2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-radius: 8px;
+    padding: 8px 10px;
+    font: inherit;
+    font-size: 13px;
+}
+
+.field input[type='range'] {
+    width: 100%;
+    accent-color: var(--accent);
+}
+
+.hint {
+    margin: -6px 0 0;
+    font-size: 12px;
+    color: var(--muted);
+    line-height: 1.4;
+}
+
+.metrics {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 10px;
+}
+
+.metric {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.metricLabel {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--muted);
+}
+
+.metricValue {
+    font-family: var(--mono);
+    font-size: 20px;
+    font-weight: 600;
+}
+
+.badge {
+    align-self: flex-start;
+    background: rgba(52, 211, 153, 0.12);
+    border: 1px solid rgba(52, 211, 153, 0.4);
+    color: var(--good);
+    font-size: 12px;
+    padding: 5px 12px;
+    border-radius: 999px;
+}
+
+.card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 14px;
+}
+
+.card h3 {
+    margin: 0 0 10px;
+    font-size: 13px;
+    font-weight: 600;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
+.card h3 span {
+    font-weight: 400;
+    font-size: 11px;
+    color: var(--muted);
+}

--- a/site/src/components/controls/Controls.tsx
+++ b/site/src/components/controls/Controls.tsx
@@ -1,0 +1,157 @@
+import type { ReactNode } from 'react';
+import styles from './Controls.module.css';
+
+// Shared, presentational building blocks for every algorithm playground. Each playground
+// composes these (transport, sliders, selects, metrics, cards) around its own visualization,
+// so adding a new algorithm is mostly "pick controls + draw your model".
+
+export function ControlPanel({ children }: { children: ReactNode }) {
+    return <aside className={styles.panel}>{children}</aside>;
+}
+
+export function RunControls({
+    running,
+    onToggle,
+    onStep,
+    onReset,
+}: {
+    running: boolean;
+    onToggle: () => void;
+    onStep: () => void;
+    onReset: () => void;
+}) {
+    return (
+        <div className={styles.transport}>
+            <button className={`${styles.btn} ${styles.primary}`} onClick={onToggle}>
+                {running ? '❚❚ Pause' : '▶ Train'}
+            </button>
+            <button className={styles.btn} onClick={onStep} disabled={running}>
+                Step
+            </button>
+            <button className={styles.btn} onClick={onReset}>
+                Reset
+            </button>
+        </div>
+    );
+}
+
+export function Field({ label, value, children }: { label: string; value?: string; children: ReactNode }) {
+    return (
+        <label className={styles.field}>
+            <span>
+                {label}
+                {value !== undefined && <em>{value}</em>}
+            </span>
+            {children}
+        </label>
+    );
+}
+
+export function Slider({
+    label,
+    value,
+    display,
+    min,
+    max,
+    step = 1,
+    onChange,
+}: {
+    label: string;
+    value: number;
+    display?: string;
+    min: number;
+    max: number;
+    step?: number;
+    onChange: (value: number) => void;
+}) {
+    return (
+        <Field label={label} value={display}>
+            <input
+                type="range"
+                min={min}
+                max={max}
+                step={step}
+                value={value}
+                onChange={e => onChange(Number(e.target.value))}
+            />
+        </Field>
+    );
+}
+
+export interface SelectOption {
+    value: string;
+    label: string;
+}
+
+export function Select({
+    label,
+    value,
+    options,
+    onChange,
+}: {
+    label: string;
+    value: string;
+    options: SelectOption[];
+    onChange: (value: string) => void;
+}) {
+    return (
+        <Field label={label}>
+            <select value={value} onChange={e => onChange(e.target.value)}>
+                {options.map(option => (
+                    <option key={option.value} value={option.value}>
+                        {option.label}
+                    </option>
+                ))}
+            </select>
+        </Field>
+    );
+}
+
+export function NumberField({
+    label,
+    value,
+    onChange,
+}: {
+    label: string;
+    value: number;
+    onChange: (value: number) => void;
+}) {
+    return (
+        <Field label={label}>
+            <input type="number" value={value} onChange={e => onChange(Number(e.target.value))} />
+        </Field>
+    );
+}
+
+export function Hint({ children }: { children: ReactNode }) {
+    return <p className={styles.hint}>{children}</p>;
+}
+
+export function MetricsRow({ children }: { children: ReactNode }) {
+    return <div className={styles.metrics}>{children}</div>;
+}
+
+export function Metric({ label, value }: { label: string; value: string }) {
+    return (
+        <div className={styles.metric}>
+            <span className={styles.metricLabel}>{label}</span>
+            <span className={styles.metricValue}>{value}</span>
+        </div>
+    );
+}
+
+export function Badge({ children }: { children: ReactNode }) {
+    return <div className={styles.badge}>{children}</div>;
+}
+
+export function Card({ title, subtitle, children }: { title: string; subtitle?: string; children: ReactNode }) {
+    return (
+        <div className={styles.card}>
+            <h3>
+                {title}
+                {subtitle && <span>{subtitle}</span>}
+            </h3>
+            {children}
+        </div>
+    );
+}

--- a/site/src/content/linear-regression.mdx
+++ b/site/src/content/linear-regression.mdx
@@ -1,0 +1,70 @@
+import { LinearRegressionPlayground } from '../components/LinearRegressionPlayground';
+
+# Linear Regression
+
+Linear regression is the "hello world" of machine learning: given a cloud of points, find the
+straight line that best fits them. Below is the real
+[`LinearRegression`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/supervised/LinearRegression.ts)
+model, fitting a line by gradient descent — live. Press **Train** and watch the orange line
+rotate into place as the loss falls.
+
+<div className="breakout">
+  <LinearRegressionPlayground />
+</div>
+
+The faint vertical lines are the **residuals** — the gap between each point and the line. Their
+squared lengths are exactly what training is shrinking.
+
+## The model
+
+A line in one variable is just `y = slope · x + intercept`. Linear regression learns those two
+numbers. The prediction is a plain matrix product of the (bias-enriched) inputs with the
+weight vector — that's the whole of `LinearRegression`:
+
+```ts
+protected predictFromEnrichedInputs(inputs: Matrix) {
+    return Matrix.multiply(inputs, this.getHypothesis());
+}
+```
+
+The "bias-enriched" part is a trick worth knowing: a leading column of `1`s is glued onto the
+inputs so the intercept becomes just another weight, folded into the same multiply (see
+`Regression.enrichedWithBiases`).
+
+## Measuring fit: mean squared error
+
+How good is a line? Average the squared residuals — the **mean squared error**:
+
+$$
+\text{MSE} = \frac{1}{m} \sum_{i=1}^{m} \big(\hat{y}_i - y_i\big)^2
+$$
+
+Squaring punishes big misses more than small ones and keeps the error positive. That's the
+curve in the **Loss** panel.
+
+## Learning by gradient descent
+
+Training starts from a flat line (slope and intercept both zero) and repeatedly nudges the
+weights downhill on the MSE surface. The shared `Regression.train` loop computes the error,
+turns it into a gradient, and steps:
+
+```ts
+const errors = predictions.subtract(targets).transpose();
+const gradient = errors.multiply(inputs).transpose();
+this.hypothesis = Matrix.subtract(this.hypothesis, gradient.multiply(learningRate / exampleCount));
+```
+
+The **learning rate** sets the step size. Too small and the line crawls toward the data; too
+large and it overshoots and oscillates. Try dragging it on the **Steep** dataset to feel both
+failure modes.
+
+> Linear regression and logistic regression share this exact training loop — the only
+> difference is that logistic regression squashes the output through a sigmoid to predict a
+> class instead of a continuous value.
+
+## Try it yourself
+
+- Switch to **Noisy** — the line settles on the best *average* trend, but the MSE never reaches
+  zero, because no line can pass through scattered points.
+- Lower the **learning rate** and watch the line approach its final angle in slow motion.
+- Change the **seed** to resample the data and confirm the fit is reproducible.

--- a/site/src/content/logistic-regression.mdx
+++ b/site/src/content/logistic-regression.mdx
@@ -1,0 +1,60 @@
+import { LogisticRegressionPlayground } from '../components/LogisticRegressionPlayground';
+
+# Logistic Regression
+
+Logistic regression is linear regression's classifying cousin: instead of predicting a number,
+it predicts the **probability** that a point belongs to a class. Below is the real
+[`LogisticRegression`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/supervised/LogisticRegression.ts)
+model, training live. Press **Train** and watch the colored regions settle — then switch
+datasets to see exactly where a straight line runs out of road.
+
+<div className="breakout">
+  <LogisticRegressionPlayground />
+</div>
+
+## From a line to a probability
+
+It starts just like linear regression — a weighted sum of the inputs (with the bias folded in) —
+but then squashes that number through the **sigmoid** so the output lands in `(0, 1)` and reads
+as a probability:
+
+$$
+\hat{y} = \sigma(\mathbf{w} \cdot \mathbf{x}), \qquad \sigma(z) = \frac{1}{1 + e^{-z}}
+$$
+
+That one extra step is the *entire* difference from linear regression in the source:
+
+```ts
+protected predictFromEnrichedInputs(inputs: Matrix) {
+    return Matrix.multiply(inputs, this.getHypothesis()).transform(z => 1 / (1 + Math.exp(-z)));
+}
+```
+
+Everything else — the bias trick, the gradient-descent training loop in `Regression.train` — is
+shared with linear regression. To turn a probability into a class, threshold at `0.5`.
+
+## The loss: cross-entropy
+
+Squared error is the wrong yardstick for probabilities; logistic regression minimises
+**cross-entropy** instead, which rewards confident-and-correct and heavily punishes
+confident-and-wrong:
+
+$$
+L = -\frac{1}{m}\sum_{i=1}^{m}\Big[\,y_i \log \hat{y}_i + (1-y_i)\log(1-\hat{y}_i)\,\Big]
+$$
+
+That's the curve in the **Loss** panel.
+
+## What a straight line can — and can't — do
+
+The decision boundary of logistic regression is always a single straight line (in 2-D). That's
+its strength and its limit:
+
+- **Blobs** — two separated clusters. The line slides right between them: ~100% accuracy.
+- **Two moons** — the line catches most points but can't follow the curve: it plateaus around 85%.
+- **Circles** and **XNOR** — no straight line can separate these, so accuracy stalls near 50% and
+  the loss flattens at $\ln 2 \approx 0.69$. This is precisely the problem a
+  [neural network](/machine-learning/neural-network) solves by stacking non-linear layers.
+
+Flip between the datasets above and watch the boundary try — the failures are as instructive as
+the successes.

--- a/site/src/content/multiclass-logistic-regression.mdx
+++ b/site/src/content/multiclass-logistic-regression.mdx
@@ -1,0 +1,45 @@
+import { MulticlassLogisticRegressionPlayground } from '../components/MulticlassLogisticRegressionPlayground';
+
+# Multiclass Logistic Regression
+
+[Logistic regression](/machine-learning/logistic-regression) only knows two classes. To handle
+three or more, this library uses the **one-vs-rest** trick: train one binary classifier per
+class, each answering "is this point my class, or not?", and let the most confident one win.
+Below is the real
+[`MulticlassLogisticRegression`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/supervised/MulticlassLogisticRegression.ts)
+training live across three classes.
+
+<div className="breakout">
+  <MulticlassLogisticRegressionPlayground />
+</div>
+
+## One-vs-rest
+
+The targets are **one-hot**: each row is `[1,0,0]`, `[0,1,0]`, or `[0,0,1]`. Training spins up one
+`LogisticRegression` per column and trains each on its own slice — class _i_ versus everyone else:
+
+```ts
+this.logisticRegressions.forEach((classifier, i) =>
+    classifier.train(inputs, targets.getColumn(i)),
+);
+```
+
+To predict, every classifier produces a probability and the columns are stacked back together;
+the winner is the **argmax** — the class whose classifier is most confident:
+
+```ts
+predictions.getMaximumRowIndeces(); // index of the largest value in each row
+```
+
+That argmax is exactly what colors each cell of the map above.
+
+## What the boundaries look like
+
+Because each underlying classifier draws a straight line, the regions meet along straight
+seams — you can see the plane carved into wedges. On well-separated **blobs** or horizontal
+**stripes** that's a near-perfect fit; on the **pinwheel** the straight seams can only roughly
+follow the curved class borders, so a few points near the center get misfiled.
+
+> For boundaries that genuinely curve, you need a non-linear model — that's the
+> [neural network](/machine-learning/neural-network), or the local voting of
+> [k-nearest neighbours](/machine-learning/nearest-neighbors).

--- a/site/src/content/nearest-neighbors.mdx
+++ b/site/src/content/nearest-neighbors.mdx
@@ -1,0 +1,45 @@
+import { NearestNeighborsPlayground } from '../components/NearestNeighborsPlayground';
+
+# k-Nearest Neighbours
+
+Every other model on this site learns parameters by gradient descent. k-NN does something
+refreshingly different: it **doesn't really train at all**. It just remembers the examples, and
+to classify a new point it asks its `k` closest neighbours to vote. Below is the real
+[`NearestNeighbors`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/supervised/NearestNeighbors.ts)
+— drag **k** and switch datasets, and the boundary recomputes instantly (there are no epochs to wait for).
+
+<div className="breakout">
+  <NearestNeighborsPlayground />
+</div>
+
+## Lazy learning
+
+"Training" is a single line — store the data:
+
+```ts
+train(inputs: Matrix, targets: Matrix) {
+    this.inputs = inputs;
+    this.targets = targets;
+}
+```
+
+All the work happens at prediction time. For each query point, `NearestNeighbors` measures the
+distance to every stored example (squared Euclidean by default, but the metric is swappable via
+`setDistanceFunction`), keeps the closest `k`, and averages their labels. Above 0.5 → class 1.
+
+## The role of k
+
+`k` is the one knob, and it trades detail for smoothness:
+
+- **k = 1** — each point copies its single nearest neighbour. The boundary hugs the data
+  exactly: jagged, islanded, and prone to overfitting noise.
+- **larger k** — more neighbours vote, so the boundary smooths out and shrugs off outliers — at
+  the risk of washing out genuinely small regions.
+
+## The payoff: non-linear for free
+
+Switch to **moons**, **circles**, or the **spiral** — the shapes that
+[logistic regression](/machine-learning/logistic-regression) simply could not separate. k-NN
+follows every curve without any extra machinery, because its boundary is defined by the data
+itself rather than by a fixed equation. The cost is that it must keep all the training data and
+compare against it for every single prediction.

--- a/site/src/ml/metrics.ts
+++ b/site/src/ml/metrics.ts
@@ -12,3 +12,19 @@ export function accuracy(predictions: number[][], targets: number[][]): number {
     }
     return correct / predictions.length;
 }
+
+/**
+ * Mean squared error — the average squared gap between prediction and target. This is what
+ * linear regression minimises; the library's Regression models don't expose it, so we compute
+ * it here for the loss curve.
+ */
+export function mse(predictions: number[][], targets: number[][]): number {
+    if (predictions.length === 0) return 0;
+
+    let sum = 0;
+    for (let i = 0; i < predictions.length; i++) {
+        const error = predictions[i][0] - targets[i][0];
+        sum += error * error;
+    }
+    return sum / predictions.length;
+}

--- a/site/src/ml/metrics.ts
+++ b/site/src/ml/metrics.ts
@@ -45,3 +45,31 @@ export function crossEntropy(predictions: number[][], targets: number[][]): numb
     }
     return sum / predictions.length;
 }
+
+/** Mean per-example cross-entropy summed across all class columns (one-vs-rest). */
+export function crossEntropyMulticlass(predictions: number[][], targets: number[][]): number {
+    if (predictions.length === 0) return 0;
+
+    const eps = 1e-7;
+    const classes = predictions[0].length;
+    let sum = 0;
+    for (let i = 0; i < predictions.length; i++) {
+        for (let c = 0; c < classes; c++) {
+            const p = Math.min(1 - eps, Math.max(eps, predictions[i][c]));
+            const y = targets[i][c];
+            sum -= y * Math.log(p) + (1 - y) * Math.log(1 - p);
+        }
+    }
+    return sum / predictions.length;
+}
+
+/** Argmax-match accuracy: fraction of rows whose predicted class equals the target class. */
+export function argmaxAccuracy(predictedClass: number[], trueClass: number[]): number {
+    if (predictedClass.length === 0) return 0;
+
+    let correct = 0;
+    for (let i = 0; i < predictedClass.length; i++) {
+        if (predictedClass[i] === trueClass[i]) correct++;
+    }
+    return correct / predictedClass.length;
+}

--- a/site/src/ml/metrics.ts
+++ b/site/src/ml/metrics.ts
@@ -28,3 +28,20 @@ export function mse(predictions: number[][], targets: number[][]): number {
     }
     return sum / predictions.length;
 }
+
+/**
+ * Average binary cross-entropy between sigmoid predictions and 0/1 targets — the loss logistic
+ * regression minimises. Predictions are clamped away from 0 and 1 so log() stays finite.
+ */
+export function crossEntropy(predictions: number[][], targets: number[][]): number {
+    if (predictions.length === 0) return 0;
+
+    const eps = 1e-7;
+    let sum = 0;
+    for (let i = 0; i < predictions.length; i++) {
+        const p = Math.min(1 - eps, Math.max(eps, predictions[i][0]));
+        const y = targets[i][0];
+        sum -= y * Math.log(p) + (1 - y) * Math.log(1 - p);
+    }
+    return sum / predictions.length;
+}

--- a/site/src/ml/multiclassDatasets.ts
+++ b/site/src/ml/multiclassDatasets.ts
@@ -1,0 +1,99 @@
+import type { Domain } from './datasets';
+import { gaussian, mulberry32 } from './rng';
+
+/** A 3-class 2D dataset with one-hot targets (N×3). */
+export interface MulticlassDataset {
+    id: string;
+    label: string;
+    blurb: string;
+    domain: Domain;
+    recommendedLr: number;
+    classes: number;
+    generate: (seed: number, n: number) => { inputs: number[][]; targets: number[][] };
+}
+
+const DOMAIN: Domain = { xMin: -1.4, xMax: 1.4, yMin: -1.4, yMax: 1.4 };
+
+function oneHot(classIndex: number, classes = 3): number[] {
+    const row = new Array(classes).fill(0);
+    row[classIndex] = 1;
+    return row;
+}
+
+/** Three Gaussian clusters at the vertices of a triangle — cleanly separable. */
+function blobs3(seed: number, n: number) {
+    const rand = mulberry32(seed);
+    const centers = [
+        [0, 0.75],
+        [-0.7, -0.45],
+        [0.7, -0.45],
+    ];
+    const inputs: number[][] = [];
+    const targets: number[][] = [];
+    for (let i = 0; i < n; i++) {
+        const c = i % 3;
+        inputs.push([centers[c][0] + gaussian(rand) * 0.22, centers[c][1] + gaussian(rand) * 0.22]);
+        targets.push(oneHot(c));
+    }
+    return { inputs, targets };
+}
+
+/** Three horizontal bands — separable by horizontal lines. */
+function stripes3(seed: number, n: number) {
+    const rand = mulberry32(seed);
+    const inputs: number[][] = [];
+    const targets: number[][] = [];
+    for (let i = 0; i < n; i++) {
+        const c = i % 3;
+        const x = rand() * 2.4 - 1.2;
+        const y = (c - 1) * 0.8 + gaussian(rand) * 0.12; // bands at y ≈ -0.8, 0, 0.8
+        inputs.push([x, y]);
+        targets.push(oneHot(c));
+    }
+    return { inputs, targets };
+}
+
+/** Three rotating wedges meeting at the center — boundaries are roughly linear from the origin. */
+function pinwheel3(seed: number, n: number) {
+    const rand = mulberry32(seed);
+    const inputs: number[][] = [];
+    const targets: number[][] = [];
+    for (let i = 0; i < n; i++) {
+        const c = i % 3;
+        const radius = Math.sqrt(rand()) * 1.1;
+        const angle = (c * 2 * Math.PI) / 3 + rand() * ((2 * Math.PI) / 3) + gaussian(rand) * 0.08;
+        inputs.push([radius * Math.cos(angle), radius * Math.sin(angle)]);
+        targets.push(oneHot(c));
+    }
+    return { inputs, targets };
+}
+
+export const MULTICLASS_DATASETS: MulticlassDataset[] = [
+    {
+        id: 'blobs3',
+        label: 'Three blobs',
+        blurb: 'Three separated clusters — one-vs-rest carves clean wedges between them.',
+        domain: DOMAIN,
+        recommendedLr: 1,
+        classes: 3,
+        generate: blobs3,
+    },
+    {
+        id: 'stripes3',
+        label: 'Three stripes',
+        blurb: 'Horizontal bands — each class peels off the rest with a straight line.',
+        domain: DOMAIN,
+        recommendedLr: 1,
+        classes: 3,
+        generate: stripes3,
+    },
+    {
+        id: 'pinwheel3',
+        label: 'Pinwheel',
+        blurb: 'Three wedges around the center — the straight boundaries only roughly fit.',
+        domain: DOMAIN,
+        recommendedLr: 1,
+        classes: 3,
+        generate: pinwheel3,
+    },
+];

--- a/site/src/ml/regressionDatasets.ts
+++ b/site/src/ml/regressionDatasets.ts
@@ -1,0 +1,65 @@
+import type { Domain } from './datasets';
+import { gaussian, mulberry32 } from './rng';
+
+/** A 1-D regression dataset: one input feature per row, one continuous target per row. */
+export interface RegressionDataset {
+    id: string;
+    label: string;
+    blurb: string;
+    domain: Domain;
+    /** A learning rate that converges quickly here — applied as the default when selected. */
+    recommendedLr: number;
+    generate: (seed: number, n: number) => { inputs: number[][]; targets: number[][] };
+}
+
+// Inputs are kept in [-1, 1] so plain gradient descent converges quickly without feature scaling.
+const DOMAIN: Domain = { xMin: -1.2, xMax: 1.2, yMin: -2, yMax: 2 };
+
+function line(slope: number, intercept: number, noise: number) {
+    return (seed: number, n: number) => {
+        const rand = mulberry32(seed);
+        const inputs: number[][] = [];
+        const targets: number[][] = [];
+        for (let i = 0; i < n; i++) {
+            const x = rand() * 2 - 1;
+            inputs.push([x]);
+            targets.push([slope * x + intercept + gaussian(rand) * noise]);
+        }
+        return { inputs, targets };
+    };
+}
+
+export const REGRESSION_DATASETS: RegressionDataset[] = [
+    {
+        id: 'trend',
+        label: 'Upward trend',
+        blurb: 'A gentle positive slope with a little noise.',
+        domain: DOMAIN,
+        recommendedLr: 0.5,
+        generate: line(0.8, 0.1, 0.12),
+    },
+    {
+        id: 'steep',
+        label: 'Steep',
+        blurb: 'A strong slope — the line has to rotate a long way to fit.',
+        domain: DOMAIN,
+        recommendedLr: 0.4,
+        generate: line(1.6, -0.1, 0.15),
+    },
+    {
+        id: 'negative',
+        label: 'Downward',
+        blurb: 'A negative slope — the line tilts the other way.',
+        domain: DOMAIN,
+        recommendedLr: 0.5,
+        generate: line(-0.9, 0.2, 0.12),
+    },
+    {
+        id: 'noisy',
+        label: 'Noisy',
+        blurb: 'A weak trend buried in noise — the best fit is far from perfect.',
+        domain: DOMAIN,
+        recommendedLr: 0.5,
+        generate: line(0.5, 0.0, 0.4),
+    },
+];

--- a/site/src/viz/multiclass.ts
+++ b/site/src/viz/multiclass.ts
@@ -1,0 +1,75 @@
+import type { Domain } from '../ml/datasets';
+
+// Three-class palette: sky, amber, violet.
+export const CLASS_RGB: [number, number, number][] = [
+    [56, 189, 248],
+    [251, 146, 60],
+    [167, 139, 250],
+];
+export const CLASS_HEX = ['#38bdf8', '#fb923c', '#a78bfa'];
+
+export function classHex(index: number): string {
+    return CLASS_HEX[index % CLASS_HEX.length];
+}
+
+/**
+ * Paints a multiclass decision map into a size×size offscreen canvas: each cell is colored by
+ * the winning class (argmax of the per-class scores), with opacity driven by the margin between
+ * the top two classes — so contested borders read as soft seams.
+ */
+export function paintMulticlass(offscreen: HTMLCanvasElement, values: number[][], size: number): void {
+    if (offscreen.width !== size || offscreen.height !== size) {
+        offscreen.width = size;
+        offscreen.height = size;
+    }
+    const ctx = offscreen.getContext('2d');
+    if (!ctx) return;
+
+    const image = ctx.createImageData(size, size);
+    for (let k = 0; k < values.length; k++) {
+        const row = values[k];
+        let top = -Infinity;
+        let second = -Infinity;
+        let argmax = 0;
+        for (let c = 0; c < row.length; c++) {
+            if (row[c] > top) {
+                second = top;
+                top = row[c];
+                argmax = c;
+            } else if (row[c] > second) {
+                second = row[c];
+            }
+        }
+        const [r, g, b] = CLASS_RGB[argmax % CLASS_RGB.length];
+        const margin = Math.min(1, Math.max(0, top - second));
+        const a = Math.round(120 + 115 * Math.min(1, margin * 3));
+        const o = k * 4;
+        image.data[o] = r;
+        image.data[o + 1] = g;
+        image.data[o + 2] = b;
+        image.data[o + 3] = a;
+    }
+    ctx.putImageData(image, 0, 0);
+}
+
+/** Draws training points colored by their (integer) class index. */
+export function drawClassPoints(
+    ctx: CanvasRenderingContext2D,
+    inputs: number[][],
+    classIndex: number[],
+    domain: Domain,
+    width: number,
+    height: number,
+): void {
+    for (let i = 0; i < inputs.length; i++) {
+        const px = ((inputs[i][0] - domain.xMin) / (domain.xMax - domain.xMin)) * width;
+        const py = (1 - (inputs[i][1] - domain.yMin) / (domain.yMax - domain.yMin)) * height;
+        ctx.beginPath();
+        ctx.arc(px, py, 4, 0, 2 * Math.PI);
+        ctx.fillStyle = classHex(classIndex[i]);
+        ctx.fill();
+        ctx.lineWidth = 1.5;
+        ctx.strokeStyle = 'rgba(11, 17, 32, 0.85)';
+        ctx.stroke();
+    }
+}

--- a/site/src/viz/regressionLine.ts
+++ b/site/src/viz/regressionLine.ts
@@ -1,0 +1,72 @@
+import type { Domain } from '../ml/datasets';
+
+// Renders the regression view: a scatter of (x, y) points, faint vertical "residual" lines from
+// each point to the current fit (the squared lengths are what training shrinks), and the fitted
+// line itself. Redrawn every frame, so the line visibly rotates into place as the model learns.
+export function drawRegression(
+    ctx: CanvasRenderingContext2D,
+    width: number,
+    height: number,
+    domain: Domain,
+    inputs: number[][],
+    targets: number[][],
+    /** The model's predicted y at each input (same order), for the residual lines. */
+    predicted: number[],
+    /** Two endpoints of the fitted line in data coordinates: [[x0, y0], [x1, y1]]. */
+    line: [[number, number], [number, number]],
+): void {
+    ctx.clearRect(0, 0, width, height);
+    ctx.fillStyle = '#0b1120';
+    ctx.fillRect(0, 0, width, height);
+
+    const sx = (x: number) => ((x - domain.xMin) / (domain.xMax - domain.xMin)) * width;
+    const sy = (y: number) => (1 - (y - domain.yMin) / (domain.yMax - domain.yMin)) * height;
+
+    // Zero axes for orientation.
+    ctx.strokeStyle = 'rgba(148, 164, 189, 0.18)';
+    ctx.lineWidth = 1;
+    if (domain.yMin < 0 && domain.yMax > 0) {
+        const y0 = sy(0);
+        ctx.beginPath();
+        ctx.moveTo(0, y0);
+        ctx.lineTo(width, y0);
+        ctx.stroke();
+    }
+    if (domain.xMin < 0 && domain.xMax > 0) {
+        const x0 = sx(0);
+        ctx.beginPath();
+        ctx.moveTo(x0, 0);
+        ctx.lineTo(x0, height);
+        ctx.stroke();
+    }
+
+    // Residuals: the gap each point contributes to the loss.
+    ctx.strokeStyle = 'rgba(56, 189, 248, 0.28)';
+    ctx.lineWidth = 1;
+    for (let i = 0; i < inputs.length; i++) {
+        const x = sx(inputs[i][0]);
+        ctx.beginPath();
+        ctx.moveTo(x, sy(targets[i][0]));
+        ctx.lineTo(x, sy(predicted[i]));
+        ctx.stroke();
+    }
+
+    // Data points.
+    for (let i = 0; i < inputs.length; i++) {
+        ctx.beginPath();
+        ctx.arc(sx(inputs[i][0]), sy(targets[i][0]), 3.5, 0, 2 * Math.PI);
+        ctx.fillStyle = '#38bdf8';
+        ctx.fill();
+        ctx.lineWidth = 1;
+        ctx.strokeStyle = 'rgba(11, 17, 32, 0.8)';
+        ctx.stroke();
+    }
+
+    // The fitted line.
+    ctx.beginPath();
+    ctx.moveTo(sx(line[0][0]), sy(line[0][1]));
+    ctx.lineTo(sx(line[1][0]), sy(line[1][1]));
+    ctx.strokeStyle = '#fb923c';
+    ctx.lineWidth = 3;
+    ctx.stroke();
+}


### PR DESCRIPTION
Grows the playground from one algorithm to **all five**, on a shared, templatized shell. Site-only — **no library API change, no npm release needed**.

## Shared foundation
- `components/controls/` — `ControlPanel`, `RunControls`, `Slider`, `Select`, `NumberField`, `MetricsRow`, `Metric`, `Badge`, `Card` (+ shared CSS), composed by every playground.
- Refactored the neural-network playground onto them (behavior unchanged, re-verified).

## The five playgrounds
| Algorithm | Visualization | Story |
|---|---|---|
| **Neural network** | decision-boundary heatmap + animated weight diagram + loss | learns any shape (XNOR→spiral) |
| **Linear regression** | scatter + animated fit line + residuals + MSE | recovers the true slope |
| **Logistic regression** | straight-line boundary + cross-entropy | blobs 100%, circles/XNOR fail |
| **Multiclass logistic** | argmax-colored wedge regions (3 classes) | one-vs-rest; blobs/stripes 100%, pinwheel ~98% |
| **k-NN** | instant boundary, **no training loop** | non-parametric — bends around moons/circles/spirals; k trades jagged↔smooth |

New supporting modules: `ml/regressionDatasets.ts`, `ml/multiclassDatasets.ts`, `viz/regressionLine.ts`, `viz/multiclass.ts`, and `metrics` (`mse`, `crossEntropy`, `crossEntropyMulticlass`, `argmaxAccuracy`).

## Wiring & tutorials
- Registry: all five → **live**; sidebar / landing cards / routes derive from it automatically.
- An MDX tutorial per algorithm, each mapping the math onto the real source and cross-linking the **linear-vs-non-linear** through-line (logistic fails the curves → neural net / k-NN solve them).

## Verification
- `yarn --cwd site typecheck` + `build` → green.
- Headless training confirms every dataset (regression recovers true slopes; multiclass 100/100/98%; logistic blobs 100% / circles ~54%; k-NN grid 40–130ms).
- Screenshots confirm all five render + train with **zero console errors**.

Merging redeploys the site automatically (the `site/**` path triggers `deploy-site.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)