### PR TITLE
Add Site CI (type-check + build the playground on PRs)

### DIFF
--- a/.github/workflows/site-ci.yml
+++ b/.github/workflows/site-ci.yml
@@ -1,0 +1,41 @@
+name: Site CI
+
+# Pre-merge signal for the playground app (the library has its own ci.yml). Runs on PRs that
+# touch the site or the library source it imports.
+on:
+  pull_request:
+    paths:
+      - 'site/**'
+      - 'src/lib/**'
+      - '.github/workflows/site-ci.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: yarn
+          cache-dependency-path: |
+            yarn.lock
+            site/yarn.lock
+
+      # The site type-checks against the library's built declarations, so build the lib first.
+      - name: Build library
+        run: |
+          yarn install --frozen-lockfile
+          yarn build
+
+      - name: Type-check and build site
+        working-directory: site
+        run: |
+          yarn install --frozen-lockfile
+          yarn typecheck
+          yarn build


### PR DESCRIPTION
Gives the playground app the same pre-merge signal the library gets from `ci.yml`.

`.github/workflows/site-ci.yml` runs on PRs touching `site/**` or `src/lib/**`: it builds the library first (so the site's `tsc` can resolve types from `dist/lib`), then runs `yarn typecheck` + `yarn build` in `site/`. No deploy — it mirrors the build job of `deploy-site.yml` without the Pages steps.

Uses the current action majors (`checkout@v6`, `setup-node@v6`) and caches both lockfiles. This PR triggers the workflow on itself (its path is in the filter), so the check validates as it lands.