### PR TITLE
Add k-means clustering (first unsupervised algorithm) + playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Below are some simple code usage examples.
 * [Logistic Regression](#logistic-regression)
 * [Multiclass Logistic Regression](#multiclass-logistic-regression)
 * [Nearest Neighbors](#nearest-neighbors)
+* [k-Means Clustering](#k-means-clustering)
 
 ### Feedforward Neural Network
 ```TypeScript
@@ -124,6 +125,31 @@ const unknowns = new ml.Matrix([[0.5, 0.5], [1.5, 1.5], [1.75, 1.75]]);
 const predictions = nearestNeighbors.predict(unknowns);
 console.log(predictions.toArray());
 // [ [ 0.4, 0.2, 0.2, 0.2 ], [ 0.6666666666666666, 0, 0, 0.3333333333333333 ], [ 0, 0, 0, 1 ] ]
+
+```
+
+### k-Means Clustering
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// k-Means clustering (unsupervised): group points into 2 clusters — note there are no targets.
+const inputs = new ml.Matrix([[0, 0], [1, 0], [0, 1], [10, 10], [11, 10], [10, 11]]);
+
+const kMeans = new ml.KMeans();
+kMeans.setNumberOfClusters(2);
+kMeans.setSeed(0); // makes the random centroid initialisation reproducible
+
+kMeans.train(inputs);
+
+const predictions = kMeans.predict(inputs);
+console.log(predictions.toArray());
+// one-hot cluster membership per point (the low blob is cluster 1, the high blob cluster 0)
+// [ [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 1, 0 ], [ 1, 0 ], [ 1, 0 ] ]
+
+console.log(kMeans.getCentroids().toArray());
+// the two cluster centres (each blob's mean)
+// [ [ 10.333333333333332, 10.333333333333332 ], [ 0.3333333333333333, 0.3333333333333333 ] ]
 
 ```
 

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -77,6 +77,24 @@ import * as ml from '../src/lib';
 }
 
 {
+    // k-Means clustering (unsupervised): group points into 2 clusters — note there are no targets.
+    const inputs = new ml.Matrix([[0, 0], [1, 0], [0, 1], [10, 10], [11, 10], [10, 11]]);
+
+    const kMeans = new ml.KMeans();
+    kMeans.setNumberOfClusters(2);
+    kMeans.setSeed(0);
+
+    kMeans.train(inputs);
+    const predictions = kMeans.predict(inputs);
+    console.log(predictions.toArray());
+    // one-hot cluster membership per point (the low blob is cluster 1, the high blob cluster 0):
+    // [ [ 0, 1 ], [ 0, 1 ], [ 0, 1 ], [ 1, 0 ], [ 1, 0 ], [ 1, 0 ] ]
+    console.log(kMeans.getCentroids().toArray());
+    // the two cluster centres (each blob's mean):
+    // [ [ 10.333333333333332, 10.333333333333332 ], [ 0.3333333333333333, 0.3333333333333333 ] ]
+}
+
+{
     const nn = new ml.FeedforwardNeuralNetwork([40, 40, 40, 40, 40]);
     console.log('');
     console.log('Checking FeedforwardNeuralNetwork gradients...');

--- a/package.json
+++ b/package.json
@@ -39,10 +39,6 @@
     "url": "https://github.com/erikgerrits/machine-learning/issues"
   },
   "homepage": "https://github.com/erikgerrits/machine-learning#readme",
-  "dependencies": {
-    "@types/chance": "^0.7.31",
-    "chance": "^1.0.4"
-  },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^4.1.8",

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -8,6 +8,7 @@ import LinearRegressionTutorial from './content/linear-regression.mdx';
 import LogisticRegressionTutorial from './content/logistic-regression.mdx';
 import MulticlassLogisticRegressionTutorial from './content/multiclass-logistic-regression.mdx';
 import NearestNeighborsTutorial from './content/nearest-neighbors.mdx';
+import KMeansTutorial from './content/k-means.mdx';
 
 export function App() {
     return (
@@ -51,6 +52,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <NearestNeighborsTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="k-means"
+                    element={
+                        <TutorialPage>
+                            <KMeansTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -4,6 +4,7 @@ import { LinearRegressionPlayground } from './components/LinearRegressionPlaygro
 import { LogisticRegressionPlayground } from './components/LogisticRegressionPlayground';
 import { MulticlassLogisticRegressionPlayground } from './components/MulticlassLogisticRegressionPlayground';
 import { NearestNeighborsPlayground } from './components/NearestNeighborsPlayground';
+import { KMeansPlayground } from './components/KMeansPlayground';
 
 /**
  * The catalog of algorithms the site covers. The neural network is live (flagship); the rest
@@ -59,5 +60,13 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         tagline: 'Classifies each point by the company it keeps.',
         status: 'live',
         Playground: NearestNeighborsPlayground,
+    },
+    {
+        id: 'k-means',
+        path: '/k-means',
+        title: 'k-Means',
+        tagline: 'Finds clusters in unlabelled data all on its own.',
+        status: 'live',
+        Playground: KMeansPlayground,
     },
 ];

--- a/site/src/components/KMeansPlayground.tsx
+++ b/site/src/components/KMeansPlayground.tsx
@@ -1,0 +1,251 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { KMeans, Matrix } from 'machine-learning';
+import { CLUSTERING_DATASETS } from '../ml/clusteringDatasets';
+import type { Domain } from '../ml/datasets';
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+import { fitCanvas } from '../viz/canvas';
+import { makeGrid, type Grid } from '../viz/decisionBoundary';
+import { centroidsMoved, drawCentroids, drawClusterPoints, inertia, paintClusters } from '../viz/clusters';
+import { drawLossCurve } from '../viz/lossCurve';
+import {
+    Card,
+    ControlPanel,
+    Hint,
+    Metric,
+    MetricsRow,
+    NumberField,
+    RunControls,
+    Select,
+    Slider,
+} from './controls/Controls';
+import styles from './LogisticRegressionPlayground.module.css';
+
+// The Voronoi map is recomputed only when the centroids move (one Lloyd step at a time), so an
+// 80×80 grid stays cheap while reading crisply.
+const GRID = 80;
+const POINTS = 220;
+
+// Each cluster index column from predict() is one-hot, so argmax recovers the assigned cluster.
+const argmaxRows = (matrix: Matrix): number[] => matrix.getMaximumRowIndeces().toArray().map(row => row[0]);
+
+interface TrainingData {
+    inputs: number[][];
+    inputMatrix: Matrix;
+}
+
+export function KMeansPlayground() {
+    const [datasetId, setDatasetId] = useState(CLUSTERING_DATASETS[0].id);
+    const [k, setK] = useState(CLUSTERING_DATASETS[0].recommendedClusters);
+    const [seed, setSeed] = useState(0);
+    const [speed, setSpeed] = useState(4); // Lloyd steps per second
+    const [running, setRunning] = useState(false);
+    const [metrics, setMetrics] = useState({ iteration: 0, inertia: 0, converged: false });
+
+    const speedRef = useRef(speed);
+    speedRef.current = speed;
+
+    const modelRef = useRef<KMeans | null>(null);
+    const dataRef = useRef<TrainingData | null>(null);
+    const gridRef = useRef<Grid | null>(null);
+    const domainRef = useRef<Domain>(CLUSTERING_DATASETS[0].domain);
+    const inertiaRef = useRef<number[]>([]);
+    const iterationRef = useRef(0);
+    const convergedRef = useRef(false);
+    const offscreenRef = useRef<HTMLCanvasElement | null>(null);
+    const frameRef = useRef(0);
+
+    const boundaryCanvasRef = useRef<HTMLCanvasElement | null>(null);
+    const inertiaCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const drawAll = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        const grid = gridRef.current;
+        if (!model || !data || !grid) return;
+
+        const boundaryCanvas = boundaryCanvasRef.current;
+        if (boundaryCanvas) {
+            const { ctx, width, height } = fitCanvas(boundaryCanvas);
+            ctx.fillStyle = '#0b1120';
+            ctx.fillRect(0, 0, width, height);
+
+            const cellClusters = argmaxRows(model.predict(grid.matrix));
+            if (!offscreenRef.current) offscreenRef.current = document.createElement('canvas');
+            paintClusters(offscreenRef.current, cellClusters, grid.size);
+            ctx.imageSmoothingEnabled = true;
+            ctx.drawImage(offscreenRef.current, 0, 0, width, height);
+
+            const pointClusters = argmaxRows(model.predict(data.inputMatrix));
+            drawClusterPoints(ctx, data.inputs, pointClusters, domainRef.current, width, height);
+            drawCentroids(ctx, model.getCentroids().toArray(), domainRef.current, width, height);
+        }
+
+        const inertiaCanvas = inertiaCanvasRef.current;
+        if (inertiaCanvas) {
+            const { ctx, width, height } = fitCanvas(inertiaCanvas);
+            drawLossCurve(ctx, width, height, inertiaRef.current);
+        }
+    }, []);
+
+    const rebuild = useCallback(() => {
+        const dataset = CLUSTERING_DATASETS.find(d => d.id === datasetId) ?? CLUSTERING_DATASETS[0];
+        const { inputs } = dataset.generate(seed, POINTS);
+        const inputMatrix = new Matrix(inputs);
+
+        const model = new KMeans();
+        model.setNumberOfClusters(k);
+        model.setSeed(seed);
+        model.setNumberOfIterations(0); // place the initial centroids without stepping yet…
+        model.train(inputMatrix);
+        model.setNumberOfIterations(1); // …so each later train() call is exactly one Lloyd step
+
+        modelRef.current = model;
+        dataRef.current = { inputs, inputMatrix };
+        gridRef.current = makeGrid(dataset.domain, GRID);
+        domainRef.current = dataset.domain;
+        iterationRef.current = 0;
+        convergedRef.current = false;
+        frameRef.current = 0;
+
+        const assignments = argmaxRows(model.predict(inputMatrix));
+        inertiaRef.current = [inertia(inputs, model.getCentroids().toArray(), assignments)];
+        setMetrics({ iteration: 0, inertia: inertiaRef.current[0], converged: false });
+        drawAll();
+    }, [datasetId, seed, k, drawAll]);
+
+    // Re-initialise whenever the dataset, seed, or k changes (all are captured by rebuild).
+    useEffect(() => {
+        rebuild();
+    }, [rebuild]);
+
+    const doIteration = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        if (!model || !data) return;
+        if (convergedRef.current) {
+            setRunning(false);
+            return;
+        }
+
+        const before = model.getCentroids().toArray();
+        model.train(data.inputMatrix); // one Lloyd step (assign → move centroids)
+        iterationRef.current += 1;
+        const after = model.getCentroids().toArray();
+
+        const assignments = argmaxRows(model.predict(data.inputMatrix));
+        const score = inertia(data.inputs, after, assignments);
+        inertiaRef.current.push(score);
+        if (inertiaRef.current.length > 1200) inertiaRef.current.shift();
+
+        if (centroidsMoved(before, after) === 0) convergedRef.current = true;
+
+        drawAll();
+        setMetrics({ iteration: iterationRef.current, inertia: score, converged: convergedRef.current });
+        if (convergedRef.current) setRunning(false);
+    }, [drawAll]);
+
+    // The animation runs at ~60fps; throttle it down to the chosen number of steps per second so
+    // each discrete Lloyd iteration is actually watchable.
+    const tick = useCallback(() => {
+        frameRef.current += 1;
+        const framesPerStep = Math.max(1, Math.round(60 / speedRef.current));
+        if (frameRef.current % framesPerStep === 0) doIteration();
+    }, [doIteration]);
+
+    useAnimationFrame(tick, running);
+
+    const handleToggle = () => {
+        if (convergedRef.current) return; // nothing left to run until Reset
+        setRunning(r => !r);
+    };
+    const handleStep = () => {
+        if (!running) doIteration();
+    };
+    const handleReset = () => {
+        setRunning(false);
+        rebuild();
+    };
+    const handleDataset = (id: string) => {
+        const next = CLUSTERING_DATASETS.find(d => d.id === id);
+        if (!next) return;
+        setRunning(false);
+        setDatasetId(next.id);
+        setK(next.recommendedClusters);
+    };
+    const handleK = (value: number) => {
+        setRunning(false);
+        setK(value);
+    };
+
+    const dataset = CLUSTERING_DATASETS.find(d => d.id === datasetId);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <RunControls
+                    running={running}
+                    onToggle={handleToggle}
+                    onStep={handleStep}
+                    onReset={handleReset}
+                />
+                <Select
+                    label="Dataset"
+                    value={datasetId}
+                    options={CLUSTERING_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={handleDataset}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Slider
+                    label="Clusters (k)"
+                    value={k}
+                    display={String(k)}
+                    min={2}
+                    max={6}
+                    onChange={handleK}
+                />
+                <Slider
+                    label="Speed"
+                    value={speed}
+                    display={`${speed} steps / sec`}
+                    min={1}
+                    max={20}
+                    onChange={setSpeed}
+                />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+                <Hint>No labels needed — k-means groups the points all on its own.</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.boundaryWrap}>
+                    <canvas ref={boundaryCanvasRef} className={styles.boundary} />
+                    <div className={styles.activation}>
+                        <span>◆ centroids</span>
+                        <span>● points by cluster</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Iteration" value={String(metrics.iteration)} />
+                        <Metric label="Inertia" value={metrics.inertia.toFixed(3)} />
+                        <Metric label="Status" value={metrics.converged ? 'converged' : 'running'} />
+                    </MetricsRow>
+
+                    <Card title="Lloyd's algorithm" subtitle="assign → move, repeat">
+                        <p className={styles.note}>
+                            Each step does two things: every point is <strong>assigned</strong> to its
+                            nearest centroid (the coloured Voronoi cells), then every centroid{' '}
+                            <strong>moves</strong> to the mean of its points. Repeat until nothing moves —
+                            that's convergence. Change <strong>k</strong> or the <strong>seed</strong> to
+                            see it land in a different grouping.
+                        </p>
+                    </Card>
+
+                    <Card title="Inertia" subtitle="mean squared distance to centroid">
+                        <canvas ref={inertiaCanvasRef} className={styles.lossCanvas} />
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/content/k-means.mdx
+++ b/site/src/content/k-means.mdx
@@ -1,0 +1,68 @@
+import { KMeansPlayground } from '../components/KMeansPlayground';
+
+# k-Means Clustering
+
+Every other model on this site is **supervised** — it learns from inputs paired with the right
+answers. k-means is different: it's **unsupervised**. You hand it a pile of points with _no
+labels_ and it discovers the groups on its own. Below is the real
+[`KMeans`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/unsupervised/KMeans.ts)
+clustering live — press **Train** and watch the centroids slide into place.
+
+<div className="breakout">
+  <KMeansPlayground />
+</div>
+
+## Lloyd's algorithm
+
+k-means starts by scattering `k` **centroids** onto random data points, then repeats two steps
+until nothing changes:
+
+1. **Assign** every point to its nearest centroid — those are the coloured regions.
+2. **Move** every centroid to the mean of the points now assigned to it.
+
+That's the whole training loop, straight from the source:
+
+```ts
+for (let iteration = 0; iteration < this.numberOfIterations; iteration++) {
+    const assignments = this.assign(inputs);             // step 1: nearest centroid
+    const newCentroids = this.recomputeCentroids(inputs, assignments); // step 2: the means
+
+    // Stop early once the centroids stop moving — the clustering has converged.
+    const converged = this.centroidsEqual(this.centroids, newCentroids);
+    this.centroids = newCentroids;
+    if (converged) break;
+}
+```
+
+Because each round can only ever lower the total distance from points to their centroids, the
+**inertia** curve on the right falls monotonically and then flattens — that flat line is
+convergence.
+
+## No targets, just inputs
+
+Look at the signature: `train(inputs)` takes a single matrix. There is no `targets` argument
+anywhere, which is what makes this unsupervised. `predict` then hands back **one-hot membership**
+— a `1` in the column of each point's cluster:
+
+```ts
+kmeans.train(new Matrix([[0, 0], [0, 1], [10, 10], [10, 11]]));
+kmeans.predict(new Matrix([[0, 0], [10, 10]])); // e.g. [[1, 0], [0, 1]]
+kmeans.getCentroids();                          // the cluster centres themselves
+```
+
+## Where it shines, and where it doesn't
+
+On the **blobs** datasets, k-means is near-perfect once `k` matches the number of real clusters.
+But it always carves the plane into straight-edged Voronoi cells around round centres, so:
+
+- On **uniform scatter** there's no real structure — it still tiles the plane into `k` arbitrary cells.
+- On **two moons** the round-cluster assumption breaks: it slices each crescent in half instead of
+  following the curve.
+
+The starting centroids are random, so the **seed** matters: a bad initialisation can settle into a
+worse grouping. Nudge the seed slider and watch the final clusters — and the converged inertia —
+change.
+
+> For clusters that curve, or labels you actually have, reach for a non-linear
+> [neural network](/machine-learning/neural-network) or the local voting of
+> [k-nearest neighbours](/machine-learning/nearest-neighbors).

--- a/site/src/ml/clusteringDatasets.ts
+++ b/site/src/ml/clusteringDatasets.ts
@@ -1,0 +1,97 @@
+import type { Domain } from './datasets';
+import { gaussian, mulberry32 } from './rng';
+
+/**
+ * Unlabelled 2-D point clouds for the k-means playground. Unlike the supervised datasets these
+ * carry **no targets** — clustering is unsupervised, so all the model ever sees is `inputs`.
+ * `recommendedClusters` is the value of k that matches the data's natural structure.
+ */
+export interface ClusteringDataset {
+    id: string;
+    label: string;
+    blurb: string;
+    domain: Domain;
+    recommendedClusters: number;
+    generate: (seed: number, n: number) => { inputs: number[][] };
+}
+
+const DOMAIN: Domain = { xMin: -1.4, xMax: 1.4, yMin: -1.4, yMax: 1.4 };
+
+/** `count` Gaussian blobs whose centres sit evenly around a circle. */
+function ringOfBlobs(count: number, radius = 0.95, spread = 0.16) {
+    return (seed: number, n: number) => {
+        const rand = mulberry32(seed);
+        const centers = Array.from({ length: count }, (_, c) => {
+            const angle = (c / count) * 2 * Math.PI - Math.PI / 2;
+            return [radius * Math.cos(angle), radius * Math.sin(angle)];
+        });
+
+        const inputs: number[][] = [];
+        for (let i = 0; i < n; i++) {
+            const center = centers[i % count];
+            inputs.push([center[0] + gaussian(rand) * spread, center[1] + gaussian(rand) * spread]);
+        }
+        return { inputs };
+    };
+}
+
+/** Uniform noise — no real clusters, so k-means just tiles the plane into Voronoi cells. */
+function scatter(seed: number, n: number) {
+    const rand = mulberry32(seed);
+    const inputs: number[][] = [];
+    for (let i = 0; i < n; i++) {
+        inputs.push([rand() * 2.4 - 1.2, rand() * 2.4 - 1.2]);
+    }
+    return { inputs };
+}
+
+/** Two interleaving crescents — round-cluster k-means can't follow the curve (a teachable miss). */
+function moons(seed: number, n: number) {
+    const rand = mulberry32(seed);
+    const inputs: number[][] = [];
+    const half = Math.floor(n / 2);
+    for (let i = 0; i < n; i++) {
+        const upper = i < half;
+        const span = upper ? half : n - half;
+        const t = (Math.PI * (upper ? i : i - half)) / span;
+        const x = (upper ? Math.cos(t) : 1 - Math.cos(t)) + gaussian(rand) * 0.1;
+        const y = (upper ? Math.sin(t) : 0.5 - Math.sin(t)) + gaussian(rand) * 0.1;
+        inputs.push([x, y]);
+    }
+    return { inputs };
+}
+
+export const CLUSTERING_DATASETS: ClusteringDataset[] = [
+    {
+        id: 'blobs5',
+        label: 'Five blobs',
+        blurb: 'Five tidy Gaussian clusters — k-means nails these when k matches.',
+        domain: DOMAIN,
+        recommendedClusters: 5,
+        generate: ringOfBlobs(5),
+    },
+    {
+        id: 'blobs3',
+        label: 'Three blobs',
+        blurb: 'Three well-separated clusters around a triangle. Try k = 3.',
+        domain: DOMAIN,
+        recommendedClusters: 3,
+        generate: ringOfBlobs(3, 0.85, 0.18),
+    },
+    {
+        id: 'scatter',
+        label: 'Uniform scatter',
+        blurb: 'No real structure — k-means still partitions the plane into k Voronoi cells.',
+        domain: { xMin: -1.3, xMax: 1.3, yMin: -1.3, yMax: 1.3 },
+        recommendedClusters: 4,
+        generate: scatter,
+    },
+    {
+        id: 'moons',
+        label: 'Two moons',
+        blurb: 'Curved clusters. k-means assumes round blobs, so it splits the moons oddly.',
+        domain: { xMin: -1.5, xMax: 2.5, yMin: -1.2, yMax: 1.6 },
+        recommendedClusters: 2,
+        generate: moons,
+    },
+];

--- a/site/src/viz/clusters.ts
+++ b/site/src/viz/clusters.ts
@@ -1,0 +1,128 @@
+import type { Domain } from '../ml/datasets';
+
+// A six-way cluster palette (sky, amber, violet, emerald, pink, yellow) — enough distinct hues
+// for every k the playground allows. Colours wrap if k somehow exceeds the palette length.
+export const CLUSTER_RGB: [number, number, number][] = [
+    [56, 189, 248],
+    [251, 146, 60],
+    [167, 139, 250],
+    [52, 211, 153],
+    [244, 114, 182],
+    [250, 204, 21],
+];
+export const CLUSTER_HEX = ['#38bdf8', '#fb923c', '#a78bfa', '#34d399', '#f472b6', '#facc15'];
+
+export function clusterHex(index: number): string {
+    return CLUSTER_HEX[index % CLUSTER_HEX.length];
+}
+
+function project(x: number, y: number, domain: Domain, width: number, height: number): [number, number] {
+    const px = ((x - domain.xMin) / (domain.xMax - domain.xMin)) * width;
+    const py = (1 - (y - domain.yMin) / (domain.yMax - domain.yMin)) * height;
+    return [px, py];
+}
+
+/**
+ * Paints the cluster map into a size×size offscreen canvas: each cell is filled with the colour
+ * of the centroid it belongs to, so the plane reads as a set of Voronoi regions. `assignments`
+ * holds one cluster index per cell (row-major, matching the sampling grid).
+ */
+export function paintClusters(offscreen: HTMLCanvasElement, assignments: number[], size: number): void {
+    if (offscreen.width !== size || offscreen.height !== size) {
+        offscreen.width = size;
+        offscreen.height = size;
+    }
+    const ctx = offscreen.getContext('2d');
+    if (!ctx) return;
+
+    const image = ctx.createImageData(size, size);
+    for (let i = 0; i < assignments.length; i++) {
+        const [r, g, b] = CLUSTER_RGB[assignments[i] % CLUSTER_RGB.length];
+        const o = i * 4;
+        image.data[o] = r;
+        image.data[o + 1] = g;
+        image.data[o + 2] = b;
+        image.data[o + 3] = 150; // translucent so points and centroids stay legible on top
+    }
+    ctx.putImageData(image, 0, 0);
+}
+
+/** Draws the data points, each coloured by the cluster it is currently assigned to. */
+export function drawClusterPoints(
+    ctx: CanvasRenderingContext2D,
+    inputs: number[][],
+    assignments: number[],
+    domain: Domain,
+    width: number,
+    height: number,
+): void {
+    for (let i = 0; i < inputs.length; i++) {
+        const [px, py] = project(inputs[i][0], inputs[i][1], domain, width, height);
+        ctx.beginPath();
+        ctx.arc(px, py, 3.5, 0, 2 * Math.PI);
+        ctx.fillStyle = clusterHex(assignments[i]);
+        ctx.fill();
+        ctx.lineWidth = 1.25;
+        ctx.strokeStyle = 'rgba(11, 17, 32, 0.85)';
+        ctx.stroke();
+    }
+}
+
+/** Draws each centroid as a bold, white-ringed diamond so it stands out from the round points. */
+export function drawCentroids(
+    ctx: CanvasRenderingContext2D,
+    centroids: number[][],
+    domain: Domain,
+    width: number,
+    height: number,
+): void {
+    const s = 8;
+    for (let c = 0; c < centroids.length; c++) {
+        const [px, py] = project(centroids[c][0], centroids[c][1], domain, width, height);
+
+        ctx.save();
+        ctx.translate(px, py);
+        ctx.rotate(Math.PI / 4); // a rotated square reads as a diamond
+        ctx.lineJoin = 'round';
+        ctx.fillStyle = clusterHex(c);
+        ctx.beginPath();
+        ctx.rect(-s, -s, 2 * s, 2 * s);
+        ctx.fill();
+        ctx.lineWidth = 3;
+        ctx.strokeStyle = '#f8fafc';
+        ctx.stroke();
+        ctx.lineWidth = 1;
+        ctx.strokeStyle = 'rgba(11, 17, 32, 0.9)';
+        ctx.stroke();
+        ctx.restore();
+    }
+}
+
+/** Mean squared distance from each point to its assigned centroid — the quantity k-means minimises. */
+export function inertia(inputs: number[][], centroids: number[][], assignments: number[]): number {
+    if (inputs.length === 0) return 0;
+
+    let sum = 0;
+    for (let i = 0; i < inputs.length; i++) {
+        const centroid = centroids[assignments[i]];
+        for (let j = 0; j < inputs[i].length; j++) {
+            const diff = inputs[i][j] - centroid[j];
+            sum += diff * diff;
+        }
+    }
+    return sum / inputs.length;
+}
+
+/** Total distance the centroids travelled between two iterations — 0 means k-means has converged. */
+export function centroidsMoved(before: number[][], after: number[][]): number {
+    let total = 0;
+    for (let c = 0; c < after.length; c++) {
+        let squared = 0;
+        for (let j = 0; j < after[c].length; j++) {
+            const diff = after[c][j] - before[c][j];
+            squared += diff * diff;
+        }
+        total += Math.sqrt(squared);
+    }
+    return total;
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,4 +1,5 @@
 export { default as FeedforwardNeuralNetwork } from "./machine-learning/supervised/FeedforwardNeuralNetwork";
+export { default as KMeans } from "./machine-learning/unsupervised/KMeans";
 export { default as LinearRegression } from "./machine-learning/supervised/LinearRegression";
 export { default as LogisticRegression } from "./machine-learning/supervised/LogisticRegression";
 export { default as Matrix } from "./math/linear-algebra/Matrix";

--- a/src/lib/machine-learning/supervised/FeedforwardNeuralNetwork.ts
+++ b/src/lib/machine-learning/supervised/FeedforwardNeuralNetwork.ts
@@ -83,10 +83,12 @@ export default class FeedforwardNeuralNetwork {
 
     public setActivationFunction (activationFunction: (value: number) => number) {
         this.activationFunction = activationFunction;
+        return this;
     }
 
     public setActivationGradientFunction (activationGradientFunction: (value: number) => number) {
         this.activationGradientFunction = activationGradientFunction;
+        return this;
     }
 
     /**
@@ -99,10 +101,12 @@ export default class FeedforwardNeuralNetwork {
      */
     public setBatchSize (batchSize = 0) {
         this.batchSize = batchSize;
+        return this;
     }
 
     public setLearningRate (learningRate = 0.001) {
         this.learningRate = learningRate;
+        return this;
     }
 
     /**
@@ -112,6 +116,7 @@ export default class FeedforwardNeuralNetwork {
      */
     public setNumberOfEpochs (numberOfEpochs = 1000) {
         this.numberOfEpochs = numberOfEpochs;
+        return this;
     }
 
     /* Parameter getters */

--- a/src/lib/machine-learning/supervised/MulticlassLogisticRegression.ts
+++ b/src/lib/machine-learning/supervised/MulticlassLogisticRegression.ts
@@ -52,26 +52,32 @@ export default class MulticlassLogisticRegression {
      */
     public setBatchSize (batchSize = 0) {
         this.batchSize = batchSize;
+        return this;
     }
 
     public setLearningRate (learningRate: number) {
         this.learningRate = learningRate;
+        return this;
     }
 
     public setNumberOfEpochs (numberOfEpochs: number) {
         this.numberOfEpochs = numberOfEpochs;
+        return this;
     }
 
     public setRegularizationFactor (regularizationFactor: number) {
         this.regularizationFactor = regularizationFactor;
+        return this;
     }
 
     public setHypothesis (hypothesesPerClass: Matrix[]) {
         this.logisticRegressions.forEach((logisticRegression, i) => logisticRegression.setHypothesis(hypothesesPerClass[i]));
+        return this;
     }
 
     public resetHypothesis () {
         this.logisticRegressions = undefined;
+        return this;
     }
 
     /* Parameter getters */

--- a/src/lib/machine-learning/supervised/NearestNeighbors.ts
+++ b/src/lib/machine-learning/supervised/NearestNeighbors.ts
@@ -35,10 +35,12 @@ export default class NearestNeighbors {
 
     public setDistanceFunction (distanceFunction: (x: Matrix, y: Matrix) => number) {
         this.distanceFunction = distanceFunction;
+        return this;
     }
 
     public setNumberOfNeighbors (numberOfNeighbors: number) {
         this.numberOfNeighbors = numberOfNeighbors;
+        return this;
     }
 
     /* Parameter getters */

--- a/src/lib/machine-learning/supervised/Regression.ts
+++ b/src/lib/machine-learning/supervised/Regression.ts
@@ -57,6 +57,7 @@ abstract class Regression {
      */
     public setBatchSize (batchSize = 0) {
         this.batchSize = batchSize;
+        return this;
     }
 
     public setLearningRate (learningRate: number) {
@@ -76,10 +77,12 @@ abstract class Regression {
 
     public setHypothesis (hypothesis: Matrix) {
         this.hypothesis = hypothesis;
+        return this;
     }
 
     public resetHypothesis () {
         this.hypothesis = undefined;
+        return this;
     }
 
     /* Parameter getters */

--- a/src/lib/machine-learning/unsupervised/KMeans.ts
+++ b/src/lib/machine-learning/unsupervised/KMeans.ts
@@ -1,0 +1,208 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+import mulberry32 from "../../math/random/mulberry32";
+
+/**
+ * k-means clustering — the library's first *unsupervised* model. Unlike every other algorithm
+ * here it is handed inputs with **no targets**: it discovers structure on its own by grouping the
+ * points into `k` clusters of nearby neighbours.
+ *
+ * It runs Lloyd's algorithm. Start with `k` centroids (each a randomly chosen data point), then
+ * repeat two steps until the assignments stop changing:
+ *   1. **Assign** every point to its nearest centroid (Euclidean distance by default).
+ *   2. **Update** each centroid to the mean of the points now assigned to it.
+ *
+ * Like the iterative supervised models, the centroids are instance state and are NOT reset by
+ * `train()`, so calling `setNumberOfIterations(1)` and then `train()` in a loop steps the
+ * algorithm one round at a time — handy for watching the centroids migrate in a live visualisation.
+ * Pass a seed via {@link setSeed} to make the random initialisation (and therefore the whole
+ * clustering) reproducible.
+ *
+ * @example
+ * const kmeans = new KMeans().setNumberOfClusters(2).setSeed(0);
+ * kmeans.train(new Matrix([[0, 0], [0, 1], [10, 10], [10, 11]]));
+ * kmeans.predict(new Matrix([[0, 0], [10, 10]])); // one-hot membership, e.g. [[1, 0], [0, 1]]
+ * kmeans.getCentroids();                          // the two cluster centres
+ */
+export default class KMeans {
+
+    private distanceFunction = (x: Matrix, y: Matrix) => Matrix.subtract(x, y).transform(value => value * value).getSum();
+    private numberOfClusters = 2;
+    private numberOfIterations = 100;
+    private seed: number = undefined;
+
+    private centroids: Matrix;
+
+    public constructor () {}
+
+    public train (inputs: Matrix) {
+        if (this.centroids === undefined) {
+            this.centroids = this.initialiseCentroids(inputs);
+        }
+
+        for (let iteration = 0; iteration < this.numberOfIterations; iteration++) {
+            const assignments = this.assign(inputs);
+            const newCentroids = this.recomputeCentroids(inputs, assignments);
+
+            // Stop early once the centroids stop moving — the clustering has converged.
+            const converged = this.centroidsEqual(this.centroids, newCentroids);
+            this.centroids = newCentroids;
+
+            if (converged) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Assigns each input to its nearest centroid, returned as a one-hot membership matrix
+     * (one column per cluster). Call `.getMaximumRowIndeces()` on the result for the raw
+     * cluster index of each point.
+     */
+    public predict (inputs: Matrix) {
+        const outputs = Matrix.zeros(inputs.getRowCount(), this.numberOfClusters);
+
+        for (let i = 0; i < inputs.getRowCount(); i++) {
+            outputs.setElement(i, this.nearestCentroidIndex(inputs.getRow(i)), 1);
+        }
+
+        return outputs;
+    }
+
+    /* Parameter setters */
+
+    public setDistanceFunction (distanceFunction: (x: Matrix, y: Matrix) => number) {
+        this.distanceFunction = distanceFunction;
+        return this;
+    }
+
+    public setNumberOfClusters (numberOfClusters: number) {
+        this.numberOfClusters = numberOfClusters;
+        return this;
+    }
+
+    public setNumberOfIterations (numberOfIterations: number) {
+        this.numberOfIterations = numberOfIterations;
+        return this;
+    }
+
+    public setSeed (seed: number) {
+        this.seed = seed;
+        return this;
+    }
+
+    public setCentroids (centroids: Matrix) {
+        this.centroids = centroids;
+        return this;
+    }
+
+    public resetCentroids () {
+        this.centroids = undefined;
+        return this;
+    }
+
+    /* Parameter getters */
+
+    public getDistanceFunction () {
+        return this.distanceFunction;
+    }
+
+    public getNumberOfClusters () {
+        return this.numberOfClusters;
+    }
+
+    public getNumberOfIterations () {
+        return this.numberOfIterations;
+    }
+
+    public getSeed () {
+        return this.seed;
+    }
+
+    public getCentroids () {
+        return this.centroids;
+    }
+
+    /* Private methods */
+
+    private initialiseCentroids (inputs: Matrix) {
+        // Forgy initialisation: pick `k` distinct data points as the starting centroids.
+        const random = mulberry32(this.seed !== undefined ? this.seed : Math.floor(Math.random() * 0x100000000));
+        const rowCount = inputs.getRowCount();
+
+        const chosen = new Set<number>();
+        const centroids = new Matrix([]);
+
+        while (chosen.size < this.numberOfClusters && chosen.size < rowCount) {
+            const index = Math.floor(random() * rowCount);
+
+            if (chosen.has(index)) {
+                continue;
+            }
+
+            chosen.add(index);
+            centroids.appendBottom(inputs.getRow(index));
+        }
+
+        return centroids;
+    }
+
+    private assign (inputs: Matrix) {
+        const assignments: number[] = [];
+
+        for (let i = 0; i < inputs.getRowCount(); i++) {
+            assignments.push(this.nearestCentroidIndex(inputs.getRow(i)));
+        }
+
+        return assignments;
+    }
+
+    private nearestCentroidIndex (input: Matrix) {
+        let nearestIndex = 0;
+        let nearestDistance = Number.POSITIVE_INFINITY;
+
+        for (let cluster = 0; cluster < this.centroids.getRowCount(); cluster++) {
+            const distance = this.distanceFunction(input, this.centroids.getRow(cluster));
+
+            if (distance < nearestDistance) {
+                nearestDistance = distance;
+                nearestIndex = cluster;
+            }
+        }
+
+        return nearestIndex;
+    }
+
+    private recomputeCentroids (inputs: Matrix, assignments: number[]) {
+        const featureCount = inputs.getColumnCount();
+        const clusterCount = this.centroids.getRowCount();
+
+        const sums: Matrix[] = [];
+        const counts: number[] = [];
+        for (let cluster = 0; cluster < clusterCount; cluster++) {
+            sums.push(Matrix.zeros(1, featureCount));
+            counts.push(0);
+        }
+
+        for (let i = 0; i < inputs.getRowCount(); i++) {
+            const cluster = assignments[i];
+            sums[cluster].add(inputs.getRow(i));
+            counts[cluster]++;
+        }
+
+        const newCentroids = new Matrix([]);
+        for (let cluster = 0; cluster < clusterCount; cluster++) {
+            // An empty cluster keeps its previous centroid rather than collapsing to a NaN row.
+            const centroid = counts[cluster] === 0 ? this.centroids.getRow(cluster) : sums[cluster].multiply(1 / counts[cluster]);
+            newCentroids.appendBottom(centroid);
+        }
+
+        return newCentroids;
+    }
+
+    private centroidsEqual (a: Matrix, b: Matrix) {
+        const aValues = a.toArray().flat();
+        const bValues = b.toArray().flat();
+
+        return aValues.every((value, index) => value === bValues[index]);
+    }
+}

--- a/src/lib/math/linear-algebra/Matrix.ts
+++ b/src/lib/math/linear-algebra/Matrix.ts
@@ -1,4 +1,4 @@
-import { Chance } from 'chance';
+import mulberry32 from "../random/mulberry32";
 
 /**
  * A dense 2-D matrix of numbers — the workhorse every algorithm in this library is built on.
@@ -100,12 +100,13 @@ export default class Matrix {
     }
 
     public static rand (rowCount: number, columnCount: number, epsilon = 1, seed: number = undefined) {
-        const chance = seed !== undefined ? new Chance(seed) : new Chance();
+        // Seeded for reproducibility; an undefined seed falls back to a random one (as before).
+        const random = mulberry32(seed !== undefined ? seed : Math.floor(Math.random() * 0x100000000));
         const size = rowCount * columnCount;
         const data = new Float64Array(size);
 
         for (let index = 0; index < size; index++) {
-            data[index] = chance.floating({min: 0, max: 1}) * 2 * epsilon - epsilon;
+            data[index] = random() * 2 * epsilon - epsilon;
         }
 
         return new Matrix(data, rowCount, columnCount);

--- a/src/lib/math/random/mulberry32.ts
+++ b/src/lib/math/random/mulberry32.ts
@@ -1,0 +1,22 @@
+/**
+ * mulberry32 — a tiny, seedable pseudo-random number generator returning floats in [0, 1).
+ *
+ * Calling it with the same seed always yields the same sequence, which is what makes the
+ * library's seeded models reproducible (e.g. {@link Matrix.rand}'s weight initialisation and
+ * k-means' centroid placement). It is a few lines of integer math, so the library stays
+ * dependency-free — no external RNG package required.
+ *
+ * @example
+ * const random = mulberry32(42);
+ * random(); // 0.6011037519201636 — and always the same for seed 42
+ */
+export default function mulberry32 (seed: number): () => number {
+    let state = seed >>> 0;
+
+    return function () {
+        state = (state + 0x6d2b79f5) | 0;
+        let t = Math.imul(state ^ (state >>> 15), 1 | state);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}

--- a/src/test/KMeans.test.ts
+++ b/src/test/KMeans.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import KMeans from '../lib/machine-learning/unsupervised/KMeans';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+import { KMEANS_INPUTS, KMEANS_LOW_BLOB_MEAN, KMEANS_HIGH_BLOB_MEAN, FIXED_SEED } from './helpers/fixtures';
+
+describe('KMeans', () => {
+
+    const trainBlobs = (seed = FIXED_SEED) => {
+        const kmeans = new KMeans().setNumberOfClusters(2).setSeed(seed);
+        kmeans.train(new Matrix(KMEANS_INPUTS));
+        return kmeans;
+    };
+
+    it('groups two well-separated blobs into two clusters', () => {
+        const kmeans = trainBlobs();
+        const labels = kmeans.predict(new Matrix(KMEANS_INPUTS)).getMaximumRowIndeces().toArray().flat();
+
+        // The three low points share one cluster, the three high points share the other.
+        expect(labels[0]).toBe(labels[1]);
+        expect(labels[1]).toBe(labels[2]);
+        expect(labels[3]).toBe(labels[4]);
+        expect(labels[4]).toBe(labels[5]);
+        expect(labels[0]).not.toBe(labels[3]);
+    });
+
+    it('converges its centroids to the blob means', () => {
+        const centroids = trainBlobs().getCentroids().toArray();
+
+        // Cluster order depends on the random init, so compare after sorting by x.
+        const sorted = centroids.slice().sort((a, b) => a[0] - b[0]);
+
+        expect(sorted[0][0]).toBeCloseTo(KMEANS_LOW_BLOB_MEAN[0], 9);
+        expect(sorted[0][1]).toBeCloseTo(KMEANS_LOW_BLOB_MEAN[1], 9);
+        expect(sorted[1][0]).toBeCloseTo(KMEANS_HIGH_BLOB_MEAN[0], 9);
+        expect(sorted[1][1]).toBeCloseTo(KMEANS_HIGH_BLOB_MEAN[1], 9);
+    });
+
+    it('is reproducible: the same seed yields identical centroids', () => {
+        expect(trainBlobs().getCentroids().toArray()).toEqual(trainBlobs().getCentroids().toArray());
+    });
+
+    it('predicts a one-hot membership row per input', () => {
+        const memberships = trainBlobs().predict(new Matrix(KMEANS_INPUTS));
+
+        expect(memberships.getRowCount()).toBe(KMEANS_INPUTS.length);
+        expect(memberships.getColumnCount()).toBe(2);
+        for (const row of memberships.toArray()) {
+            expect(row.reduce((sum, value) => sum + value, 0)).toBe(1);
+        }
+    });
+
+    it('assigns points to provided centroids without training', () => {
+        const kmeans = new KMeans().setNumberOfClusters(2).setCentroids(new Matrix([[0, 0], [10, 10]]));
+
+        const memberships = kmeans.predict(new Matrix([[1, 1], [9, 9]])).toArray();
+
+        expect(memberships).toEqual([[1, 0], [0, 1]]);
+    });
+
+    it('keeps a centroid that wins no points instead of producing NaNs', () => {
+        const kmeans = new KMeans().setNumberOfClusters(2).setNumberOfIterations(1);
+        kmeans.setCentroids(new Matrix([[0, 0], [100, 100]]));
+
+        // Every point is nearest to [0, 0], so the second cluster ends up empty.
+        kmeans.train(new Matrix([[0, 0], [1, 1], [2, 2]]));
+        const centroids = kmeans.getCentroids().toArray();
+
+        expect(centroids[0]).toEqual([1, 1]);     // mean of the three points
+        expect(centroids[1]).toEqual([100, 100]); // empty cluster keeps its old centroid
+    });
+
+    it('uses the configured distance function', () => {
+        const manhattan = (x: Matrix, y: Matrix) => Matrix.subtract(x, y).transform(Math.abs).getSum();
+        const kmeans = new KMeans().setNumberOfClusters(2).setDistanceFunction(manhattan).setCentroids(new Matrix([[6, 8], [0, 11]]));
+
+        // For the origin the two metrics disagree: Euclidean picks [6, 8] (100 < 121), but
+        // Manhattan picks [0, 11] (11 < 14) — so cluster 1 proves the custom distance is used.
+        expect(kmeans.predict(new Matrix([[0, 0]])).toArray()).toEqual([[0, 1]]);
+    });
+
+    it('round-trips its configuration', () => {
+        const distance = (x: Matrix, y: Matrix) => Math.abs(x.getElement(0, 0) - y.getElement(0, 0));
+        const kmeans = new KMeans()
+            .setNumberOfClusters(3)
+            .setNumberOfIterations(25)
+            .setSeed(7)
+            .setDistanceFunction(distance);
+
+        expect(kmeans.getNumberOfClusters()).toBe(3);
+        expect(kmeans.getNumberOfIterations()).toBe(25);
+        expect(kmeans.getSeed()).toBe(7);
+        expect(kmeans.getDistanceFunction()).toBe(distance);
+    });
+
+    it('resetCentroids clears the learned centroids', () => {
+        const kmeans = trainBlobs();
+        expect(kmeans.getCentroids()).toBeDefined();
+
+        kmeans.resetCentroids();
+
+        expect(kmeans.getCentroids()).toBeUndefined();
+    });
+});

--- a/src/test/LinearRegression.test.ts
+++ b/src/test/LinearRegression.test.ts
@@ -40,9 +40,30 @@ describe('LinearRegression', () => {
 
     it('exposes its hyperparameters', () => {
         const regression = new LinearRegression();
-        regression.setLearningRate(0.05).setNumberOfEpochs(42);
+        regression.setLearningRate(0.05).setNumberOfEpochs(42).setBatchSize(3);
 
         expect(regression.getLearningRate()).toBe(0.05);
         expect(regression.getNumberOfEpochs()).toBe(42);
+        expect(regression.getRegularizationFactor()).toBe(0);
+    });
+
+    it('applies L2 regularization when a factor is set', () => {
+        const train = (regularizationFactor: number) => {
+            const regression = new LinearRegression();
+            regression.setNumberOfEpochs(5000).setLearningRate(0.02).setRegularizationFactor(regularizationFactor);
+            regression.train(new Matrix(LINEAR_INPUTS), new Matrix(LINEAR_TARGETS));
+            return regression;
+        };
+
+        const regularized = train(0.5);
+        expect(regularized.getRegularizationFactor()).toBe(0.5);
+
+        // The penalty shrinks the weights, so the slope (excluding the bias) ends up smaller than
+        // the unregularized fit — but the predictions still increase with the input.
+        const slope = (model: LinearRegression) => model.getHypothesis().getElement(1, 0);
+        expect(Math.abs(slope(regularized))).toBeLessThan(Math.abs(slope(train(0))));
+
+        const predictions = regularized.predict(new Matrix(LINEAR_INPUTS)).toArray();
+        expect(predictions[4][0]).toBeGreaterThan(predictions[0][0]);
     });
 });

--- a/src/test/MulticlassLogisticRegression.test.ts
+++ b/src/test/MulticlassLogisticRegression.test.ts
@@ -36,4 +36,32 @@ describe('MulticlassLogisticRegression', () => {
 
         expect(regression.getHypothesis()).toHaveLength(MULTICLASS_TARGETS[0].length);
     });
+
+    it('round-trips its hyperparameters', () => {
+        const regression = new MulticlassLogisticRegression();
+        regression.setBatchSize(4).setLearningRate(0.05).setNumberOfEpochs(42).setRegularizationFactor(0.2);
+
+        expect(regression.getBatchSize()).toBe(4);
+        expect(regression.getLearningRate()).toBe(0.05);
+        expect(regression.getNumberOfEpochs()).toBe(42);
+        expect(regression.getRegularizationFactor()).toBe(0.2);
+    });
+
+    it('round-trips per-class hypotheses and resetHypothesis clears them', () => {
+        const inputs = new Matrix(MULTICLASS_INPUTS);
+        const targets = new Matrix(MULTICLASS_TARGETS);
+
+        const regression = new MulticlassLogisticRegression();
+        regression.setNumberOfEpochs(50).train(inputs, targets);
+
+        const learned = regression.getHypothesis();
+        regression.setHypothesis(learned);
+        expect(regression.getHypothesis().map(hypothesis => hypothesis.toArray()))
+            .toEqual(learned.map(hypothesis => hypothesis.toArray()));
+
+        // After a reset the next train() rebuilds one classifier per class from scratch.
+        regression.resetHypothesis();
+        regression.train(inputs, targets);
+        expect(regression.getHypothesis()).toHaveLength(MULTICLASS_TARGETS[0].length);
+    });
 });

--- a/src/test/helpers/fixtures.ts
+++ b/src/test/helpers/fixtures.ts
@@ -31,5 +31,11 @@ export const KNN_EXPECTED = [
     [0, 0, 0, 1],
 ];
 
-/** A fixed seed makes seeded models (Matrix.rand, FeedforwardNeuralNetwork) reproducible. */
+/** Two well-separated blobs for clustering: three points near the origin, three near (10, 10). */
+export const KMEANS_INPUTS = [[0, 0], [1, 0], [0, 1], [10, 10], [11, 10], [10, 11]];
+/** The mean of each blob — what the two centroids should converge to. */
+export const KMEANS_LOW_BLOB_MEAN = [1 / 3, 1 / 3];
+export const KMEANS_HIGH_BLOB_MEAN = [31 / 3, 31 / 3];
+
+/** A fixed seed makes seeded models (Matrix.rand, FeedforwardNeuralNetwork, KMeans) reproducible. */
 export const FIXED_SEED = 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -318,10 +318,6 @@
     "@types/deep-eql" "*"
     assertion-error "^2.0.1"
 
-"@types/chance@^0.7.31":
-  version "0.7.31"
-  resolved "https://registry.yarnpkg.com/@types/chance/-/chance-0.7.31.tgz#8dcd812456a261bb4d832243b85ebc5c68e28c80"
-
 "@types/deep-eql@*":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
@@ -433,10 +429,6 @@ chai@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
   integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
-
-chance@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/chance/-/chance-1.0.4.tgz#2dbc3ea6ad0541f7f965bd0af25d1ca275c853c4"
 
 convert-source-map@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Adds the library's first **unsupervised** algorithm — k-means clustering — end to end: the algorithm, a live playground, a tutorial, plus two pieces of cleanup that paved the way.

## What's in here (4 focused commits)

**1. Drop the `chance` dependency**
The README billed the library as "dependency-free", but it shipped `chance` (+ `@types/chance`) as a runtime dep, used in exactly one place: seeded random floats in `Matrix.rand`. Replaced with a tiny inline `mulberry32` PRNG in `math/random` — the same algorithm the playground already uses — so the claim is now true and the install is lighter. Seeding behaviour is unchanged (same seed → same sequence).

**2. Make every model setter chainable + close coverage gaps**
The setter API was inconsistent: `Regression`'s `setLearningRate`/`setNumberOfEpochs` returned `this` (and the README chains them), but `FeedforwardNeuralNetwork`, `NearestNeighbors`, and several base setters returned `void`. Now every setter across every model returns `this`. Also added tests for previously-uncovered paths — L2 regularization in `Regression` and the full config + per-class hypothesis round-trip on `MulticlassLogisticRegression` (both now 100% statements; overall coverage 95.1% → 97.3%).

**3. Add `KMeans`**
Lloyd's algorithm, following the library's conventions: `train(inputs)` with **no targets**, one-hot membership from `predict()`, `getCentroids()`, Forgy init seeded for reproducibility, early-stop on convergence, empty-cluster handling, and the `setNumberOfIterations(1)` + loop pattern for live stepping. Exported from `index`, documented in the README + `examples/demo.ts`, covered by a dedicated test suite.

**4. Add the k-means playground + tutorial**
Brings the site's "watch it train" treatment to the new model. `KMeansPlayground` animates Lloyd's algorithm one step at a time — points recolour by nearest centroid (a Voronoi map), diamond-marked centroids slide to their cluster means, and an inertia curve falls until it converges (auto-pausing). Adds unlabelled clustering datasets (blobs, uniform scatter, two moons — the last a deliberate "round-cluster k-means can't follow the curve" lesson), a cluster viz module, an MDX tutorial, and wires the entry into the algorithm catalog (nav/landing/routes derive from it).

## Verification
- **Library:** 76 tests pass (was 64), typecheck + build clean, demo output matches docs.
- **Site:** `tsc` clean, production build succeeds, dev server boots and serves 200, and Vite transforms all new modules without error.
- **Caveat:** verified compile/typecheck/build/serve and reasoned through the runtime animation logic, but did not visually confirm the rendered playground in a browser (no browser tooling in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)