### PR TITLE
Release 0.7.0: SVM, the full unsupervised suite, time series & a woven course

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Below are some simple code usage examples.
 * [Decision Tree](#decision-tree)
 * [Random Forest](#random-forest)
 * [Gradient Boosting](#gradient-boosting)
+* [Support Vector Machine](#support-vector-machine)
 * [k-Means Clustering](#k-means-clustering)
 
 ### Feedforward Neural Network
@@ -206,6 +207,31 @@ gradientBoosting.train(inputs, targets);
 const predictions = gradientBoosting.predict(inputs);
 console.log(predictions.getMaximumRowIndeces().toArray());
 // [ [ 0 ], [ 0 ], [ 0 ], [ 1 ], [ 1 ], [ 0 ] ]
+
+```
+
+### Support Vector Machine
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// Support vector machine: the widest-margin boundary between two classes.
+// A linear kernel draws a straight max-margin line; .setKernel('rbf') carves curves (the kernel trick).
+const inputs = new ml.Matrix([[2, 2], [3, 3], [3, 1], [1, 3], [-2, -2], [-3, -3], [-3, -1], [-1, -3]]);
+const targets = new ml.Matrix([[1], [1], [1], [1], [0], [0], [0], [0]]);
+
+const supportVectorMachine = new ml.SupportVectorMachine();
+supportVectorMachine.setKernel('linear').setRegularization(10).setNumberOfIterations(50);
+
+supportVectorMachine.train(inputs, targets);
+
+// predict returns the raw decision score per row; its sign is the class (>= 0 -> class 1).
+const predictions = supportVectorMachine.predict(inputs);
+console.log(predictions.transform(score => (score >= 0 ? 1 : 0)).toArray());
+// [ [ 1 ], [ 1 ], [ 1 ], [ 1 ], [ 0 ], [ 0 ], [ 0 ], [ 0 ] ]
+
+console.log(supportVectorMachine.getSupportVectorIndices());
+// [ 0, 2, 3, 4, 6 ]  <- the boundary-hugging points the line balances on (the rest could be deleted)
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Below are some simple code usage examples.
 * [Anomaly Detection](#anomaly-detection)
 * [Association Rules](#association-rules)
 * [Recommender](#recommender)
+* [Exponential Smoothing (time series)](#exponential-smoothing-time-series)
 
 ### Feedforward Neural Network
 ```TypeScript
@@ -407,6 +408,28 @@ console.log(recommender.recommend(1)); // user 1's unrated items, best first
 
 console.log(recommender.predict().toArray()[3][0].toFixed(2)); // user 3's hidden item 0
 // 1.29  <- correctly low: user 3 is in the other taste group
+
+```
+
+### Exponential Smoothing (time series)
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// Exponential smoothing (Holt-Winters): forecast a series with a weekly rhythm.
+// Two weeks of daily croissant demand (Mon..Sun) - quiet midweek, busy weekends, slight uptrend.
+const demand = new ml.Matrix([
+    [40], [42], [45], [50], [80], [95], [70],
+    [44], [46], [49], [55], [85], [100], [74],
+]);
+
+const model = new ml.ExponentialSmoothing();
+model.setAlpha(0.4).setBeta(0.1).setGamma(0.5).setSeasonLength(7); // level, trend, season, period
+
+model.train(demand);
+
+console.log(model.predict(7).toArray().map(row => Math.round(row[0])));
+// [ 47, 49, 52, 57, 87, 103, 78 ]  <- next week, continuing the weekly rhythm (busy Fri/Sat) + uptrend
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Below are some simple code usage examples.
 * [DBSCAN](#dbscan)
 * [PCA](#pca)
 * [Anomaly Detection](#anomaly-detection)
+* [Association Rules](#association-rules)
 
 ### Feedforward Neural Network
 ```TypeScript
@@ -351,6 +352,33 @@ console.log(detector.predict(new ml.Matrix([[0, 0], [0.5, 0.5], [8, 8]])).toArra
 
 console.log(detector.score(new ml.Matrix([[8, 8]])).toArray());
 // [ [ 12.22 ] ]  <- its Mahalanobis distance, far past the threshold
+
+```
+
+### Association Rules
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// Association rules (unsupervised): mine "basket" data for "buys X also buys Y".
+// Items: 0=coffee, 1=croissant, 2=tea, 3=cookie. One row per receipt, 1 = item present.
+const inputs = new ml.Matrix([
+    [1, 1, 0, 0],
+    [1, 1, 0, 0],
+    [1, 1, 0, 1],
+    [0, 0, 1, 1],
+    [0, 0, 1, 1],
+    [1, 0, 1, 1],
+]);
+
+const rules = new ml.AssociationRules();
+rules.setMinSupport(0.3).setMinConfidence(0.6); // support/confidence bars for keeping a rule
+
+rules.train(inputs);
+
+const top = rules.getRules()[0]; // rules come sorted strongest (highest lift) first
+console.log(top.antecedent, '->', top.consequent, '| confidence', top.confidence, 'lift', top.lift);
+// [ 1 ] -> [ 0 ] | confidence 1 lift 1.5  <- everyone who bought a croissant also bought coffee
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Below are some simple code usage examples.
 * [Gradient Boosting](#gradient-boosting)
 * [Support Vector Machine](#support-vector-machine)
 * [k-Means Clustering](#k-means-clustering)
+* [Hierarchical Clustering](#hierarchical-clustering)
 
 ### Feedforward Neural Network
 ```TypeScript
@@ -257,6 +258,31 @@ console.log(predictions.toArray());
 console.log(kMeans.getCentroids().toArray());
 // the two cluster centres (each blob's mean)
 // [ [ 10.333333333333332, 10.333333333333332 ], [ 0.3333333333333333, 0.3333333333333333 ] ]
+
+```
+
+### Hierarchical Clustering
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// Hierarchical clustering (unsupervised): merge the closest groups bottom-up into a tree,
+// then cut it to k clusters — no need to fix k before building.
+const inputs = new ml.Matrix([[0, 0], [1, 0], [0, 1], [10, 10], [11, 10], [10, 11]]);
+
+const hierarchical = new ml.HierarchicalClustering();
+hierarchical.setNumberOfClusters(2).setLinkage('average'); // 'single' | 'complete' | 'average'
+
+hierarchical.train(inputs);
+
+const predictions = hierarchical.predict(inputs);
+console.log(predictions.toArray());
+// one-hot cluster membership (the low blob is one cluster, the high blob the other)
+// [ [ 1, 0 ], [ 1, 0 ], [ 1, 0 ], [ 0, 1 ], [ 0, 1 ], [ 0, 1 ] ]
+
+console.log(hierarchical.getMergeHistory().map(m => Number(m.distance.toFixed(2))));
+// the dendrogram's merge heights, climbing until the two far-apart blobs join at the top
+// [ 1, 1, 1.21, 1.21, 14.17 ]
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Below are some simple code usage examples.
 * [Support Vector Machine](#support-vector-machine)
 * [k-Means Clustering](#k-means-clustering)
 * [Hierarchical Clustering](#hierarchical-clustering)
+* [DBSCAN](#dbscan)
 
 ### Feedforward Neural Network
 ```TypeScript
@@ -283,6 +284,28 @@ console.log(predictions.toArray());
 console.log(hierarchical.getMergeHistory().map(m => Number(m.distance.toFixed(2))));
 // the dendrogram's merge heights, climbing until the two far-apart blobs join at the top
 // [ 1, 1, 1.21, 1.21, 14.17 ]
+
+```
+
+### DBSCAN
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// DBSCAN (unsupervised): clusters by density and flags stragglers as noise — no k needed.
+// Two tight blobs and one far-flung outlier.
+const inputs = new ml.Matrix([[0, 0], [0.1, 0], [0, 0.1], [0.1, 0.1], [5, 5], [5.1, 5], [5, 5.1], [5.1, 5.1], [10, 0]]);
+
+const dbscan = new ml.DBSCAN();
+dbscan.setEpsilon(0.5).setMinPoints(3); // a point is "core" with >= minPoints neighbours within epsilon
+
+dbscan.train(inputs);
+
+console.log(dbscan.getLabels());
+// [ 0, 0, 0, 0, 1, 1, 1, 1, -1 ]  <- two dense blobs (clusters 0 and 1), the lone point is noise (-1)
+
+console.log(dbscan.getClusterCount());
+// 2  <- discovered, not specified up front
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Below are some simple code usage examples.
 * [PCA](#pca)
 * [Anomaly Detection](#anomaly-detection)
 * [Association Rules](#association-rules)
+* [Recommender](#recommender)
 
 ### Feedforward Neural Network
 ```TypeScript
@@ -379,6 +380,33 @@ rules.train(inputs);
 const top = rules.getRules()[0]; // rules come sorted strongest (highest lift) first
 console.log(top.antecedent, '->', top.consequent, '| confidence', top.confidence, 'lift', top.lift);
 // [ 1 ] -> [ 0 ] | confidence 1 lift 1.5  <- everyone who bought a croissant also bought coffee
+
+```
+
+### Recommender
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// Recommender (matrix factorization): fill in ratings nobody gave, suggest what each person likes.
+// 4 users x 4 items, 0 = not rated. Two taste groups: users 0-1 vs users 2-3.
+const ratings = new ml.Matrix([
+    [5, 5, 1, 0],
+    [5, 0, 1, 1],
+    [1, 1, 5, 5],
+    [0, 1, 5, 5],
+]);
+
+const recommender = new ml.Recommender();
+recommender.setNumberOfFactors(2).setNumberOfEpochs(500).setLearningRate(0.02).setSeed(0);
+
+recommender.train(ratings);
+
+console.log(recommender.recommend(1)); // user 1's unrated items, best first
+// [ { item: 1, score: 5.24 } ]  <- predicts user 1 will love item 1 (their taste group does)
+
+console.log(recommender.predict().toArray()[3][0].toFixed(2)); // user 3's hidden item 0
+// 1.29  <- correctly low: user 3 is in the other taste group
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Below are some simple code usage examples.
 * [k-Means Clustering](#k-means-clustering)
 * [Hierarchical Clustering](#hierarchical-clustering)
 * [DBSCAN](#dbscan)
+* [PCA](#pca)
 
 ### Feedforward Neural Network
 ```TypeScript
@@ -306,6 +307,28 @@ console.log(dbscan.getLabels());
 
 console.log(dbscan.getClusterCount());
 // 2  <- discovered, not specified up front
+
+```
+
+### PCA
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// PCA (unsupervised): find the axes of greatest variance and project onto the top ones.
+// These points lie on the line y = x, so a single axis captures all the variance.
+const inputs = new ml.Matrix([[-2, -2], [-1, -1], [0, 0], [1, 1], [2, 2]]);
+
+const pca = new ml.PCA();
+pca.setNumberOfComponents(1);
+
+pca.train(inputs);
+
+console.log(pca.predict(inputs).toArray());
+// each point's position along the one axis: [ [ -2.83 ], [ -1.41 ], [ 0 ], [ 1.41 ], [ 2.83 ] ]
+
+console.log(pca.getExplainedVarianceRatio());
+// [ 1 ]  <- that single axis holds 100% of the variance (the 2nd dimension was redundant)
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Below are some simple code usage examples.
 * [Logistic Regression](#logistic-regression)
 * [Multiclass Logistic Regression](#multiclass-logistic-regression)
 * [Nearest Neighbors](#nearest-neighbors)
+* [Perceptron](#perceptron)
 * [Naive Bayes](#naive-bayes)
 * [Decision Tree](#decision-tree)
 * [Random Forest](#random-forest)
@@ -137,6 +138,28 @@ const unknowns = new ml.Matrix([[0.5, 0.5], [1.5, 1.5], [1.75, 1.75]]);
 const predictions = nearestNeighbors.predict(unknowns);
 console.log(predictions.toArray());
 // [ [ 0.4, 0.2, 0.2, 0.2 ], [ 0.6666666666666666, 0, 0, 0.3333333333333333 ], [ 0, 0, 0, 1 ] ]
+
+```
+
+### Perceptron
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// Perceptron (a single neuron): learns AND, but one straight line can't solve XOR.
+const inputs = new ml.Matrix([[0, 0], [0, 1], [1, 0], [1, 1]]);
+
+const perceptron = new ml.Perceptron();
+perceptron.setLearningRate(0.1).setNumberOfEpochs(100);
+
+perceptron.train(inputs, new ml.Matrix([[0], [0], [0], [1]])); // AND
+console.log(perceptron.predict(inputs).toArray());
+// [ [ 0 ], [ 0 ], [ 0 ], [ 1 ] ]  <- solves AND (linearly separable)
+
+perceptron.reset();
+perceptron.train(inputs, new ml.Matrix([[0], [1], [1], [0]])); // XOR
+console.log(perceptron.predict(inputs).toArray());
+// [ [ 1 ], [ 1 ], [ 0 ], [ 0 ] ] != [0,1,1,0]  <- one neuron is one line; XOR needs a layered network
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Below are some simple code usage examples.
 * [Hierarchical Clustering](#hierarchical-clustering)
 * [DBSCAN](#dbscan)
 * [PCA](#pca)
+* [Anomaly Detection](#anomaly-detection)
 
 ### Feedforward Neural Network
 ```TypeScript
@@ -329,6 +330,27 @@ console.log(pca.predict(inputs).toArray());
 
 console.log(pca.getExplainedVarianceRatio());
 // [ 1 ]  <- that single axis holds 100% of the variance (the 2nd dimension was redundant)
+
+```
+
+### Anomaly Detection
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// Anomaly detection (unsupervised): fit a Gaussian to "normal" data, flag the unlikely points.
+const inputs = new ml.Matrix([[0, 0], [1, 0], [0, 1], [-1, 0], [0, -1], [1, 1], [-1, -1], [0.5, -0.5]]);
+
+const detector = new ml.AnomalyDetector();
+detector.setThreshold(3); // flag points more than 3 Mahalanobis "std devs" from the centre
+
+detector.train(inputs);
+
+console.log(detector.predict(new ml.Matrix([[0, 0], [0.5, 0.5], [8, 8]])).toArray());
+// [ [ 0 ], [ 0 ], [ 1 ] ]  <- the far-out point is the anomaly
+
+console.log(detector.score(new ml.Matrix([[8, 8]])).toArray());
+// [ [ 12.22 ] ]  <- its Mahalanobis distance, far past the threshold
 
 ```
 

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -26,12 +26,12 @@ generative). The built algorithms become the spine; everything else is roadmap.
 
 **Goal:** engaging, fun, genuinely educational, and very cool.
 
-**Status (this release).** Woven through **Ch 0–15**: all of Part 1, the whole of Part 2 (k‑NN,
+**Status (this release).** Woven through **Ch 0–16**: all of Part 1, the whole of Part 2 (k‑NN,
 Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support Vector Machines), and Part 3
-so far — k‑Means, Hierarchical Clustering, DBSCAN, and now **Ch 15 PCA** (the newest chapter, a
-from-scratch build that adds a Jacobi eigensolver and the first dimensionality-reduction method).
-One built algorithm is *not yet woven into the story*: the **Neural Network** (Ch 20) still ships its
-older generic tutorial and needs the per-chapter café treatment. Everything else is roadmap. See the
+so far — k‑Means, Hierarchical Clustering, DBSCAN, PCA (with a Jacobi eigensolver), and now **Ch 16
+Anomaly Detection** (the newest chapter, a multivariate-Gaussian / Mahalanobis detector). One built
+algorithm is *not yet woven into the story*: the **Neural Network** (Ch 20) still ships its older
+generic tutorial and needs the per-chapter café treatment. Everything else is roadmap. See the
 status column below.
 
 ---
@@ -164,7 +164,7 @@ Every row's "Wall" is the previous tool failing.
 | 13 | **Hierarchical Clustering** | A nested family tree of menu items / customer groups | k is unknown & structure is nested → **dendrograms** | ✅ `HierarchicalClustering` |
 | 14 | **DBSCAN** | A weird late-night cluster (possible fraud) | k-means forces every point into a round blob → **density-based** clusters + outliers | ✅ `DBSCAN` |
 | 15 | **PCA / Dimensionality Reduction** | A 30-question taste survey you can't visualize | You can't see 30 dimensions; features are redundant → **principal components**: 30 → 2 "flavor axes" | ✅ `PCA` |
-| 16 | **Anomaly Detection** | Catch the fraudulent transaction / spoiled batch | Rare events drown in normal data → model "normal," flag the rest | ○ |
+| 16 | **Anomaly Detection** | Catch the fraudulent transaction / spoiled batch | Rare events drown in normal data → model "normal," flag the rest | ✅ `AnomalyDetector` |
 | 17 | **Association Rules** | "Coffee + muffin" basket combos | Need co-occurrence patterns → Apriori; support/confidence/lift | ○ |
 | 18 | **Recommender Systems** | The loyalty app suggests items per person | Basket rules are global, not personal → **collaborative filtering / matrix factorization**; latent taste factors | ○ |
 
@@ -250,7 +250,7 @@ Canvas playgrounds). Realization is staged so we never block on the whole map:
 
 **Phase 1 — Re-frame the built algorithms into café chapters (no new algorithms). [mostly done]**
 - Rewrite the tutorials in `site/src/content/*.mdx` to follow the per-chapter template (Problem
-  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–15; the one
+  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–16; the one
   remaining built algorithm (Neural Network, Ch 20) still needs this treatment.*
 - Re-theme datasets in `site/src/ml/*` (e.g. `datasets.ts`, `clusteringDatasets.ts`) to café data
   (demand, batches, pastries, regulars) **with the same underlying shapes/labels**, so the existing

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -26,13 +26,13 @@ generative). The built algorithms become the spine; everything else is roadmap.
 
 **Goal:** engaging, fun, genuinely educational, and very cool.
 
-**Status (this release).** Woven through **Ch 0–17**: all of Part 1, the whole of Part 2 (k‑NN,
-Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support Vector Machines), and Part 3
-so far — k‑Means, Hierarchical Clustering, DBSCAN, PCA (with a Jacobi eigensolver), Anomaly Detection,
-and now **Ch 17 Association Rules** (the newest chapter, an Apriori market-basket miner). One built
-algorithm is *not yet woven into the story*: the **Neural Network** (Ch 20) still ships its older
-generic tutorial and needs the per-chapter café treatment. Everything else is roadmap. See the
-status column below.
+**Status (this release).** Woven through **Ch 0–18**: all of Part 1, the whole of Part 2 (k‑NN,
+Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support Vector Machines), and **all
+of Part 3** — k‑Means, Hierarchical Clustering, DBSCAN, PCA (with a Jacobi eigensolver), Anomaly
+Detection, Association Rules, and now **Ch 18 Recommender Systems** (the newest chapter, matrix
+factorization). One built algorithm is *not yet woven into the story*: the **Neural Network** (Ch 20)
+still ships its older generic tutorial and needs the per-chapter café treatment. Everything else is
+roadmap. See the status column below.
 
 ---
 
@@ -166,7 +166,7 @@ Every row's "Wall" is the previous tool failing.
 | 15 | **PCA / Dimensionality Reduction** | A 30-question taste survey you can't visualize | You can't see 30 dimensions; features are redundant → **principal components**: 30 → 2 "flavor axes" | ✅ `PCA` |
 | 16 | **Anomaly Detection** | Catch the fraudulent transaction / spoiled batch | Rare events drown in normal data → model "normal," flag the rest | ✅ `AnomalyDetector` |
 | 17 | **Association Rules** | "Coffee + muffin" basket combos | Need co-occurrence patterns → Apriori; support/confidence/lift | ✅ `AssociationRules` |
-| 18 | **Recommender Systems** | The loyalty app suggests items per person | Basket rules are global, not personal → **collaborative filtering / matrix factorization**; latent taste factors | ○ |
+| 18 | **Recommender Systems** | The loyalty app suggests items per person | Basket rules are global, not personal → **collaborative filtering / matrix factorization**; latent taste factors | ✅ `Recommender` |
 
 ### Part 4 — Scale, sequences & deep learning (Season 3)
 | # | Chapter | Café problem | The Wall → The Idea | Status |
@@ -250,8 +250,8 @@ Canvas playgrounds). Realization is staged so we never block on the whole map:
 
 **Phase 1 — Re-frame the built algorithms into café chapters (no new algorithms). [mostly done]**
 - Rewrite the tutorials in `site/src/content/*.mdx` to follow the per-chapter template (Problem
-  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–17; the one
-  remaining built algorithm (Neural Network, Ch 20) still needs this treatment.*
+  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–18 (all of
+  Parts 0–3); the one remaining built algorithm (Neural Network, Ch 20) still needs this treatment.*
 - Re-theme datasets in `site/src/ml/*` (e.g. `datasets.ts`, `clusteringDatasets.ts`) to café data
   (demand, batches, pastries, regulars) **with the same underlying shapes/labels**, so the existing
   Canvas playgrounds and viz keep working unchanged.

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -26,13 +26,13 @@ generative). The built algorithms become the spine; everything else is roadmap.
 
 **Goal:** engaging, fun, genuinely educational, and very cool.
 
-**Status (this release).** Woven through **Ch 0–18**: all of Part 1, the whole of Part 2 (k‑NN,
-Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support Vector Machines), and **all
-of Part 3** — k‑Means, Hierarchical Clustering, DBSCAN, PCA (with a Jacobi eigensolver), Anomaly
-Detection, Association Rules, and now **Ch 18 Recommender Systems** (the newest chapter, matrix
-factorization). One built algorithm is *not yet woven into the story*: the **Neural Network** (Ch 20)
-still ships its older generic tutorial and needs the per-chapter café treatment. Everything else is
-roadmap. See the status column below.
+**Status (this release).** Woven through **Ch 0–19**: all of Part 1, the whole of Part 2 (k‑NN,
+Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support Vector Machines), all of
+Part 3 (k‑Means, Hierarchical Clustering, DBSCAN, PCA, Anomaly Detection, Association Rules,
+Recommender Systems), and the opening of Part 4 — **Ch 19 Time Series** (the newest chapter,
+Holt-Winters exponential smoothing, the library's first time-series method). One built algorithm is
+*not yet woven into the story*: the **Neural Network** (Ch 20) still ships its older generic tutorial
+and needs the per-chapter café treatment. Everything else is roadmap. See the status column below.
 
 ---
 
@@ -171,7 +171,7 @@ Every row's "Wall" is the previous tool failing.
 ### Part 4 — Scale, sequences & deep learning (Season 3)
 | # | Chapter | Café problem | The Wall → The Idea | Status |
 |---|---|---|---|---|
-| 19 | **Time Series Forecasting** | *Forecasting numbers* across weeks & seasons | Plain regression ignores order & seasonality → moving averages, exponential smoothing, trend/seasonality (ARIMA-lite) | ○ |
+| 19 | **Time Series Forecasting** | *Forecasting numbers* across weeks & seasons | Plain regression ignores order & seasonality → moving averages, exponential smoothing, trend/seasonality (ARIMA-lite) | ✅ `ExponentialSmoothing` |
 | — | *Interlude: The Perceptron* | A single artificial "brain cell" | **Not a standalone café problem** — a short history interlude (Priya shows Nadia where neural nets came from), or folded into the open of Ch 21: weighted sum + activation; why one neuron can't do XOR | ○ (interlude) |
 | 20 | **Neural Networks & Backprop** | Danger/delight hides in *combinations* of cues (XNOR-like) | k-NN is slow, memoryless, and dumb in high dimensions; linear can't combine → **stack layers that learn features**; backprop ("blame flows backward"); dropout; SGD/Adam | ◐ `FeedforwardNeuralNetwork` (tutorial not yet woven into the story) |
 | 21 | **Convolutional Nets (CNNs)** | Grade latte-art photos / spot pastry defects / scan receipts | Dense nets ignore spatial structure → **convolutions**, filters, pooling (computer vision) | ○ (adopts) |
@@ -250,8 +250,9 @@ Canvas playgrounds). Realization is staged so we never block on the whole map:
 
 **Phase 1 — Re-frame the built algorithms into café chapters (no new algorithms). [mostly done]**
 - Rewrite the tutorials in `site/src/content/*.mdx` to follow the per-chapter template (Problem
-  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–18 (all of
-  Parts 0–3); the one remaining built algorithm (Neural Network, Ch 20) still needs this treatment.*
+  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–19 (Parts
+  0–3 and the opening of Part 4); the one remaining built algorithm (Neural Network, Ch 20) still
+  needs this treatment.*
 - Re-theme datasets in `site/src/ml/*` (e.g. `datasets.ts`, `clusteringDatasets.ts`) to café data
   (demand, batches, pastries, regulars) **with the same underlying shapes/labels**, so the existing
   Canvas playgrounds and viz keep working unchanged.

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -29,11 +29,12 @@ generative). The built algorithms become the spine; everything else is roadmap.
 **Status (this release).** Woven through **Ch 0–19**: all of Part 1, the whole of Part 2 (k‑NN,
 Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support Vector Machines), all of
 Part 3 (k‑Means, Hierarchical Clustering, DBSCAN, PCA, Anomaly Detection, Association Rules,
-Recommender Systems), and the opening of Part 4 — **Ch 19 Time Series** (Holt-Winters exponential
-smoothing) plus the **Perceptron interlude** (the newest piece: a single neuron that learns AND/OR
-but stalls on XOR, setting up neural networks). One built algorithm is *not yet woven into the
-story*: the **Neural Network** (Ch 20) still ships its older generic tutorial and needs the
-per-chapter café treatment. Everything else is roadmap. See the status column below.
+Recommender Systems), and Part 4 so far — **Ch 19 Time Series** (Holt-Winters exponential
+smoothing), the **Perceptron interlude**, and now **Ch 20 Neural Networks** (the newest weave: the
+matching-dials XNOR problem → hidden layers + backprop). **Every built algorithm is now woven into
+the café story** — there is no longer a built-but-unwoven chapter. Everything past Ch 20 (CNNs,
+RNNs/transformers, reinforcement learning, generative, Bayesian) is roadmap: new builds the library
+grows into. See the status column below.
 
 ---
 
@@ -129,7 +130,7 @@ Ordered simplest → most advanced. Three states:
 - **✅ DONE** — built *and* woven into the café story: the algorithm lives in `src/lib` with a
   playground, and its tutorial follows the per-chapter template in Nadia's voice.
 - **◐ BUILT** — the algorithm + playground exist in the code, but the tutorial is still the older
-  generic explainer, *not yet re-themed* into the story. (Currently: Neural Networks.)
+  generic explainer, *not yet re-themed* into the story. (Currently: none — every built algorithm is woven.)
 - **○ ROADMAP** — a future chapter; the library grows into it.
 
 Every row's "Wall" is the previous tool failing.
@@ -174,7 +175,7 @@ Every row's "Wall" is the previous tool failing.
 |---|---|---|---|---|
 | 19 | **Time Series Forecasting** | *Forecasting numbers* across weeks & seasons | Plain regression ignores order & seasonality → moving averages, exponential smoothing, trend/seasonality (ARIMA-lite) | ✅ `ExponentialSmoothing` |
 | — | *Interlude: The Perceptron* | A single artificial "brain cell" | Built as a short history interlude (Priya shows Nadia where neural nets came from): weighted sum + activation; why one neuron can't do XOR | ✅ `Perceptron` (interlude) |
-| 20 | **Neural Networks & Backprop** | Danger/delight hides in *combinations* of cues (XNOR-like) | k-NN is slow, memoryless, and dumb in high dimensions; linear can't combine → **stack layers that learn features**; backprop ("blame flows backward"); dropout; SGD/Adam | ◐ `FeedforwardNeuralNetwork` (tutorial not yet woven into the story) |
+| 20 | **Neural Networks & Backprop** | Danger/delight hides in *combinations* of cues (XNOR-like) | k-NN is slow, memoryless, and dumb in high dimensions; linear can't combine → **stack layers that learn features**; backprop ("blame flows backward"); dropout; SGD/Adam | ✅ `FeedforwardNeuralNetwork` |
 | 21 | **Convolutional Nets (CNNs)** | Grade latte-art photos / spot pastry defects / scan receipts | Dense nets ignore spatial structure → **convolutions**, filters, pooling (computer vision) | ○ (adopts) |
 | 22 | **Recurrent Nets / LSTMs** | Learn *sequence & text representations* (reviews, chat logs) — **not** forecasting (that's Ch 19) | Feedforward has no memory of order; this is the bridge to language → recurrence, memory, vanishing gradients. *Embeddings are introduced here as connective tissue* — learned word/item **vectors** where "similar sits close" (also reused by recsys, Ch 18) | ○ (adopts) |
 | 23 | **Transformers & Attention** | The café's AI assistant / chatbot | RNNs forget long context & don't parallelize → **attention**; the modern backbone (and a nod to the model writing this) | ○ (adopts) |
@@ -251,9 +252,9 @@ Canvas playgrounds). Realization is staged so we never block on the whole map:
 
 **Phase 1 — Re-frame the built algorithms into café chapters (no new algorithms). [mostly done]**
 - Rewrite the tutorials in `site/src/content/*.mdx` to follow the per-chapter template (Problem
-  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–19 (Parts
-  0–3 and the opening of Part 4); the one remaining built algorithm (Neural Network, Ch 20) still
-  needs this treatment.*
+  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for every built
+  algorithm (Ch 0–20 plus the Perceptron interlude). Phase 1 is complete; future chapters are new
+  builds (Phase 2+).*
 - Re-theme datasets in `site/src/ml/*` (e.g. `datasets.ts`, `clusteringDatasets.ts`) to café data
   (demand, batches, pastries, regulars) **with the same underlying shapes/labels**, so the existing
   Canvas playgrounds and viz keep working unchanged.

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -29,10 +29,11 @@ generative). The built algorithms become the spine; everything else is roadmap.
 **Status (this release).** Woven through **Ch 0–19**: all of Part 1, the whole of Part 2 (k‑NN,
 Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support Vector Machines), all of
 Part 3 (k‑Means, Hierarchical Clustering, DBSCAN, PCA, Anomaly Detection, Association Rules,
-Recommender Systems), and the opening of Part 4 — **Ch 19 Time Series** (the newest chapter,
-Holt-Winters exponential smoothing, the library's first time-series method). One built algorithm is
-*not yet woven into the story*: the **Neural Network** (Ch 20) still ships its older generic tutorial
-and needs the per-chapter café treatment. Everything else is roadmap. See the status column below.
+Recommender Systems), and the opening of Part 4 — **Ch 19 Time Series** (Holt-Winters exponential
+smoothing) plus the **Perceptron interlude** (the newest piece: a single neuron that learns AND/OR
+but stalls on XOR, setting up neural networks). One built algorithm is *not yet woven into the
+story*: the **Neural Network** (Ch 20) still ships its older generic tutorial and needs the
+per-chapter café treatment. Everything else is roadmap. See the status column below.
 
 ---
 
@@ -172,7 +173,7 @@ Every row's "Wall" is the previous tool failing.
 | # | Chapter | Café problem | The Wall → The Idea | Status |
 |---|---|---|---|---|
 | 19 | **Time Series Forecasting** | *Forecasting numbers* across weeks & seasons | Plain regression ignores order & seasonality → moving averages, exponential smoothing, trend/seasonality (ARIMA-lite) | ✅ `ExponentialSmoothing` |
-| — | *Interlude: The Perceptron* | A single artificial "brain cell" | **Not a standalone café problem** — a short history interlude (Priya shows Nadia where neural nets came from), or folded into the open of Ch 21: weighted sum + activation; why one neuron can't do XOR | ○ (interlude) |
+| — | *Interlude: The Perceptron* | A single artificial "brain cell" | Built as a short history interlude (Priya shows Nadia where neural nets came from): weighted sum + activation; why one neuron can't do XOR | ✅ `Perceptron` (interlude) |
 | 20 | **Neural Networks & Backprop** | Danger/delight hides in *combinations* of cues (XNOR-like) | k-NN is slow, memoryless, and dumb in high dimensions; linear can't combine → **stack layers that learn features**; backprop ("blame flows backward"); dropout; SGD/Adam | ◐ `FeedforwardNeuralNetwork` (tutorial not yet woven into the story) |
 | 21 | **Convolutional Nets (CNNs)** | Grade latte-art photos / spot pastry defects / scan receipts | Dense nets ignore spatial structure → **convolutions**, filters, pooling (computer vision) | ○ (adopts) |
 | 22 | **Recurrent Nets / LSTMs** | Learn *sequence & text representations* (reviews, chat logs) — **not** forecasting (that's Ch 19) | Feedforward has no memory of order; this is the bridge to language → recurrence, memory, vanishing gradients. *Embeddings are introduced here as connective tissue* — learned word/item **vectors** where "similar sits close" (also reused by recsys, Ch 18) | ○ (adopts) |

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -26,11 +26,12 @@ generative). The built algorithms become the spine; everything else is roadmap.
 
 **Goal:** engaging, fun, genuinely educational, and very cool.
 
-**Status (this release).** Woven through **Ch 0–12**: all of Part 1, the whole of Part 2 (k‑NN,
-Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support Vector Machines), and the
-opening of Part 3 — **Ch 12 k‑Means** (the newest chapter). One built algorithm is *not yet woven
-into the story*: the **Neural Network** (Ch 20) still ships its older generic tutorial and needs the
-per-chapter café treatment. Everything else is roadmap. See the status column below.
+**Status (this release).** Woven through **Ch 0–13**: all of Part 1, the whole of Part 2 (k‑NN,
+Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support Vector Machines), and Part 3
+so far — **Ch 12 k‑Means** and **Ch 13 Hierarchical Clustering** (the newest chapter, a from-scratch
+build). One built algorithm is *not yet woven into the story*: the **Neural Network** (Ch 20) still
+ships its older generic tutorial and needs the per-chapter café treatment. Everything else is
+roadmap. See the status column below.
 
 ---
 
@@ -159,7 +160,7 @@ Every row's "Wall" is the previous tool failing.
 | # | Chapter | Café problem | The Wall → The Idea | Status |
 |---|---|---|---|---|
 | 12 | **k-Means Clustering** | Who *are* my regulars? (no labels) | Every method so far needed an answer key — here there's none → **unsupervised**; Lloyd's algorithm; inertia; choosing k | ✅ `KMeans` |
-| 13 | **Hierarchical Clustering** | A nested family tree of menu items / customer groups | k is unknown & structure is nested → **dendrograms** | ○ |
+| 13 | **Hierarchical Clustering** | A nested family tree of menu items / customer groups | k is unknown & structure is nested → **dendrograms** | ✅ `HierarchicalClustering` |
 | 14 | **DBSCAN** | A weird late-night cluster (possible fraud) | k-means forces every point into a round blob → **density-based** clusters + outliers | ○ |
 | 15 | **PCA / Dimensionality Reduction** | A 30-question taste survey you can't visualize | You can't see 30 dimensions; features are redundant → **principal components**: 30 → 2 "flavor axes" | ○ |
 | 16 | **Anomaly Detection** | Catch the fraudulent transaction / spoiled batch | Rare events drown in normal data → model "normal," flag the rest | ○ |
@@ -248,7 +249,7 @@ Canvas playgrounds). Realization is staged so we never block on the whole map:
 
 **Phase 1 — Re-frame the built algorithms into café chapters (no new algorithms). [mostly done]**
 - Rewrite the tutorials in `site/src/content/*.mdx` to follow the per-chapter template (Problem
-  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–12; the one
+  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–13; the one
   remaining built algorithm (Neural Network, Ch 20) still needs this treatment.*
 - Re-theme datasets in `site/src/ml/*` (e.g. `datasets.ts`, `clusteringDatasets.ts`) to café data
   (demand, batches, pastries, regulars) **with the same underlying shapes/labels**, so the existing

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -26,12 +26,13 @@ generative). The built algorithms become the spine; everything else is roadmap.
 
 **Goal:** engaging, fun, genuinely educational, and very cool.
 
-**Status (this release).** Woven through **Ch 0–14**: all of Part 1, the whole of Part 2 (k‑NN,
+**Status (this release).** Woven through **Ch 0–15**: all of Part 1, the whole of Part 2 (k‑NN,
 Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support Vector Machines), and Part 3
-so far — **Ch 12 k‑Means**, **Ch 13 Hierarchical Clustering**, and **Ch 14 DBSCAN** (the newest
-chapter, a from-scratch build). One built algorithm is *not yet woven into the story*: the **Neural
-Network** (Ch 20) still ships its older generic tutorial and needs the per-chapter café treatment.
-Everything else is roadmap. See the status column below.
+so far — k‑Means, Hierarchical Clustering, DBSCAN, and now **Ch 15 PCA** (the newest chapter, a
+from-scratch build that adds a Jacobi eigensolver and the first dimensionality-reduction method).
+One built algorithm is *not yet woven into the story*: the **Neural Network** (Ch 20) still ships its
+older generic tutorial and needs the per-chapter café treatment. Everything else is roadmap. See the
+status column below.
 
 ---
 
@@ -162,7 +163,7 @@ Every row's "Wall" is the previous tool failing.
 | 12 | **k-Means Clustering** | Who *are* my regulars? (no labels) | Every method so far needed an answer key — here there's none → **unsupervised**; Lloyd's algorithm; inertia; choosing k | ✅ `KMeans` |
 | 13 | **Hierarchical Clustering** | A nested family tree of menu items / customer groups | k is unknown & structure is nested → **dendrograms** | ✅ `HierarchicalClustering` |
 | 14 | **DBSCAN** | A weird late-night cluster (possible fraud) | k-means forces every point into a round blob → **density-based** clusters + outliers | ✅ `DBSCAN` |
-| 15 | **PCA / Dimensionality Reduction** | A 30-question taste survey you can't visualize | You can't see 30 dimensions; features are redundant → **principal components**: 30 → 2 "flavor axes" | ○ |
+| 15 | **PCA / Dimensionality Reduction** | A 30-question taste survey you can't visualize | You can't see 30 dimensions; features are redundant → **principal components**: 30 → 2 "flavor axes" | ✅ `PCA` |
 | 16 | **Anomaly Detection** | Catch the fraudulent transaction / spoiled batch | Rare events drown in normal data → model "normal," flag the rest | ○ |
 | 17 | **Association Rules** | "Coffee + muffin" basket combos | Need co-occurrence patterns → Apriori; support/confidence/lift | ○ |
 | 18 | **Recommender Systems** | The loyalty app suggests items per person | Basket rules are global, not personal → **collaborative filtering / matrix factorization**; latent taste factors | ○ |
@@ -249,7 +250,7 @@ Canvas playgrounds). Realization is staged so we never block on the whole map:
 
 **Phase 1 — Re-frame the built algorithms into café chapters (no new algorithms). [mostly done]**
 - Rewrite the tutorials in `site/src/content/*.mdx` to follow the per-chapter template (Problem
-  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–14; the one
+  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–15; the one
   remaining built algorithm (Neural Network, Ch 20) still needs this treatment.*
 - Re-theme datasets in `site/src/ml/*` (e.g. `datasets.ts`, `clusteringDatasets.ts`) to café data
   (demand, batches, pastries, regulars) **with the same underlying shapes/labels**, so the existing

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -26,12 +26,12 @@ generative). The built algorithms become the spine; everything else is roadmap.
 
 **Goal:** engaging, fun, genuinely educational, and very cool.
 
-**Status (this release).** Woven through **Ch 0–13**: all of Part 1, the whole of Part 2 (k‑NN,
+**Status (this release).** Woven through **Ch 0–14**: all of Part 1, the whole of Part 2 (k‑NN,
 Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support Vector Machines), and Part 3
-so far — **Ch 12 k‑Means** and **Ch 13 Hierarchical Clustering** (the newest chapter, a from-scratch
-build). One built algorithm is *not yet woven into the story*: the **Neural Network** (Ch 20) still
-ships its older generic tutorial and needs the per-chapter café treatment. Everything else is
-roadmap. See the status column below.
+so far — **Ch 12 k‑Means**, **Ch 13 Hierarchical Clustering**, and **Ch 14 DBSCAN** (the newest
+chapter, a from-scratch build). One built algorithm is *not yet woven into the story*: the **Neural
+Network** (Ch 20) still ships its older generic tutorial and needs the per-chapter café treatment.
+Everything else is roadmap. See the status column below.
 
 ---
 
@@ -161,7 +161,7 @@ Every row's "Wall" is the previous tool failing.
 |---|---|---|---|---|
 | 12 | **k-Means Clustering** | Who *are* my regulars? (no labels) | Every method so far needed an answer key — here there's none → **unsupervised**; Lloyd's algorithm; inertia; choosing k | ✅ `KMeans` |
 | 13 | **Hierarchical Clustering** | A nested family tree of menu items / customer groups | k is unknown & structure is nested → **dendrograms** | ✅ `HierarchicalClustering` |
-| 14 | **DBSCAN** | A weird late-night cluster (possible fraud) | k-means forces every point into a round blob → **density-based** clusters + outliers | ○ |
+| 14 | **DBSCAN** | A weird late-night cluster (possible fraud) | k-means forces every point into a round blob → **density-based** clusters + outliers | ✅ `DBSCAN` |
 | 15 | **PCA / Dimensionality Reduction** | A 30-question taste survey you can't visualize | You can't see 30 dimensions; features are redundant → **principal components**: 30 → 2 "flavor axes" | ○ |
 | 16 | **Anomaly Detection** | Catch the fraudulent transaction / spoiled batch | Rare events drown in normal data → model "normal," flag the rest | ○ |
 | 17 | **Association Rules** | "Coffee + muffin" basket combos | Need co-occurrence patterns → Apriori; support/confidence/lift | ○ |
@@ -249,7 +249,7 @@ Canvas playgrounds). Realization is staged so we never block on the whole map:
 
 **Phase 1 — Re-frame the built algorithms into café chapters (no new algorithms). [mostly done]**
 - Rewrite the tutorials in `site/src/content/*.mdx` to follow the per-chapter template (Problem
-  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–13; the one
+  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–14; the one
   remaining built algorithm (Neural Network, Ch 20) still needs this treatment.*
 - Re-theme datasets in `site/src/ml/*` (e.g. `datasets.ts`, `clusteringDatasets.ts`) to café data
   (demand, batches, pastries, regulars) **with the same underlying shapes/labels**, so the existing

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -7,9 +7,9 @@
 
 ## Context — why we're doing this
 
-The site already has six excellent, technically-honest tutorials (Linear/Logistic/Multiclass
-Regression, k‑NN, a neural net, k‑Means), each mapping real math onto the real library source via
-live Canvas playgrounds. The weakness is **motivation**: the problems are abstract toy datasets
+When this plan was written, the site had six excellent, technically-honest tutorials
+(Linear/Logistic/Multiclass Regression, k‑NN, a neural net, k‑Means), each mapping real math onto
+the real library source via live Canvas playgrounds. The weakness was **motivation**: the problems were abstract toy datasets
 ("here is a cloud of points"). Nothing pulls you from one algorithm to the next.
 
 This plan reframes the whole thing as a **narrative course**: one character, Nadia, revives a
@@ -22,9 +22,15 @@ before you're taught it.
 We also use this as the excuse to **widen the curriculum massively** — simpler starting points,
 the missing in-between methods, advanced models, and whole other paradigms (ensembles,
 dimensionality reduction, recommenders, sequences, deep learning, reinforcement learning,
-generative). The 6 built algorithms become the spine; everything else is roadmap.
+generative). The built algorithms become the spine; everything else is roadmap.
 
 **Goal:** engaging, fun, genuinely educational, and very cool.
+
+**Status (this release).** Part 1 is fully woven (Ch 0–5), and so is the whole of Part 2 — k‑NN,
+Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, and now **Ch 11 Support Vector
+Machines** (the newest chapter). Two algorithms are *built but not yet woven into the story*:
+**k‑Means** (Ch 12) and the **Neural Network** (Ch 20) still ship their older generic tutorials and
+need the per-chapter café treatment. Everything else is roadmap. See the status column below.
 
 ---
 
@@ -115,38 +121,44 @@ grows and the *kind* of question changes. This is the engine that keeps the syll
 
 ## The course map (the wide, adaptable outline)
 
-Ordered simplest → most advanced. **★ BUILT** = the algorithm already exists in `src/lib` with a
-playground (we re-theme its tutorial). **○ ROADMAP** = a future chapter; the library grows into it.
+Ordered simplest → most advanced. Three states:
+
+- **✅ DONE** — built *and* woven into the café story: the algorithm lives in `src/lib` with a
+  playground, and its tutorial follows the per-chapter template in Nadia's voice.
+- **◐ BUILT** — the algorithm + playground exist in the code, but the tutorial is still the older
+  generic explainer, *not yet re-themed* into the story. (Currently: k-Means, Neural Networks.)
+- **○ ROADMAP** — a future chapter; the library grows into it.
+
 Every row's "Wall" is the previous tool failing.
 
 ### Part 0 — Foundations (the data mindset)
 | # | Chapter | Café problem | The Wall → The Idea | Status |
 |---|---|---|---|---|
-| 0 | **The Ledger** | Make sense of a shoebox of receipts | No method yet → learn to think in *observations, features, train vs. predict, error*; meet the baseline predictors (**predict the mean** / **predict the majority**) and the rule "you must beat the baseline" | ○ (intro) |
+| 0 | **The Ledger** | Make sense of a shoebox of receipts | No method yet → learn to think in *observations, features, train vs. predict, error*; meet the baseline predictors (**predict the mean** / **predict the majority**) and the rule "you must beat the baseline" | ✅ DONE (intro) |
 
 ### Part 1 — Predicting & deciding (Season 1)
 | # | Chapter | Café problem | The Wall → The Idea | Status |
 |---|---|---|---|---|
-| 1 | **Linear Regression** | How many croissants to bake tomorrow? | Baking the daily *average* wastes stock on slow days and sells out on sunny Saturdays → fit a **line** through demand vs. temperature; MSE; gradient descent | ★ `LinearRegression` |
-| 2 | **Many features** | Demand depends on temp **and** weekday **and** foot traffic | One input is too crude → **multiple** features as a weighted sum; feature scaling; the **Matrix** as "a page of measurements" | ★ `LinearRegression` (multi-feature) |
-| 3 | **Overfitting & Regularization** | She adds 30 features incl. silly ones; nails last week, flops on next week | "More features = better?" No → **train/test split**, overfitting, **L2/ridge** to shrink weights | ★ `Regression` (`regularizationFactor`) |
-| 4 | **Logistic Regression** | Will this dough batch rise? (good / bad) | Regression-on-0/1 overshoots past 1, one bad batch tilts the line, "0.5 risen" is nonsense → **sigmoid** → probability; decision boundary; log-loss | ★ `LogisticRegression` |
-| 5 | **Multiclass / Softmax** | Auto-sort pastries into 5 types on the line | Yes/no can't pick among 5 → **one-vs-rest**, one-hot, argmax | ★ `MulticlassLogisticRegression` |
+| 1 | **Linear Regression** | How many croissants to bake tomorrow? | Baking the daily *average* wastes stock on slow days and sells out on sunny Saturdays → fit a **line** through demand vs. temperature; MSE; gradient descent | ✅ `LinearRegression` |
+| 2 | **Many features** | Demand depends on temp **and** weekday **and** foot traffic | One input is too crude → **multiple** features as a weighted sum; feature scaling; the **Matrix** as "a page of measurements" | ✅ `LinearRegression` (multi-feature) |
+| 3 | **Overfitting & Regularization** | She adds 30 features incl. silly ones; nails last week, flops on next week | "More features = better?" No → **train/test split**, overfitting, **L2/ridge** to shrink weights | ✅ `Regression` (`regularizationFactor`) |
+| 4 | **Logistic Regression** | Will this dough batch rise? (good / bad) | Regression-on-0/1 overshoots past 1, one bad batch tilts the line, "0.5 risen" is nonsense → **sigmoid** → probability; decision boundary; log-loss | ✅ `LogisticRegression` |
+| 5 | **Multiclass / Softmax** | Auto-sort pastries into 5 types on the line | Yes/no can't pick among 5 → **one-vs-rest**, one-hot, argmax | ✅ `MulticlassLogisticRegression` |
 
 ### Part 2 — A wider toolbox (Season 2)
 | # | Chapter | Café problem | The Wall → The Idea | Status |
 |---|---|---|---|---|
-| 6 | **k-Nearest Neighbors** | Lookalike customers/items that swirl together | Straight boundaries *cannot* carve a spiral → **ask the neighbors**; Euclidean distance; lazy learning; choosing k | ★ `NearestNeighbors` |
-| 7 | **Naive Bayes** | Filter spam reservations & complaint emails | k-NN/logistic need numbers; this is *text* → **Bayes' rule**, bag-of-words, fast & probabilistic | ○ |
-| 8 | **Decision Trees** | Staff need an explainable "comp this order?" rulebook | Linear models & k-NN are opaque → a **flowchart of yes/no splits**; entropy/info-gain; interpretability | ○ |
-| 9 | **Random Forests / Bagging** | One tree's calls are jumpy & overfit | A single tree is unstable → **many trees vote**; bagging; feature importance | ○ |
-| 10 | **Gradient Boosting** | Cogwheel's forecasts beat hers | Need the tabular workhorse → **boost**: each model fixes the last one's mistakes | ○ |
-| 11 | **Support Vector Machines** | Find the *safest* boundary, not just *a* boundary | Logistic gives any separating line → **max-margin** + the **kernel trick** for nonlinearity without nets | ○ |
+| 6 | **k-Nearest Neighbors** | Lookalike customers/items that swirl together | Straight boundaries *cannot* carve a spiral → **ask the neighbors**; Euclidean distance; lazy learning; choosing k | ✅ `NearestNeighbors` |
+| 7 | **Naive Bayes** | Filter spam reservations & complaint emails | k-NN/logistic need numbers; this is *text* → **Bayes' rule**, bag-of-words, fast & probabilistic | ✅ `NaiveBayes` |
+| 8 | **Decision Trees** | Staff need an explainable "comp this order?" rulebook | Linear models & k-NN are opaque → a **flowchart of yes/no splits**; entropy/info-gain; interpretability | ✅ `DecisionTree` |
+| 9 | **Random Forests / Bagging** | One tree's calls are jumpy & overfit | A single tree is unstable → **many trees vote**; bagging; feature importance | ✅ `RandomForest` |
+| 10 | **Gradient Boosting** | Cogwheel's forecasts beat hers | Need the tabular workhorse → **boost**: each model fixes the last one's mistakes | ✅ `GradientBoosting` |
+| 11 | **Support Vector Machines** | Find the *safest* boundary, not just *a* boundary | Logistic gives any separating line → **max-margin** + the **kernel trick** for nonlinearity without nets | ✅ `SupportVectorMachine` |
 
 ### Part 3 — Understanding customers (Season 2, unsupervised)
 | # | Chapter | Café problem | The Wall → The Idea | Status |
 |---|---|---|---|---|
-| 12 | **k-Means Clustering** | Who *are* my regulars? (no labels) | Every method so far needed an answer key — here there's none → **unsupervised**; Lloyd's algorithm; inertia; choosing k | ★ `KMeans` |
+| 12 | **k-Means Clustering** | Who *are* my regulars? (no labels) | Every method so far needed an answer key — here there's none → **unsupervised**; Lloyd's algorithm; inertia; choosing k | ◐ `KMeans` (tutorial not yet woven into the story) |
 | 13 | **Hierarchical Clustering** | A nested family tree of menu items / customer groups | k is unknown & structure is nested → **dendrograms** | ○ |
 | 14 | **DBSCAN** | A weird late-night cluster (possible fraud) | k-means forces every point into a round blob → **density-based** clusters + outliers | ○ |
 | 15 | **PCA / Dimensionality Reduction** | A 30-question taste survey you can't visualize | You can't see 30 dimensions; features are redundant → **principal components**: 30 → 2 "flavor axes" | ○ |
@@ -159,7 +171,7 @@ Every row's "Wall" is the previous tool failing.
 |---|---|---|---|---|
 | 19 | **Time Series Forecasting** | *Forecasting numbers* across weeks & seasons | Plain regression ignores order & seasonality → moving averages, exponential smoothing, trend/seasonality (ARIMA-lite) | ○ |
 | — | *Interlude: The Perceptron* | A single artificial "brain cell" | **Not a standalone café problem** — a short history interlude (Priya shows Nadia where neural nets came from), or folded into the open of Ch 21: weighted sum + activation; why one neuron can't do XOR | ○ (interlude) |
-| 20 | **Neural Networks & Backprop** | Danger/delight hides in *combinations* of cues (XNOR-like) | k-NN is slow, memoryless, and dumb in high dimensions; linear can't combine → **stack layers that learn features**; backprop ("blame flows backward"); dropout; SGD/Adam | ★ `FeedforwardNeuralNetwork` |
+| 20 | **Neural Networks & Backprop** | Danger/delight hides in *combinations* of cues (XNOR-like) | k-NN is slow, memoryless, and dumb in high dimensions; linear can't combine → **stack layers that learn features**; backprop ("blame flows backward"); dropout; SGD/Adam | ◐ `FeedforwardNeuralNetwork` (tutorial not yet woven into the story) |
 | 21 | **Convolutional Nets (CNNs)** | Grade latte-art photos / spot pastry defects / scan receipts | Dense nets ignore spatial structure → **convolutions**, filters, pooling (computer vision) | ○ (adopts) |
 | 22 | **Recurrent Nets / LSTMs** | Learn *sequence & text representations* (reviews, chat logs) — **not** forecasting (that's Ch 19) | Feedforward has no memory of order; this is the bridge to language → recurrence, memory, vanishing gradients. *Embeddings are introduced here as connective tissue* — learned word/item **vectors** where "similar sits close" (also reused by recsys, Ch 18) | ○ (adopts) |
 | 23 | **Transformers & Attention** | The café's AI assistant / chatbot | RNNs forget long context & don't parallelize → **attention**; the modern backbone (and a nod to the model writing this) | ○ (adopts) |
@@ -234,9 +246,10 @@ deep-dive blocks.
 We already know the exact extension points from the existing site (registry-driven MDX +
 Canvas playgrounds). Realization is staged so we never block on the whole map:
 
-**Phase 1 — Re-frame the built six into café chapters (no new algorithms).**
-- Rewrite the six tutorials in `site/src/content/*.mdx` to follow the per-chapter template (Problem
-  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice.
+**Phase 1 — Re-frame the built algorithms into café chapters (no new algorithms). [mostly done]**
+- Rewrite the tutorials in `site/src/content/*.mdx` to follow the per-chapter template (Problem
+  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–11; the two
+  remaining built algorithms (k‑Means, Neural Network) still need this treatment.*
 - Re-theme datasets in `site/src/ml/*` (e.g. `datasets.ts`, `clusteringDatasets.ts`) to café data
   (demand, batches, pastries, regulars) **with the same underlying shapes/labels**, so the existing
   Canvas playgrounds and viz keep working unchanged.

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -26,11 +26,11 @@ generative). The built algorithms become the spine; everything else is roadmap.
 
 **Goal:** engaging, fun, genuinely educational, and very cool.
 
-**Status (this release).** Part 1 is fully woven (Ch 0–5), and so is the whole of Part 2 — k‑NN,
-Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, and now **Ch 11 Support Vector
-Machines** (the newest chapter). Two algorithms are *built but not yet woven into the story*:
-**k‑Means** (Ch 12) and the **Neural Network** (Ch 20) still ship their older generic tutorials and
-need the per-chapter café treatment. Everything else is roadmap. See the status column below.
+**Status (this release).** Woven through **Ch 0–12**: all of Part 1, the whole of Part 2 (k‑NN,
+Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support Vector Machines), and the
+opening of Part 3 — **Ch 12 k‑Means** (the newest chapter). One built algorithm is *not yet woven
+into the story*: the **Neural Network** (Ch 20) still ships its older generic tutorial and needs the
+per-chapter café treatment. Everything else is roadmap. See the status column below.
 
 ---
 
@@ -126,7 +126,7 @@ Ordered simplest → most advanced. Three states:
 - **✅ DONE** — built *and* woven into the café story: the algorithm lives in `src/lib` with a
   playground, and its tutorial follows the per-chapter template in Nadia's voice.
 - **◐ BUILT** — the algorithm + playground exist in the code, but the tutorial is still the older
-  generic explainer, *not yet re-themed* into the story. (Currently: k-Means, Neural Networks.)
+  generic explainer, *not yet re-themed* into the story. (Currently: Neural Networks.)
 - **○ ROADMAP** — a future chapter; the library grows into it.
 
 Every row's "Wall" is the previous tool failing.
@@ -158,7 +158,7 @@ Every row's "Wall" is the previous tool failing.
 ### Part 3 — Understanding customers (Season 2, unsupervised)
 | # | Chapter | Café problem | The Wall → The Idea | Status |
 |---|---|---|---|---|
-| 12 | **k-Means Clustering** | Who *are* my regulars? (no labels) | Every method so far needed an answer key — here there's none → **unsupervised**; Lloyd's algorithm; inertia; choosing k | ◐ `KMeans` (tutorial not yet woven into the story) |
+| 12 | **k-Means Clustering** | Who *are* my regulars? (no labels) | Every method so far needed an answer key — here there's none → **unsupervised**; Lloyd's algorithm; inertia; choosing k | ✅ `KMeans` |
 | 13 | **Hierarchical Clustering** | A nested family tree of menu items / customer groups | k is unknown & structure is nested → **dendrograms** | ○ |
 | 14 | **DBSCAN** | A weird late-night cluster (possible fraud) | k-means forces every point into a round blob → **density-based** clusters + outliers | ○ |
 | 15 | **PCA / Dimensionality Reduction** | A 30-question taste survey you can't visualize | You can't see 30 dimensions; features are redundant → **principal components**: 30 → 2 "flavor axes" | ○ |
@@ -248,8 +248,8 @@ Canvas playgrounds). Realization is staged so we never block on the whole map:
 
 **Phase 1 — Re-frame the built algorithms into café chapters (no new algorithms). [mostly done]**
 - Rewrite the tutorials in `site/src/content/*.mdx` to follow the per-chapter template (Problem
-  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–11; the two
-  remaining built algorithms (k‑Means, Neural Network) still need this treatment.*
+  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–12; the one
+  remaining built algorithm (Neural Network, Ch 20) still needs this treatment.*
 - Re-theme datasets in `site/src/ml/*` (e.g. `datasets.ts`, `clusteringDatasets.ts`) to café data
   (demand, batches, pastries, regulars) **with the same underlying shapes/labels**, so the existing
   Canvas playgrounds and viz keep working unchanged.

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -26,10 +26,10 @@ generative). The built algorithms become the spine; everything else is roadmap.
 
 **Goal:** engaging, fun, genuinely educational, and very cool.
 
-**Status (this release).** Woven through **Ch 0–16**: all of Part 1, the whole of Part 2 (k‑NN,
+**Status (this release).** Woven through **Ch 0–17**: all of Part 1, the whole of Part 2 (k‑NN,
 Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support Vector Machines), and Part 3
-so far — k‑Means, Hierarchical Clustering, DBSCAN, PCA (with a Jacobi eigensolver), and now **Ch 16
-Anomaly Detection** (the newest chapter, a multivariate-Gaussian / Mahalanobis detector). One built
+so far — k‑Means, Hierarchical Clustering, DBSCAN, PCA (with a Jacobi eigensolver), Anomaly Detection,
+and now **Ch 17 Association Rules** (the newest chapter, an Apriori market-basket miner). One built
 algorithm is *not yet woven into the story*: the **Neural Network** (Ch 20) still ships its older
 generic tutorial and needs the per-chapter café treatment. Everything else is roadmap. See the
 status column below.
@@ -165,7 +165,7 @@ Every row's "Wall" is the previous tool failing.
 | 14 | **DBSCAN** | A weird late-night cluster (possible fraud) | k-means forces every point into a round blob → **density-based** clusters + outliers | ✅ `DBSCAN` |
 | 15 | **PCA / Dimensionality Reduction** | A 30-question taste survey you can't visualize | You can't see 30 dimensions; features are redundant → **principal components**: 30 → 2 "flavor axes" | ✅ `PCA` |
 | 16 | **Anomaly Detection** | Catch the fraudulent transaction / spoiled batch | Rare events drown in normal data → model "normal," flag the rest | ✅ `AnomalyDetector` |
-| 17 | **Association Rules** | "Coffee + muffin" basket combos | Need co-occurrence patterns → Apriori; support/confidence/lift | ○ |
+| 17 | **Association Rules** | "Coffee + muffin" basket combos | Need co-occurrence patterns → Apriori; support/confidence/lift | ✅ `AssociationRules` |
 | 18 | **Recommender Systems** | The loyalty app suggests items per person | Basket rules are global, not personal → **collaborative filtering / matrix factorization**; latent taste factors | ○ |
 
 ### Part 4 — Scale, sequences & deep learning (Season 3)
@@ -250,7 +250,7 @@ Canvas playgrounds). Realization is staged so we never block on the whole map:
 
 **Phase 1 — Re-frame the built algorithms into café chapters (no new algorithms). [mostly done]**
 - Rewrite the tutorials in `site/src/content/*.mdx` to follow the per-chapter template (Problem
-  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–16; the one
+  → Wall → Idea → How It Works → Try It → What Broke), in Nadia's voice. *Done for Ch 0–17; the one
   remaining built algorithm (Neural Network, Ch 20) still needs this treatment.*
 - Re-theme datasets in `site/src/ml/*` (e.g. `datasets.ts`, `clusteringDatasets.ts`) to café data
   (demand, batches, pastries, regulars) **with the same underlying shapes/labels**, so the existing

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -286,6 +286,23 @@ import * as ml from '../src/lib';
 }
 
 {
+    // Perceptron (a single neuron): learns AND, but one straight line can't solve XOR.
+    const gates = new ml.Matrix([[0, 0], [0, 1], [1, 0], [1, 1]]);
+
+    const perceptron = new ml.Perceptron();
+    perceptron.setLearningRate(0.1).setNumberOfEpochs(100);
+
+    perceptron.train(gates, new ml.Matrix([[0], [0], [0], [1]])); // AND
+    console.log(perceptron.predict(gates).toArray());
+    // [ [ 0 ], [ 0 ], [ 0 ], [ 1 ] ]  ← solves AND (linearly separable)
+
+    perceptron.reset();
+    perceptron.train(gates, new ml.Matrix([[0], [1], [1], [0]])); // XOR
+    console.log(perceptron.predict(gates).toArray());
+    // [ [ 1 ], [ 1 ], [ 0 ], [ 0 ] ] ≠ [0,1,1,0] — XOR isn't linearly separable; it takes a layered network (below)
+}
+
+{
     const nn = new ml.FeedforwardNeuralNetwork([40, 40, 40, 40, 40]);
     console.log('');
     console.log('Checking FeedforwardNeuralNetwork gradients...');

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -152,6 +152,24 @@ import * as ml from '../src/lib';
 }
 
 {
+    // Support vector machine: the widest-margin boundary between two classes. A linear kernel draws
+    // a straight max-margin line; swap in .setKernel('rbf') to carve curved boundaries (the kernel trick).
+    const inputs = new ml.Matrix([[2, 2], [3, 3], [3, 1], [1, 3], [-2, -2], [-3, -3], [-3, -1], [-1, -3]]);
+    const targets = new ml.Matrix([[1], [1], [1], [1], [0], [0], [0], [0]]);
+
+    const supportVectorMachine = new ml.SupportVectorMachine();
+    supportVectorMachine.setKernel('linear').setRegularization(10).setNumberOfIterations(50);
+
+    supportVectorMachine.train(inputs, targets);
+    // predict returns the raw decision score per row; its sign is the class (≥ 0 → class 1).
+    const predictions = supportVectorMachine.predict(inputs);
+    console.log(predictions.transform(score => (score >= 0 ? 1 : 0)).toArray());
+    // [ [ 1 ], [ 1 ], [ 1 ], [ 1 ], [ 0 ], [ 0 ], [ 0 ], [ 0 ] ]
+    console.log(supportVectorMachine.getSupportVectorIndices());
+    // [ 0, 2, 3, 4, 6 ]  ← the boundary-hugging points the line balances on (the rest could be deleted)
+}
+
+{
     const nn = new ml.FeedforwardNeuralNetwork([40, 40, 40, 40, 40]);
     console.log('');
     console.log('Checking FeedforwardNeuralNetwork gradients...');

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -195,6 +195,22 @@ import * as ml from '../src/lib';
 }
 
 {
+    // Exponential smoothing (Holt-Winters): forecast a series with a weekly rhythm.
+    // Two weeks of daily croissant demand (Mon..Sun) — quiet midweek, busy weekends, slight uptrend.
+    const demand = new ml.Matrix([
+        [40], [42], [45], [50], [80], [95], [70],
+        [44], [46], [49], [55], [85], [100], [74],
+    ]);
+
+    const model = new ml.ExponentialSmoothing();
+    model.setAlpha(0.4).setBeta(0.1).setGamma(0.5).setSeasonLength(7);
+
+    model.train(demand);
+    console.log(model.predict(7).toArray().map(row => Math.round(row[0])));
+    // [ 47, 49, 52, 57, 87, 103, 78 ]  ← next week, continuing the weekly rhythm (busy Fri/Sat) + uptrend
+}
+
+{
     // Naive Bayes (multinomial): classify messages by word counts.
     // Vocabulary [free, money, table, tonight]; one-hot classes [spam, ham].
     const inputs = new ml.Matrix([[2, 1, 0, 0], [1, 2, 0, 0], [0, 0, 2, 1], [0, 0, 1, 2]]);

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -140,6 +140,20 @@ import * as ml from '../src/lib';
 }
 
 {
+    // Anomaly detection (unsupervised): fit a Gaussian to "normal" data, flag the unlikely points.
+    const inputs = new ml.Matrix([[0, 0], [1, 0], [0, 1], [-1, 0], [0, -1], [1, 1], [-1, -1], [0.5, -0.5]]);
+
+    const detector = new ml.AnomalyDetector();
+    detector.setThreshold(3); // flag points more than 3 Mahalanobis "std devs" from the centre
+
+    detector.train(inputs);
+    console.log(detector.predict(new ml.Matrix([[0, 0], [0.5, 0.5], [8, 8]])).toArray());
+    // [ [ 0 ], [ 0 ], [ 1 ] ]  ← the far-out point is the anomaly
+    console.log(detector.score(new ml.Matrix([[8, 8]])).toArray());
+    // [ [ 12.22 ] ]  ← its Mahalanobis distance, far past the threshold of 3
+}
+
+{
     // Naive Bayes (multinomial): classify messages by word counts.
     // Vocabulary [free, money, table, tonight]; one-hot classes [spam, ham].
     const inputs = new ml.Matrix([[2, 1, 0, 0], [1, 2, 0, 0], [0, 0, 2, 1], [0, 0, 1, 2]]);

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -175,6 +175,26 @@ import * as ml from '../src/lib';
 }
 
 {
+    // Recommender (matrix factorization): fill in ratings nobody gave, suggest what each person likes.
+    // 4 users x 4 items, 0 = not rated. Two taste groups: users 0–1 vs users 2–3.
+    const ratings = new ml.Matrix([
+        [5, 5, 1, 0],
+        [5, 0, 1, 1],
+        [1, 1, 5, 5],
+        [0, 1, 5, 5],
+    ]);
+
+    const recommender = new ml.Recommender();
+    recommender.setNumberOfFactors(2).setNumberOfEpochs(500).setLearningRate(0.02).setSeed(0);
+
+    recommender.train(ratings);
+    console.log(recommender.recommend(1)); // user 1's unrated items, best first
+    // [ { item: 1, score: 5.24 } ]  ← predicts user 1 will love item 1 (their taste group does)
+    console.log(recommender.predict().toArray()[3][0].toFixed(2)); // user 3's hidden item 0 → low
+    // 1.29
+}
+
+{
     // Naive Bayes (multinomial): classify messages by word counts.
     // Vocabulary [free, money, table, tonight]; one-hot classes [spam, ham].
     const inputs = new ml.Matrix([[2, 1, 0, 0], [1, 2, 0, 0], [0, 0, 2, 1], [0, 0, 1, 2]]);

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -125,6 +125,21 @@ import * as ml from '../src/lib';
 }
 
 {
+    // PCA (unsupervised): find the axes of greatest variance and project onto the top ones.
+    // These points lie exactly on the line y = x, so a single axis captures all the variance.
+    const inputs = new ml.Matrix([[-2, -2], [-1, -1], [0, 0], [1, 1], [2, 2]]);
+
+    const pca = new ml.PCA();
+    pca.setNumberOfComponents(1);
+
+    pca.train(inputs);
+    console.log(pca.predict(inputs).toArray());
+    // each point's position along the one axis: [ [ -2.83 ], [ -1.41 ], [ 0 ], [ 1.41 ], [ 2.83 ] ]
+    console.log(pca.getExplainedVarianceRatio());
+    // [ 1 ]  ← that single axis holds 100% of the variance (the 2nd dimension was redundant)
+}
+
+{
     // Naive Bayes (multinomial): classify messages by word counts.
     // Vocabulary [free, money, table, tonight]; one-hot classes [spam, ham].
     const inputs = new ml.Matrix([[2, 1, 0, 0], [1, 2, 0, 0], [0, 0, 2, 1], [0, 0, 1, 2]]);

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -95,6 +95,22 @@ import * as ml from '../src/lib';
 }
 
 {
+    // Hierarchical clustering (unsupervised): merge the closest groups bottom-up into a tree, then
+    // cut it to k clusters — no need to fix k before building. Same two blobs as k-means.
+    const inputs = new ml.Matrix([[0, 0], [1, 0], [0, 1], [10, 10], [11, 10], [10, 11]]);
+
+    const hierarchical = new ml.HierarchicalClustering();
+    hierarchical.setNumberOfClusters(2).setLinkage('average');
+
+    hierarchical.train(inputs);
+    console.log(hierarchical.predict(inputs).toArray());
+    // one-hot membership: the low blob is one cluster, the high blob the other
+    // [ [ 1, 0 ], [ 1, 0 ], [ 1, 0 ], [ 0, 1 ], [ 0, 1 ], [ 0, 1 ] ]
+    console.log(hierarchical.getMergeHistory().map(m => Number(m.distance.toFixed(2))));
+    // [ 1, 1, 1.21, 1.21, 14.17 ]  ← merge heights climbing until the two far-apart blobs join at the top
+}
+
+{
     // Naive Bayes (multinomial): classify messages by word counts.
     // Vocabulary [free, money, table, tonight]; one-hot classes [spam, ham].
     const inputs = new ml.Matrix([[2, 1, 0, 0], [1, 2, 0, 0], [0, 0, 2, 1], [0, 0, 1, 2]]);

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -111,6 +111,20 @@ import * as ml from '../src/lib';
 }
 
 {
+    // DBSCAN (unsupervised): clusters by density and flags stragglers as noise — no k needed.
+    const inputs = new ml.Matrix([[0, 0], [0.1, 0], [0, 0.1], [0.1, 0.1], [5, 5], [5.1, 5], [5, 5.1], [5.1, 5.1], [10, 0]]);
+
+    const dbscan = new ml.DBSCAN();
+    dbscan.setEpsilon(0.5).setMinPoints(3);
+
+    dbscan.train(inputs);
+    console.log(dbscan.getLabels());
+    // [ 0, 0, 0, 0, 1, 1, 1, 1, -1 ]  ← two dense blobs (clusters 0 and 1), the lone point is noise (-1)
+    console.log(dbscan.getClusterCount());
+    // 2
+}
+
+{
     // Naive Bayes (multinomial): classify messages by word counts.
     // Vocabulary [free, money, table, tonight]; one-hot classes [spam, ham].
     const inputs = new ml.Matrix([[2, 1, 0, 0], [1, 2, 0, 0], [0, 0, 2, 1], [0, 0, 1, 2]]);

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -154,6 +154,27 @@ import * as ml from '../src/lib';
 }
 
 {
+    // Association rules (unsupervised): mine "basket" data for "buys X also buys Y".
+    // Items: 0=coffee, 1=croissant, 2=tea, 3=cookie. One row per receipt, 1 = item present.
+    const inputs = new ml.Matrix([
+        [1, 1, 0, 0],
+        [1, 1, 0, 0],
+        [1, 1, 0, 1],
+        [0, 0, 1, 1],
+        [0, 0, 1, 1],
+        [1, 0, 1, 1],
+    ]);
+
+    const rules = new ml.AssociationRules();
+    rules.setMinSupport(0.3).setMinConfidence(0.6);
+
+    rules.train(inputs);
+    const top = rules.getRules()[0];
+    console.log(top.antecedent, '->', top.consequent, '| confidence', top.confidence.toFixed(2), 'lift', top.lift.toFixed(2));
+    // [ 1 ] -> [ 0 ] | confidence 1.00 lift 1.50  ← everyone who bought a croissant also bought coffee
+}
+
+{
     // Naive Bayes (multinomial): classify messages by word counts.
     // Vocabulary [free, money, table, tonight]; one-hot classes [spam, ham].
     const inputs = new ml.Matrix([[2, 1, 0, 0], [1, 2, 0, 0], [0, 0, 2, 1], [0, 0, 1, 2]]);

--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "kernel",
     "classification",
     "k-means",
-    "clustering"
+    "clustering",
+    "hierarchical clustering",
+    "agglomerative",
+    "dendrogram"
   ],
   "author": "Erik Gerrits <gerrits.erik@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,10 @@
     "mahalanobis",
     "association rules",
     "apriori",
-    "market basket analysis"
+    "market basket analysis",
+    "recommender",
+    "collaborative filtering",
+    "matrix factorization"
   ],
   "author": "Erik Gerrits <gerrits.erik@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
     "dendrogram",
     "dbscan",
     "density clustering",
-    "anomaly detection"
+    "anomaly detection",
+    "pca",
+    "principal component analysis",
+    "dimensionality reduction"
   ],
   "author": "Erik Gerrits <gerrits.erik@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-learning",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "TypeScript & JavaScript machine learning library",
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,10 @@
     "market basket analysis",
     "recommender",
     "collaborative filtering",
-    "matrix factorization"
+    "matrix factorization",
+    "time series",
+    "forecasting",
+    "exponential smoothing"
   ],
   "author": "Erik Gerrits <gerrits.erik@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "random forest",
     "gradient boosting",
     "ensemble",
+    "support vector machine",
+    "svm",
+    "kernel",
     "classification",
     "k-means",
     "clustering"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "matrix factorization",
     "time series",
     "forecasting",
-    "exponential smoothing"
+    "exponential smoothing",
+    "perceptron"
   ],
   "author": "Erik Gerrits <gerrits.erik@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,10 @@
     "clustering",
     "hierarchical clustering",
     "agglomerative",
-    "dendrogram"
+    "dendrogram",
+    "dbscan",
+    "density clustering",
+    "anomaly detection"
   ],
   "author": "Erik Gerrits <gerrits.erik@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
     "anomaly detection",
     "pca",
     "principal component analysis",
-    "dimensionality reduction"
+    "dimensionality reduction",
+    "outlier detection",
+    "mahalanobis"
   ],
   "author": "Erik Gerrits <gerrits.erik@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,10 @@
     "principal component analysis",
     "dimensionality reduction",
     "outlier detection",
-    "mahalanobis"
+    "mahalanobis",
+    "association rules",
+    "apriori",
+    "market basket analysis"
   ],
   "author": "Erik Gerrits <gerrits.erik@gmail.com>",
   "license": "MIT",

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -23,6 +23,7 @@ const GradientBoostingTutorial = lazy(() => import('./content/gradient-boosting.
 const SupportVectorMachinesTutorial = lazy(() => import('./content/support-vector-machines.mdx'));
 const KMeansTutorial = lazy(() => import('./content/k-means.mdx'));
 const HierarchicalClusteringTutorial = lazy(() => import('./content/hierarchical-clustering.mdx'));
+const DBSCANTutorial = lazy(() => import('./content/dbscan.mdx'));
 
 export function App() {
     return (
@@ -146,6 +147,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <HierarchicalClusteringTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="dbscan"
+                    element={
+                        <TutorialPage>
+                            <DBSCANTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -22,6 +22,7 @@ const RandomForestsTutorial = lazy(() => import('./content/random-forests.mdx'))
 const GradientBoostingTutorial = lazy(() => import('./content/gradient-boosting.mdx'));
 const SupportVectorMachinesTutorial = lazy(() => import('./content/support-vector-machines.mdx'));
 const KMeansTutorial = lazy(() => import('./content/k-means.mdx'));
+const HierarchicalClusteringTutorial = lazy(() => import('./content/hierarchical-clustering.mdx'));
 
 export function App() {
     return (
@@ -137,6 +138,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <KMeansTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="hierarchical-clustering"
+                    element={
+                        <TutorialPage>
+                            <HierarchicalClusteringTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -25,6 +25,7 @@ const KMeansTutorial = lazy(() => import('./content/k-means.mdx'));
 const HierarchicalClusteringTutorial = lazy(() => import('./content/hierarchical-clustering.mdx'));
 const DBSCANTutorial = lazy(() => import('./content/dbscan.mdx'));
 const PCATutorial = lazy(() => import('./content/pca.mdx'));
+const AnomalyDetectionTutorial = lazy(() => import('./content/anomaly-detection.mdx'));
 
 export function App() {
     return (
@@ -164,6 +165,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <PCATutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="anomaly-detection"
+                    element={
+                        <TutorialPage>
+                            <AnomalyDetectionTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -28,6 +28,7 @@ const PCATutorial = lazy(() => import('./content/pca.mdx'));
 const AnomalyDetectionTutorial = lazy(() => import('./content/anomaly-detection.mdx'));
 const AssociationRulesTutorial = lazy(() => import('./content/association-rules.mdx'));
 const RecommenderSystemsTutorial = lazy(() => import('./content/recommender-systems.mdx'));
+const TimeSeriesTutorial = lazy(() => import('./content/time-series.mdx'));
 
 export function App() {
     return (
@@ -191,6 +192,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <RecommenderSystemsTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="time-series"
+                    element={
+                        <TutorialPage>
+                            <TimeSeriesTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -29,6 +29,7 @@ const AnomalyDetectionTutorial = lazy(() => import('./content/anomaly-detection.
 const AssociationRulesTutorial = lazy(() => import('./content/association-rules.mdx'));
 const RecommenderSystemsTutorial = lazy(() => import('./content/recommender-systems.mdx'));
 const TimeSeriesTutorial = lazy(() => import('./content/time-series.mdx'));
+const PerceptronTutorial = lazy(() => import('./content/perceptron.mdx'));
 
 export function App() {
     return (
@@ -200,6 +201,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <TimeSeriesTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="perceptron"
+                    element={
+                        <TutorialPage>
+                            <PerceptronTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -27,6 +27,7 @@ const DBSCANTutorial = lazy(() => import('./content/dbscan.mdx'));
 const PCATutorial = lazy(() => import('./content/pca.mdx'));
 const AnomalyDetectionTutorial = lazy(() => import('./content/anomaly-detection.mdx'));
 const AssociationRulesTutorial = lazy(() => import('./content/association-rules.mdx'));
+const RecommenderSystemsTutorial = lazy(() => import('./content/recommender-systems.mdx'));
 
 export function App() {
     return (
@@ -182,6 +183,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <AssociationRulesTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="recommender-systems"
+                    element={
+                        <TutorialPage>
+                            <RecommenderSystemsTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -24,6 +24,7 @@ const SupportVectorMachinesTutorial = lazy(() => import('./content/support-vecto
 const KMeansTutorial = lazy(() => import('./content/k-means.mdx'));
 const HierarchicalClusteringTutorial = lazy(() => import('./content/hierarchical-clustering.mdx'));
 const DBSCANTutorial = lazy(() => import('./content/dbscan.mdx'));
+const PCATutorial = lazy(() => import('./content/pca.mdx'));
 
 export function App() {
     return (
@@ -155,6 +156,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <DBSCANTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="pca"
+                    element={
+                        <TutorialPage>
+                            <PCATutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -20,6 +20,7 @@ const NaiveBayesTutorial = lazy(() => import('./content/naive-bayes.mdx'));
 const DecisionTreesTutorial = lazy(() => import('./content/decision-trees.mdx'));
 const RandomForestsTutorial = lazy(() => import('./content/random-forests.mdx'));
 const GradientBoostingTutorial = lazy(() => import('./content/gradient-boosting.mdx'));
+const SupportVectorMachinesTutorial = lazy(() => import('./content/support-vector-machines.mdx'));
 const KMeansTutorial = lazy(() => import('./content/k-means.mdx'));
 
 export function App() {
@@ -120,6 +121,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <GradientBoostingTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="support-vector-machines"
+                    element={
+                        <TutorialPage>
+                            <SupportVectorMachinesTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -26,6 +26,7 @@ const HierarchicalClusteringTutorial = lazy(() => import('./content/hierarchical
 const DBSCANTutorial = lazy(() => import('./content/dbscan.mdx'));
 const PCATutorial = lazy(() => import('./content/pca.mdx'));
 const AnomalyDetectionTutorial = lazy(() => import('./content/anomaly-detection.mdx'));
+const AssociationRulesTutorial = lazy(() => import('./content/association-rules.mdx'));
 
 export function App() {
     return (
@@ -173,6 +174,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <AnomalyDetectionTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="association-rules"
+                    element={
+                        <TutorialPage>
+                            <AssociationRulesTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -186,6 +186,15 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         part: PART_3,
     },
     {
+        id: 'recommender-systems',
+        path: '/recommender-systems',
+        title: 'Recommender Systems',
+        tagline: 'Suggest what each regular will love but hasn\'t tried yet.',
+        status: 'live',
+        chapter: 18,
+        part: PART_3,
+    },
+    {
         id: 'neural-network',
         path: '/neural-network',
         title: 'Neural Network',

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -159,6 +159,15 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         part: PART_3,
     },
     {
+        id: 'pca',
+        path: '/pca',
+        title: 'PCA',
+        tagline: 'Thirty survey questions, two axes you can actually see.',
+        status: 'live',
+        chapter: 15,
+        part: PART_3,
+    },
+    {
         id: 'neural-network',
         path: '/neural-network',
         title: 'Neural Network',

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -177,6 +177,15 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         part: PART_3,
     },
     {
+        id: 'association-rules',
+        path: '/association-rules',
+        title: 'Association Rules',
+        tagline: 'The coffee-and-croissant combos hiding in the receipts.',
+        status: 'live',
+        chapter: 17,
+        part: PART_3,
+    },
+    {
         id: 'neural-network',
         path: '/neural-network',
         title: 'Neural Network',

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -123,6 +123,15 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         part: PART_2,
     },
     {
+        id: 'support-vector-machines',
+        path: '/support-vector-machines',
+        title: 'Support Vector Machines',
+        tagline: 'Not just a line — the line with the widest safety margin.',
+        status: 'live',
+        chapter: 11,
+        part: PART_2,
+    },
+    {
         id: 'k-means',
         path: '/k-means',
         title: 'k-Means',

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -135,7 +135,7 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         id: 'k-means',
         path: '/k-means',
         title: 'k-Means',
-        tagline: 'Finds clusters in unlabelled data all on its own.',
+        tagline: 'Who are my regulars? Find the customer groups with no labels at all.',
         status: 'live',
         chapter: 12,
         part: PART_3,

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -168,6 +168,15 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         part: PART_3,
     },
     {
+        id: 'anomaly-detection',
+        path: '/anomaly-detection',
+        title: 'Anomaly Detection',
+        tagline: 'Learn what normal looks like, then flag whatever doesn\'t fit.',
+        status: 'live',
+        chapter: 16,
+        part: PART_3,
+    },
+    {
         id: 'neural-network',
         path: '/neural-network',
         title: 'Neural Network',

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -21,7 +21,7 @@ const PART_0 = 'Part 0 · Foundations';
 const PART_1 = 'Part 1 · Predicting & deciding';
 const PART_2 = 'Part 2 · A wider toolbox';
 const PART_3 = 'Part 3 · Understanding customers';
-const PART_4 = 'Part 4 · Deep learning';
+const PART_4 = 'Part 4 · Sequences & deep learning';
 
 export const ALGORITHMS: AlgorithmEntry[] = [
     {
@@ -193,6 +193,15 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         status: 'live',
         chapter: 18,
         part: PART_3,
+    },
+    {
+        id: 'time-series',
+        path: '/time-series',
+        title: 'Time Series',
+        tagline: 'Forecast next week\'s demand — trend, weekly rhythm and all.',
+        status: 'live',
+        chapter: 19,
+        part: PART_4,
     },
     {
         id: 'neural-network',

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -150,6 +150,15 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         part: PART_3,
     },
     {
+        id: 'dbscan',
+        path: '/dbscan',
+        title: 'DBSCAN',
+        tagline: 'Cluster by density — and call the stragglers what they are: noise.',
+        status: 'live',
+        chapter: 14,
+        part: PART_3,
+    },
+    {
         id: 'neural-network',
         path: '/neural-network',
         title: 'Neural Network',

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -215,7 +215,7 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         id: 'neural-network',
         path: '/neural-network',
         title: 'Neural Network',
-        tagline: 'Bends curved boundaries no straight line could draw.',
+        tagline: 'When delight hides in a combination of cues — stack neurons and bend the boundary.',
         status: 'live',
         chapter: 20,
         part: PART_4,

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -141,6 +141,15 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         part: PART_3,
     },
     {
+        id: 'hierarchical-clustering',
+        path: '/hierarchical-clustering',
+        title: 'Hierarchical Clustering',
+        tagline: 'Grow a family tree of customers — and cut it wherever you like.',
+        status: 'live',
+        chapter: 13,
+        part: PART_3,
+    },
+    {
         id: 'neural-network',
         path: '/neural-network',
         title: 'Neural Network',

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -204,6 +204,14 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         part: PART_4,
     },
     {
+        id: 'perceptron',
+        path: '/perceptron',
+        title: 'Interlude · The Perceptron',
+        tagline: 'One neuron, one straight line — and the problem that stalled it.',
+        status: 'live',
+        part: PART_4,
+    },
+    {
         id: 'neural-network',
         path: '/neural-network',
         title: 'Neural Network',

--- a/site/src/components/AnomalyDetectionPlayground.module.css
+++ b/site/src/components/AnomalyDetectionPlayground.module.css
@@ -1,0 +1,63 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.boundaryWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 1 / 1;
+}
+
+.boundary {
+    width: 100%;
+    height: 100%;
+}
+
+.legend {
+    position: absolute;
+    bottom: 10px;
+    left: 12px;
+    display: flex;
+    gap: 14px;
+    font-size: 12px;
+    background: rgba(11, 17, 32, 0.6);
+    padding: 4px 10px;
+    border-radius: 999px;
+    backdrop-filter: blur(4px);
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/AnomalyDetectionPlayground.tsx
+++ b/site/src/components/AnomalyDetectionPlayground.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AnomalyDetector, Matrix } from 'machine-learning';
+import { ANOMALY_DATASETS } from '../ml/anomalyDatasets';
+import type { Domain } from '../ml/datasets';
+import { fitCanvas } from '../viz/canvas';
+import { makeGrid, type Grid } from '../viz/decisionBoundary';
+import { paintAnomalyRegion, drawAnomalyPoints } from '../viz/anomaly';
+import { Card, ControlPanel, Hint, Metric, MetricsRow, NumberField, Select, Slider } from './controls/Controls';
+import styles from './AnomalyDetectionPlayground.module.css';
+
+const GRID = 64;
+const POINTS = 200;
+
+interface TrainingData {
+    inputs: number[][];
+    inputMatrix: Matrix;
+}
+
+export function AnomalyDetectionPlayground() {
+    const [datasetId, setDatasetId] = useState(ANOMALY_DATASETS[0].id);
+    const [thresholdSlider, setThresholdSlider] = useState(ANOMALY_DATASETS[0].threshold * 10);
+    const [seed, setSeed] = useState(0);
+    const [anomalies, setAnomalies] = useState(0);
+
+    const threshold = thresholdSlider / 10;
+
+    const modelRef = useRef<AnomalyDetector | null>(null);
+    const dataRef = useRef<TrainingData | null>(null);
+    const gridRef = useRef<Grid | null>(null);
+    const domainRef = useRef<Domain>(ANOMALY_DATASETS[0].domain);
+    const offscreenRef = useRef<HTMLCanvasElement | null>(null);
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const draw = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        const grid = gridRef.current;
+        if (!model || !data || !grid) return;
+
+        const canvas = canvasRef.current;
+        if (canvas) {
+            const { ctx, width, height } = fitCanvas(canvas);
+            ctx.fillStyle = '#0b1120';
+            ctx.fillRect(0, 0, width, height);
+
+            const cellScores = model.score(grid.matrix).toArray().map(row => row[0]);
+            if (!offscreenRef.current) offscreenRef.current = document.createElement('canvas');
+            paintAnomalyRegion(offscreenRef.current, cellScores, model.getThreshold(), grid.size);
+            ctx.imageSmoothingEnabled = true;
+            ctx.drawImage(offscreenRef.current, 0, 0, width, height);
+
+            const flags = model.predict(data.inputMatrix).toArray().map(row => row[0]);
+            drawAnomalyPoints(ctx, data.inputs, flags, domainRef.current, width, height);
+        }
+    }, []);
+
+    const rebuild = useCallback(() => {
+        const dataset = ANOMALY_DATASETS.find(d => d.id === datasetId) ?? ANOMALY_DATASETS[0];
+        const { inputs } = dataset.generate(seed, POINTS);
+        const inputMatrix = new Matrix(inputs);
+
+        const model = new AnomalyDetector().setThreshold(threshold);
+        model.train(inputMatrix);
+
+        modelRef.current = model;
+        dataRef.current = { inputs, inputMatrix };
+        gridRef.current = makeGrid(dataset.domain, GRID);
+        domainRef.current = dataset.domain;
+
+        const flagged = model.predict(inputMatrix).toArray().reduce((sum, row) => sum + row[0], 0);
+        setAnomalies(flagged);
+        draw();
+    }, [datasetId, threshold, seed, draw]);
+
+    // Debounced so dragging the threshold (each re-scores + redraws) stays smooth.
+    useEffect(() => {
+        const timer = setTimeout(rebuild, 60);
+        return () => clearTimeout(timer);
+    }, [rebuild]);
+
+    const handleDataset = (id: string) => {
+        const next = ANOMALY_DATASETS.find(d => d.id === id);
+        if (!next) return;
+        setDatasetId(next.id);
+        setThresholdSlider(next.threshold * 10);
+    };
+
+    const dataset = ANOMALY_DATASETS.find(d => d.id === datasetId);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <Select
+                    label="Transactions"
+                    value={datasetId}
+                    options={ANOMALY_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={handleDataset}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Slider
+                    label="Threshold (sensitivity)"
+                    value={thresholdSlider}
+                    display={threshold.toFixed(1)}
+                    min={15}
+                    max={50}
+                    onChange={setThresholdSlider}
+                />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+                <Hint>Lower the threshold and the normal region shrinks — more transactions get flagged.</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.boundaryWrap}>
+                    <canvas ref={canvasRef} className={styles.boundary} />
+                    <div className={styles.legend}>
+                        <span style={{ color: '#38bdf8' }}>● normal</span>
+                        <span style={{ color: '#f87171' }}>● flagged</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Flagged" value={`${anomalies} / ${POINTS}`} />
+                        <Metric label="Threshold" value={threshold.toFixed(1)} />
+                    </MetricsRow>
+
+                    <Card title="Modelling normal" subtitle="mean + covariance">
+                        <p className={styles.note}>
+                            The detector fits one Gaussian to all the data — a centre and a spread. The
+                            blue region is where that bell curve says points are normal; its shape (round
+                            or tilted) follows the data's own covariance.
+                        </p>
+                    </Card>
+
+                    <Card title="Mahalanobis distance" subtitle="standard deviations, not units">
+                        <p className={styles.note}>
+                            A point is scored by how many standard deviations it sits from the centre — in
+                            the data's own shape. The threshold is the ring where that score tips a
+                            transaction from normal (blue) to flagged (red).
+                        </p>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/components/AssociationRulesPlayground.module.css
+++ b/site/src/components/AssociationRulesPlayground.module.css
@@ -1,0 +1,81 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.boundaryWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 1 / 1;
+}
+
+.boundary {
+    width: 100%;
+    height: 100%;
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+.ruleList {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.rule {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 13px;
+}
+
+.ruleText {
+    color: var(--text, #e2e8f0);
+}
+
+.arrow {
+    color: var(--accent-2, #fb923c);
+    font-weight: 600;
+}
+
+.ruleStats {
+    font-size: 11px;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/AssociationRulesPlayground.tsx
+++ b/site/src/components/AssociationRulesPlayground.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AssociationRules, Matrix, type AssociationRule } from 'machine-learning';
+import { ASSOCIATION_DATASETS } from '../ml/associationDatasets';
+import { fitCanvas } from '../viz/canvas';
+import { drawAssociationWeb } from '../viz/association';
+import { Card, ControlPanel, Hint, Metric, MetricsRow, NumberField, Select, Slider } from './controls/Controls';
+import styles from './AssociationRulesPlayground.module.css';
+
+const POINTS = 240;
+
+export function AssociationRulesPlayground() {
+    const [datasetId, setDatasetId] = useState(ASSOCIATION_DATASETS[0].id);
+    const [supportSlider, setSupportSlider] = useState(ASSOCIATION_DATASETS[0].minSupport * 100);
+    const [confidenceSlider, setConfidenceSlider] = useState(ASSOCIATION_DATASETS[0].minConfidence * 100);
+    const [seed, setSeed] = useState(0);
+    const [rules, setRules] = useState<AssociationRule[]>([]);
+    const [itemsetCount, setItemsetCount] = useState(0);
+
+    const minSupport = supportSlider / 100;
+    const minConfidence = confidenceSlider / 100;
+
+    const dataset = ASSOCIATION_DATASETS.find(d => d.id === datasetId) ?? ASSOCIATION_DATASETS[0];
+    const items = dataset.items;
+
+    const rulesRef = useRef<AssociationRule[]>([]);
+    const itemSupportRef = useRef<number[]>([]);
+    const itemsRef = useRef<string[]>(items);
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const draw = useCallback(() => {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        const { ctx, width, height } = fitCanvas(canvas);
+        ctx.fillStyle = '#0b1120';
+        ctx.fillRect(0, 0, width, height);
+        drawAssociationWeb(ctx, width, height, itemsRef.current, rulesRef.current, itemSupportRef.current);
+    }, []);
+
+    const rebuild = useCallback(() => {
+        const active = ASSOCIATION_DATASETS.find(d => d.id === datasetId) ?? ASSOCIATION_DATASETS[0];
+        const { inputs } = active.generate(seed, POINTS);
+
+        const model = new AssociationRules().setMinSupport(minSupport).setMinConfidence(minConfidence).setMaxItemsetSize(3);
+        model.train(new Matrix(inputs));
+
+        const found = model.getRules();
+        rulesRef.current = found;
+        itemsRef.current = active.items;
+        itemSupportRef.current = active.items.map((_, i) =>
+            inputs.reduce((sum, row) => sum + row[i], 0) / inputs.length,
+        );
+
+        setRules(found);
+        setItemsetCount(model.getFrequentItemsets().length);
+        draw();
+    }, [datasetId, minSupport, minConfidence, seed, draw]);
+
+    // Debounced so dragging the support / confidence bars (each re-mines the rules) stays smooth.
+    useEffect(() => {
+        const timer = setTimeout(rebuild, 60);
+        return () => clearTimeout(timer);
+    }, [rebuild]);
+
+    const handleDataset = (id: string) => {
+        const next = ASSOCIATION_DATASETS.find(d => d.id === id);
+        if (!next) return;
+        setDatasetId(next.id);
+        setSupportSlider(next.minSupport * 100);
+        setConfidenceSlider(next.minConfidence * 100);
+    };
+
+    const names = (indices: number[]) => indices.map(i => items[i]).join(' + ');
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <Select
+                    label="Receipts"
+                    value={datasetId}
+                    options={ASSOCIATION_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={handleDataset}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Slider
+                    label="Min support"
+                    value={supportSlider}
+                    display={`${supportSlider}%`}
+                    min={3}
+                    max={50}
+                    onChange={setSupportSlider}
+                />
+                <Slider
+                    label="Min confidence"
+                    value={confidenceSlider}
+                    display={`${confidenceSlider}%`}
+                    min={20}
+                    max={100}
+                    onChange={setConfidenceSlider}
+                />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+                <Hint>Thicker, brighter arrows are stronger associations (higher lift).</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.boundaryWrap}>
+                    <canvas ref={canvasRef} className={styles.boundary} />
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Rules found" value={String(rules.length)} />
+                        <Metric label="Frequent sets" value={String(itemsetCount)} />
+                    </MetricsRow>
+
+                    <Card title="Top rules" subtitle="sorted by lift">
+                        {rules.length === 0 ? (
+                            <p className={styles.note}>No rules clear the bars — lower min support or confidence.</p>
+                        ) : (
+                            <ul className={styles.ruleList}>
+                                {rules.slice(0, 7).map((rule, i) => (
+                                    <li key={i} className={styles.rule}>
+                                        <span className={styles.ruleText}>
+                                            {names(rule.antecedent)} <span className={styles.arrow}>→</span> {names(rule.consequent)}
+                                        </span>
+                                        <span className={styles.ruleStats}>
+                                            conf {(rule.confidence * 100).toFixed(0)}% · lift {rule.lift.toFixed(2)}
+                                        </span>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </Card>
+
+                    <Card title="Support, confidence, lift" subtitle="how a rule earns its place">
+                        <p className={styles.note}>
+                            <strong>Support</strong> is how common the combo is; <strong>confidence</strong>{' '}
+                            is how reliably the consequent follows; <strong>lift</strong> is how much more
+                            than chance they appear together. Lift above 1 is a real pairing — below 1 they
+                            actually repel.
+                        </p>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/components/DBSCANPlayground.module.css
+++ b/site/src/components/DBSCANPlayground.module.css
@@ -1,0 +1,63 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.boundaryWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 1 / 1;
+}
+
+.boundary {
+    width: 100%;
+    height: 100%;
+}
+
+.legend {
+    position: absolute;
+    bottom: 10px;
+    left: 12px;
+    display: flex;
+    gap: 14px;
+    font-size: 12px;
+    background: rgba(11, 17, 32, 0.6);
+    padding: 4px 10px;
+    border-radius: 999px;
+    backdrop-filter: blur(4px);
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/DBSCANPlayground.tsx
+++ b/site/src/components/DBSCANPlayground.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { DBSCAN, Matrix } from 'machine-learning';
+import { DBSCAN_DATASETS } from '../ml/dbscanDatasets';
+import type { Domain } from '../ml/datasets';
+import { fitCanvas } from '../viz/canvas';
+import { makeGrid, type Grid } from '../viz/decisionBoundary';
+import { paintDensity, drawDbscanPoints } from '../viz/dbscan';
+import { Card, ControlPanel, Hint, Metric, MetricsRow, NumberField, Select, Slider } from './controls/Controls';
+import styles from './DBSCANPlayground.module.css';
+
+const GRID = 64;
+const POINTS = 150;
+
+interface TrainingData {
+    inputs: number[][];
+    inputMatrix: Matrix;
+}
+
+export function DBSCANPlayground() {
+    const [datasetId, setDatasetId] = useState(DBSCAN_DATASETS[0].id);
+    const [epsilonSlider, setEpsilonSlider] = useState(DBSCAN_DATASETS[0].epsilon * 100);
+    const [minPoints, setMinPoints] = useState(DBSCAN_DATASETS[0].minPoints);
+    const [seed, setSeed] = useState(0);
+    const [metrics, setMetrics] = useState({ clusters: 0, noise: 0 });
+
+    const epsilon = epsilonSlider / 100;
+
+    const modelRef = useRef<DBSCAN | null>(null);
+    const dataRef = useRef<TrainingData | null>(null);
+    const gridRef = useRef<Grid | null>(null);
+    const domainRef = useRef<Domain>(DBSCAN_DATASETS[0].domain);
+    const offscreenRef = useRef<HTMLCanvasElement | null>(null);
+    const mapCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const draw = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        const grid = gridRef.current;
+        if (!model || !data || !grid) return;
+
+        const canvas = mapCanvasRef.current;
+        if (canvas) {
+            const { ctx, width, height } = fitCanvas(canvas);
+            ctx.fillStyle = '#0b1120';
+            ctx.fillRect(0, 0, width, height);
+
+            const cellLabels = model.predict(grid.matrix).toArray().map(row => row[0]);
+            if (!offscreenRef.current) offscreenRef.current = document.createElement('canvas');
+            paintDensity(offscreenRef.current, cellLabels, grid.size);
+            ctx.imageSmoothingEnabled = true;
+            ctx.drawImage(offscreenRef.current, 0, 0, width, height);
+
+            drawDbscanPoints(ctx, data.inputs, model.getLabels(), domainRef.current, width, height);
+        }
+    }, []);
+
+    const rebuild = useCallback(() => {
+        const dataset = DBSCAN_DATASETS.find(d => d.id === datasetId) ?? DBSCAN_DATASETS[0];
+        const { inputs } = dataset.generate(seed, POINTS);
+        const inputMatrix = new Matrix(inputs);
+
+        const model = new DBSCAN().setEpsilon(epsilon).setMinPoints(minPoints);
+        model.train(inputMatrix);
+
+        modelRef.current = model;
+        dataRef.current = { inputs, inputMatrix };
+        gridRef.current = makeGrid(dataset.domain, GRID);
+        domainRef.current = dataset.domain;
+
+        const noise = model.getLabels().filter(label => label < 0).length;
+        setMetrics({ clusters: model.getClusterCount(), noise });
+        draw();
+    }, [datasetId, epsilon, minPoints, seed, draw]);
+
+    // Debounced so dragging epsilon / minPoints (each re-runs DBSCAN) stays smooth.
+    useEffect(() => {
+        const timer = setTimeout(rebuild, 60);
+        return () => clearTimeout(timer);
+    }, [rebuild]);
+
+    const handleDataset = (id: string) => {
+        const next = DBSCAN_DATASETS.find(d => d.id === id);
+        if (!next) return;
+        setDatasetId(next.id);
+        setEpsilonSlider(next.epsilon * 100);
+        setMinPoints(next.minPoints);
+    };
+
+    const dataset = DBSCAN_DATASETS.find(d => d.id === datasetId);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <Select
+                    label="Customers"
+                    value={datasetId}
+                    options={DBSCAN_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={handleDataset}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Slider
+                    label="Epsilon (radius)"
+                    value={epsilonSlider}
+                    display={epsilon.toFixed(2)}
+                    min={4}
+                    max={60}
+                    onChange={setEpsilonSlider}
+                />
+                <Slider
+                    label="Min points"
+                    value={minPoints}
+                    display={String(minPoints)}
+                    min={2}
+                    max={12}
+                    onChange={setMinPoints}
+                />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+                <Hint>No k. The number of groups falls out of the density — and stragglers are left as noise.</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.boundaryWrap}>
+                    <canvas ref={mapCanvasRef} className={styles.boundary} />
+                    <div className={styles.legend}>
+                        <span>● clustered</span>
+                        <span style={{ color: 'rgba(148, 163, 184, 0.95)' }}>✕ noise</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Clusters found" value={String(metrics.clusters)} />
+                        <Metric label="Noise points" value={String(metrics.noise)} />
+                    </MetricsRow>
+
+                    <Card title="Density, not distance" subtitle="core → reachable → noise">
+                        <p className={styles.note}>
+                            A point is a <strong>core</strong> point when at least <em>min points</em>
+                            neighbours sit within <em>epsilon</em>. Clusters grow by chaining through
+                            core points, so they take any dense shape. Points reachable from no core are{' '}
+                            <strong>noise</strong> — drawn as grey ✕.
+                        </p>
+                    </Card>
+
+                    <Card title="Two knobs" subtitle="epsilon × min points">
+                        <p className={styles.note}>
+                            Raise <strong>epsilon</strong> and groups reach farther and merge; lower it
+                            and they splinter and more points become noise. Raise <strong>min points</strong>
+                            and it takes a denser pile to count as a cluster. There is no k to set.
+                        </p>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/components/HierarchicalClusteringPlayground.module.css
+++ b/site/src/components/HierarchicalClusteringPlayground.module.css
@@ -1,0 +1,69 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.boundaryWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 1 / 1;
+}
+
+.boundary {
+    width: 100%;
+    height: 100%;
+}
+
+.legend {
+    position: absolute;
+    bottom: 10px;
+    left: 12px;
+    display: flex;
+    gap: 14px;
+    font-size: 12px;
+    background: rgba(11, 17, 32, 0.6);
+    padding: 4px 10px;
+    border-radius: 999px;
+    backdrop-filter: blur(4px);
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.note {
+    margin: 10px 0 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+.dendroCanvas {
+    display: block;
+    width: 100%;
+    height: 190px;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/HierarchicalClusteringPlayground.tsx
+++ b/site/src/components/HierarchicalClusteringPlayground.tsx
@@ -1,0 +1,168 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { HierarchicalClustering, Matrix, type Linkage } from 'machine-learning';
+import { HIERARCHICAL_DATASETS } from '../ml/hierarchicalDatasets';
+import type { Domain } from '../ml/datasets';
+import { fitCanvas } from '../viz/canvas';
+import { makeGrid, type Grid } from '../viz/decisionBoundary';
+import { drawClusterPoints, paintClusters } from '../viz/clusters';
+import { drawDendrogram } from '../viz/dendrogram';
+import { Card, ControlPanel, Hint, Metric, MetricsRow, NumberField, Select, Slider } from './controls/Controls';
+import styles from './HierarchicalClusteringPlayground.module.css';
+
+const GRID = 64;
+const POINTS = 140;
+
+const argmaxRows = (matrix: Matrix): number[] => matrix.getMaximumRowIndeces().toArray().map(row => row[0]);
+
+const LINKAGE_OPTIONS: { value: Linkage; label: string }[] = [
+    { value: 'single', label: 'Single (nearest pair)' },
+    { value: 'complete', label: 'Complete (farthest pair)' },
+    { value: 'average', label: 'Average (mean pair)' },
+];
+
+interface TrainingData {
+    inputs: number[][];
+    inputMatrix: Matrix;
+}
+
+export function HierarchicalClusteringPlayground() {
+    const [datasetId, setDatasetId] = useState(HIERARCHICAL_DATASETS[0].id);
+    const [linkage, setLinkage] = useState<Linkage>('average');
+    const [k, setK] = useState(HIERARCHICAL_DATASETS[0].recommendedClusters);
+    const [seed, setSeed] = useState(0);
+
+    const modelRef = useRef<HierarchicalClustering | null>(null);
+    const dataRef = useRef<TrainingData | null>(null);
+    const gridRef = useRef<Grid | null>(null);
+    const domainRef = useRef<Domain>(HIERARCHICAL_DATASETS[0].domain);
+    const offscreenRef = useRef<HTMLCanvasElement | null>(null);
+
+    const mapCanvasRef = useRef<HTMLCanvasElement | null>(null);
+    const dendroCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const draw = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        const grid = gridRef.current;
+        if (!model || !data || !grid) return;
+
+        const labels = model.getClusterLabels();
+
+        const mapCanvas = mapCanvasRef.current;
+        if (mapCanvas) {
+            const { ctx, width, height } = fitCanvas(mapCanvas);
+            ctx.fillStyle = '#0b1120';
+            ctx.fillRect(0, 0, width, height);
+
+            const cellClusters = argmaxRows(model.predict(grid.matrix));
+            if (!offscreenRef.current) offscreenRef.current = document.createElement('canvas');
+            paintClusters(offscreenRef.current, cellClusters, grid.size);
+            ctx.imageSmoothingEnabled = true;
+            ctx.drawImage(offscreenRef.current, 0, 0, width, height);
+
+            drawClusterPoints(ctx, data.inputs, labels, domainRef.current, width, height);
+        }
+
+        const dendroCanvas = dendroCanvasRef.current;
+        if (dendroCanvas) {
+            const { ctx, width, height } = fitCanvas(dendroCanvas);
+            drawDendrogram(ctx, width, height, model.getMergeHistory(), data.inputs.length, k, labels);
+        }
+    }, [k]);
+
+    const rebuild = useCallback(() => {
+        const dataset = HIERARCHICAL_DATASETS.find(d => d.id === datasetId) ?? HIERARCHICAL_DATASETS[0];
+        const { inputs } = dataset.generate(seed, POINTS);
+        const inputMatrix = new Matrix(inputs);
+
+        const model = new HierarchicalClustering().setLinkage(linkage).setNumberOfClusters(k);
+        model.train(inputMatrix);
+
+        modelRef.current = model;
+        dataRef.current = { inputs, inputMatrix };
+        gridRef.current = makeGrid(dataset.domain, GRID);
+        domainRef.current = dataset.domain;
+        draw();
+    }, [datasetId, linkage, seed, k, draw]);
+
+    // Debounced so dragging k (each re-cut + redraw) stays smooth. The tree itself only changes with
+    // dataset / linkage / seed; rebuilding on k too is cheap at this scale and keeps the code simple.
+    useEffect(() => {
+        const timer = setTimeout(rebuild, 60);
+        return () => clearTimeout(timer);
+    }, [rebuild]);
+
+    const handleDataset = (id: string) => {
+        const next = HIERARCHICAL_DATASETS.find(d => d.id === id);
+        if (!next) return;
+        setDatasetId(next.id);
+        setK(next.recommendedClusters);
+    };
+
+    const dataset = HIERARCHICAL_DATASETS.find(d => d.id === datasetId);
+    const linkageLabel = linkage.charAt(0).toUpperCase() + linkage.slice(1);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <Select
+                    label="Customers"
+                    value={datasetId}
+                    options={HIERARCHICAL_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={handleDataset}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Select
+                    label="Linkage"
+                    value={linkage}
+                    options={LINKAGE_OPTIONS}
+                    onChange={value => setLinkage(value as Linkage)}
+                />
+                <Slider
+                    label="Clusters (k)"
+                    value={k}
+                    display={String(k)}
+                    min={1}
+                    max={6}
+                    onChange={setK}
+                />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+                <Hint>The tree is built once; k just chooses where to slice it. No need to fix it up front.</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.boundaryWrap}>
+                    <canvas ref={mapCanvasRef} className={styles.boundary} />
+                    <div className={styles.legend}>
+                        <span>● customers by group</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Clusters" value={String(k)} />
+                        <Metric label="Linkage" value={linkageLabel} />
+                    </MetricsRow>
+
+                    <Card title="The dendrogram" subtitle="merge tree + cut line">
+                        <canvas ref={dendroCanvasRef} className={styles.dendroCanvas} />
+                        <p className={styles.note}>
+                            Every leaf is one customer; each bracket is a merge, drawn at the distance the
+                            two groups joined. The dashed line is the <strong>cut</strong> for the current
+                            k — slide k and watch it rise or fall.
+                        </p>
+                    </Card>
+
+                    <Card title="Linkage" subtitle="how 'close' two groups are">
+                        <p className={styles.note}>
+                            <strong>Single</strong> measures groups by their nearest pair (it can chain
+                            along a curve), <strong>complete</strong> by their farthest pair (tight, round
+                            groups), <strong>average</strong> by the mean over all pairs. Same data,
+                            different trees.
+                        </p>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/components/KMeansPlayground.tsx
+++ b/site/src/components/KMeansPlayground.tsx
@@ -212,15 +212,15 @@ export function KMeansPlayground() {
                     onChange={setSpeed}
                 />
                 <NumberField label="Random seed" value={seed} onChange={setSeed} />
-                <Hint>No labels needed — k-means groups the points all on its own.</Hint>
+                <Hint>No labels — nobody told it who's who. k-means finds the segments on its own.</Hint>
             </ControlPanel>
 
             <div className={styles.stage}>
                 <div className={styles.boundaryWrap}>
                     <canvas ref={boundaryCanvasRef} className={styles.boundary} />
                     <div className={styles.activation}>
-                        <span>◆ centroids</span>
-                        <span>● points by cluster</span>
+                        <span>◆ segment centre</span>
+                        <span>● customers by segment</span>
                     </div>
                 </div>
 
@@ -233,11 +233,11 @@ export function KMeansPlayground() {
 
                     <Card title="Lloyd's algorithm" subtitle="assign → move, repeat">
                         <p className={styles.note}>
-                            Each step does two things: every point is <strong>assigned</strong> to its
-                            nearest centroid (the coloured Voronoi cells), then every centroid{' '}
-                            <strong>moves</strong> to the mean of its points. Repeat until nothing moves —
-                            that's convergence. Change <strong>k</strong> or the <strong>seed</strong> to
-                            see it land in a different grouping.
+                            Each step does two things: every customer is <strong>assigned</strong> to the
+                            nearest segment centre (the coloured regions), then every centre{' '}
+                            <strong>moves</strong> to the average of its customers. Repeat until nothing
+                            moves — that's convergence. Change <strong>k</strong> or the{' '}
+                            <strong>seed</strong> to see it land in a different grouping.
                         </p>
                     </Card>
 

--- a/site/src/components/NeuralNetworkPlayground.tsx
+++ b/site/src/components/NeuralNetworkPlayground.tsx
@@ -261,8 +261,8 @@ export function NeuralNetworkPlayground() {
                 <div className={styles.boundaryWrap}>
                     <canvas ref={boundaryCanvasRef} className={styles.boundary} />
                     <div className={styles.activation}>
-                        <span style={{ color: 'var(--accent)' }}>● class 0</span>
-                        <span style={{ color: 'var(--accent-2)' }}>● class 1</span>
+                        <span style={{ color: 'var(--accent)' }}>● flop</span>
+                        <span style={{ color: 'var(--accent-2)' }}>● delight</span>
                     </div>
                 </div>
 

--- a/site/src/components/PCAPlayground.module.css
+++ b/site/src/components/PCAPlayground.module.css
@@ -1,0 +1,63 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.boundaryWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 1 / 1;
+}
+
+.boundary {
+    width: 100%;
+    height: 100%;
+}
+
+.legend {
+    position: absolute;
+    bottom: 10px;
+    left: 12px;
+    display: flex;
+    gap: 14px;
+    font-size: 12px;
+    background: rgba(11, 17, 32, 0.6);
+    padding: 4px 10px;
+    border-radius: 999px;
+    backdrop-filter: blur(4px);
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/PCAPlayground.tsx
+++ b/site/src/components/PCAPlayground.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { PCA, Matrix } from 'machine-learning';
+import { PCA_DATASETS } from '../ml/pcaDatasets';
+import type { Domain } from '../ml/datasets';
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+import { fitCanvas } from '../viz/canvas';
+import { drawPcaAxes, drawPcaPoints, drawPc1Line } from '../viz/pca';
+import { Card, Checkbox, ControlPanel, Hint, Metric, MetricsRow, NumberField, Select } from './controls/Controls';
+import styles from './PCAPlayground.module.css';
+
+const POINTS = 160;
+
+interface FitResult {
+    points: number[][];
+    mean: number[];
+    components: number[][];
+    stds: number[];
+    ratio: number[];
+}
+
+export function PCAPlayground() {
+    const [datasetId, setDatasetId] = useState(PCA_DATASETS[0].id);
+    const [reduce, setReduce] = useState(false);
+    const [seed, setSeed] = useState(0);
+    const [ratio, setRatio] = useState([0, 0]);
+
+    const fitRef = useRef<FitResult | null>(null);
+    const domainRef = useRef<Domain>(PCA_DATASETS[0].domain);
+    const tRef = useRef(0);
+    const targetRef = useRef(0);
+    const [animating, setAnimating] = useState(false);
+
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const draw = useCallback(() => {
+        const fit = fitRef.current;
+        const canvas = canvasRef.current;
+        if (!fit || !canvas) return;
+
+        const { ctx, width, height } = fitCanvas(canvas);
+        ctx.fillStyle = '#0b1120';
+        ctx.fillRect(0, 0, width, height);
+
+        const t = tRef.current;
+        if (t > 0.01) {
+            drawPc1Line(ctx, fit.mean, fit.components[0], domainRef.current, width, height);
+        }
+        drawPcaPoints(ctx, fit.points, fit.mean, fit.components[0], domainRef.current, width, height, t);
+        drawPcaAxes(ctx, fit.mean, fit.components, fit.stds, domainRef.current, width, height);
+    }, []);
+
+    const rebuild = useCallback(() => {
+        const dataset = PCA_DATASETS.find(d => d.id === datasetId) ?? PCA_DATASETS[0];
+        const { inputs } = dataset.generate(seed, POINTS);
+
+        const model = new PCA().setNumberOfComponents(2);
+        model.train(new Matrix(inputs));
+
+        const variance = model.getExplainedVariance();
+        fitRef.current = {
+            points: inputs,
+            mean: model.getMean().toArray()[0],
+            components: model.getComponents().toArray(),
+            stds: variance.map(v => Math.sqrt(v)),
+            ratio: model.getExplainedVarianceRatio(),
+        };
+        domainRef.current = dataset.domain;
+        setRatio(fitRef.current.ratio);
+        draw();
+    }, [datasetId, seed, draw]);
+
+    useEffect(() => {
+        rebuild();
+    }, [rebuild]);
+
+    // Animate the points collapsing onto PC1 (or springing back) whenever the toggle flips.
+    useEffect(() => {
+        targetRef.current = reduce ? 1 : 0;
+        setAnimating(true);
+    }, [reduce]);
+
+    const tick = useCallback(() => {
+        const target = targetRef.current;
+        const step = 0.06;
+        if (tRef.current < target) tRef.current = Math.min(target, tRef.current + step);
+        else tRef.current = Math.max(target, tRef.current - step);
+
+        draw();
+        if (tRef.current === target) setAnimating(false);
+    }, [draw]);
+
+    useAnimationFrame(tick, animating);
+
+    const dataset = PCA_DATASETS.find(d => d.id === datasetId);
+    const pct = (value: number) => `${(value * 100).toFixed(0)}%`;
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <Select
+                    label="Customers"
+                    value={datasetId}
+                    options={PCA_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={setDatasetId}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Checkbox label="Reduce to 1 axis (project onto PC1)" checked={reduce} onChange={setReduce} />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+                <Hint>PC1 is the direction of greatest spread; PC2 is whatever's left, at a right angle.</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.boundaryWrap}>
+                    <canvas ref={canvasRef} className={styles.boundary} />
+                    <div className={styles.legend}>
+                        <span style={{ color: '#fb923c' }}>▬ PC1</span>
+                        <span style={{ color: '#94a3b8' }}>▬ PC2</span>
+                        <span style={{ color: '#38bdf8' }}>● customers</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="PC1 variance" value={pct(ratio[0] ?? 0)} />
+                        <Metric label="PC2 variance" value={pct(ratio[1] ?? 0)} />
+                    </MetricsRow>
+
+                    <Card title="Principal components" subtitle="axes of greatest variance">
+                        <p className={styles.note}>
+                            PCA rotates to find the axis the data spreads along most (<strong>PC1</strong>,
+                            the long amber arrow), then the best one at a right angle to it
+                            (<strong>PC2</strong>). The arrows' lengths are how much variance each holds.
+                        </p>
+                    </Card>
+
+                    <Card title="Keeping just PC1" subtitle="2-D → 1-D">
+                        <p className={styles.note}>
+                            Tick the box and every point collapses onto the PC1 line — that's the reduction.
+                            When PC1 holds most of the variance, the squashed points barely move and almost
+                            nothing is lost; when the cloud is round, they fall a long way and you can see
+                            the cost.
+                        </p>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/components/PerceptronPlayground.module.css
+++ b/site/src/components/PerceptronPlayground.module.css
@@ -1,0 +1,63 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.boundaryWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 1 / 1;
+}
+
+.boundary {
+    width: 100%;
+    height: 100%;
+}
+
+.legend {
+    position: absolute;
+    bottom: 10px;
+    left: 12px;
+    display: flex;
+    gap: 14px;
+    font-size: 12px;
+    background: rgba(11, 17, 32, 0.6);
+    padding: 4px 10px;
+    border-radius: 999px;
+    backdrop-filter: blur(4px);
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/PerceptronPlayground.tsx
+++ b/site/src/components/PerceptronPlayground.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Perceptron, Matrix } from 'machine-learning';
+import type { Domain } from '../ml/datasets';
+import { GATE_DATASETS } from '../ml/perceptronDatasets';
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+import { fitCanvas } from '../viz/canvas';
+import { makeGrid, paintBoundary, drawPoints, type Grid } from '../viz/decisionBoundary';
+import { drawMisclassified } from '../viz/perceptron';
+import { Card, ControlPanel, Hint, Metric, MetricsRow, NumberField, RunControls, Select, Slider } from './controls/Controls';
+import styles from './PerceptronPlayground.module.css';
+
+const GRID = 64;
+const POINTS = 120;
+
+interface TrainingData {
+    inputs: number[][];
+    targets: number[][];
+    inputMatrix: Matrix;
+    targetMatrix: Matrix;
+}
+
+export function PerceptronPlayground() {
+    const [datasetId, setDatasetId] = useState(GATE_DATASETS[0].id);
+    const [rateSlider, setRateSlider] = useState(20); // learning rate = rateSlider / 100
+    const [seed, setSeed] = useState(0);
+    const [running, setRunning] = useState(false);
+    const [metrics, setMetrics] = useState({ epoch: 0, wrong: 0 });
+
+    const learningRate = rateSlider / 100;
+
+    const modelRef = useRef<Perceptron | null>(null);
+    const dataRef = useRef<TrainingData | null>(null);
+    const gridRef = useRef<Grid | null>(null);
+    const domainRef = useRef<Domain>(GATE_DATASETS[0].domain);
+    const offscreenRef = useRef<HTMLCanvasElement | null>(null);
+    const epochRef = useRef(0);
+    const frameRef = useRef(0);
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const draw = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        const grid = gridRef.current;
+        if (!model || !data || !grid) return;
+
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        const { ctx, width, height } = fitCanvas(canvas);
+        ctx.fillStyle = '#0b1120';
+        ctx.fillRect(0, 0, width, height);
+
+        const regions = model.predict(grid.matrix).toArray().map(row => row[0]); // 0 / 1 half-planes
+        if (!offscreenRef.current) offscreenRef.current = document.createElement('canvas');
+        paintBoundary(offscreenRef.current, regions, grid.size);
+        ctx.imageSmoothingEnabled = true;
+        ctx.drawImage(offscreenRef.current, 0, 0, width, height);
+
+        drawPoints(ctx, data.inputs, data.targets, domainRef.current, width, height);
+
+        const predictions = model.predict(data.inputMatrix).toArray().map(row => row[0]);
+        const labels = data.targets.map(row => row[0]);
+        drawMisclassified(ctx, data.inputs, labels, predictions, domainRef.current, width, height);
+    }, []);
+
+    const rebuild = useCallback(() => {
+        const dataset = GATE_DATASETS.find(d => d.id === datasetId) ?? GATE_DATASETS[0];
+        const { inputs, targets } = dataset.generate(seed, POINTS);
+        const inputMatrix = new Matrix(inputs);
+        const targetMatrix = new Matrix(targets);
+
+        const model = new Perceptron().setLearningRate(learningRate).setNumberOfEpochs(1);
+        model.train(inputMatrix, targetMatrix); // one pass so the boundary exists to draw
+
+        modelRef.current = model;
+        dataRef.current = { inputs, targets, inputMatrix, targetMatrix };
+        gridRef.current = makeGrid(dataset.domain, GRID);
+        domainRef.current = dataset.domain;
+        epochRef.current = 1;
+        frameRef.current = 0;
+
+        const predictions = model.predict(inputMatrix).toArray().map(row => row[0]);
+        const wrong = predictions.filter((p, i) => p !== targets[i][0]).length;
+        setMetrics({ epoch: 1, wrong });
+        setRunning(false);
+        draw();
+    }, [datasetId, learningRate, seed, draw]);
+
+    useEffect(() => {
+        rebuild();
+    }, [rebuild]);
+
+    const step = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        if (!model || !data) return;
+
+        model.train(data.inputMatrix, data.targetMatrix);
+        epochRef.current += 1;
+
+        const predictions = model.predict(data.inputMatrix).toArray().map(row => row[0]);
+        const wrong = predictions.filter((p, i) => p !== data.targets[i][0]).length;
+
+        draw();
+        frameRef.current += 1;
+        if (frameRef.current % 2 === 0) {
+            setMetrics({ epoch: epochRef.current, wrong });
+        }
+    }, [draw]);
+
+    useAnimationFrame(step, running);
+
+    const handleStep = () => {
+        if (!running) step();
+    };
+    const handleReset = () => {
+        setRunning(false);
+        rebuild();
+    };
+
+    const dataset = GATE_DATASETS.find(d => d.id === datasetId);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <RunControls
+                    running={running}
+                    onToggle={() => setRunning(r => !r)}
+                    onStep={handleStep}
+                    onReset={handleReset}
+                />
+                <Select
+                    label="Gate"
+                    value={datasetId}
+                    options={GATE_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={setDatasetId}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Slider label="Learning rate" value={rateSlider} display={learningRate.toFixed(2)} min={1} max={100} onChange={setRateSlider} />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+                <Hint>One neuron draws one straight line. On XOR, watch the line never stop moving.</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.boundaryWrap}>
+                    <canvas ref={canvasRef} className={styles.boundary} />
+                    <div className={styles.legend}>
+                        <span style={{ color: 'var(--accent)' }}>● off (0)</span>
+                        <span style={{ color: 'var(--accent-2)' }}>● fires (1)</span>
+                        <span style={{ color: '#f87171' }}>◯ wrong</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Epoch" value={String(metrics.epoch)} />
+                        <Metric label="Misclassified" value={String(metrics.wrong)} />
+                    </MetricsRow>
+
+                    <Card title="Weighted sum + step" subtitle="one neuron">
+                        <p className={styles.note}>
+                            The perceptron adds up its inputs times their weights, plus a bias, and fires
+                            if the total clears zero. That makes its boundary a single straight line — and
+                            it learns by nudging that line toward any point it gets wrong.
+                        </p>
+                    </Card>
+
+                    <Card title="The XOR wall" subtitle="why we need layers">
+                        <p className={styles.note}>
+                            On <strong>AND</strong> and <strong>OR</strong> the misclassified count falls
+                            to zero and the line stops. On <strong>XOR</strong> it never does — no straight
+                            line can split those corners. Stacking neurons into layers is what breaks the
+                            wall (next chapter).
+                        </p>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/components/RecommenderPlayground.module.css
+++ b/site/src/components/RecommenderPlayground.module.css
@@ -1,0 +1,137 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(220px, 280px);
+    gap: 20px;
+    align-items: start;
+}
+
+.gridWrap {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.grid {
+    display: grid;
+    gap: 3px;
+}
+
+.corner {
+    background: transparent;
+}
+
+.itemHead {
+    font-size: 10px;
+    color: var(--muted);
+    text-align: center;
+    align-self: end;
+    padding-bottom: 4px;
+    line-height: 1.1;
+    word-break: break-word;
+}
+
+.userHead {
+    font-size: 12px;
+    color: var(--text, #e2e8f0);
+    background: rgba(148, 163, 184, 0.08);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0 6px;
+    cursor: pointer;
+    text-align: left;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.userHead:hover {
+    background: rgba(148, 163, 184, 0.18);
+}
+
+.userActive {
+    border-color: var(--accent, #38bdf8);
+    box-shadow: 0 0 0 1px var(--accent, #38bdf8);
+}
+
+.cell {
+    aspect-ratio: 1 / 1;
+    border-radius: 5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+
+.observed {
+    box-shadow: inset 0 0 0 2px rgba(248, 250, 252, 0.9);
+}
+
+.hidden {
+    opacity: 0.7;
+}
+
+.topPick {
+    box-shadow: 0 0 0 2px #fbbf24;
+    opacity: 1;
+    font-size: 14px;
+}
+
+.legend {
+    display: flex;
+    gap: 14px;
+    font-size: 11px;
+    color: var(--muted);
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+.pickList {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.pick {
+    display: flex;
+    justify-content: space-between;
+    font-size: 14px;
+    color: var(--text, #e2e8f0);
+}
+
+.pickScore {
+    color: var(--accent-2, #fbbf24);
+    font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/RecommenderPlayground.tsx
+++ b/site/src/components/RecommenderPlayground.tsx
@@ -1,0 +1,206 @@
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
+import { Recommender, Matrix } from 'machine-learning';
+import { RECOMMENDER_DATASETS } from '../ml/recommenderDatasets';
+import { ratingColor, ratingTextColor } from '../viz/recommender';
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+import { Card, ControlPanel, Hint, Metric, MetricsRow, NumberField, RunControls, Select, Slider } from './controls/Controls';
+import styles from './RecommenderPlayground.module.css';
+
+const STEPS_PER_FRAME = 4;
+
+export function RecommenderPlayground() {
+    const [datasetId, setDatasetId] = useState(RECOMMENDER_DATASETS[0].id);
+    const [factors, setFactors] = useState(2);
+    const [seed, setSeed] = useState(0);
+    const [running, setRunning] = useState(false);
+    const [selectedUser, setSelectedUser] = useState(0);
+    const [predicted, setPredicted] = useState<number[][]>([]);
+    const [metrics, setMetrics] = useState({ epoch: 0, rmse: 0 });
+
+    const dataset = RECOMMENDER_DATASETS.find(d => d.id === datasetId) ?? RECOMMENDER_DATASETS[0];
+
+    const modelRef = useRef<Recommender | null>(null);
+    const ratingsRef = useRef<number[][]>([]);
+    const matrixRef = useRef<Matrix | null>(null);
+    const epochRef = useRef(0);
+    const frameRef = useRef(0);
+
+    const observedRmse = useCallback((prediction: number[][]) => {
+        const ratings = ratingsRef.current;
+        let sum = 0;
+        let count = 0;
+        for (let u = 0; u < ratings.length; u++) {
+            for (let i = 0; i < ratings[u].length; i++) {
+                if (ratings[u][i] !== 0) {
+                    const error = prediction[u][i] - ratings[u][i];
+                    sum += error * error;
+                    count++;
+                }
+            }
+        }
+        return count > 0 ? Math.sqrt(sum / count) : 0;
+    }, []);
+
+    const rebuild = useCallback(() => {
+        const active = RECOMMENDER_DATASETS.find(d => d.id === datasetId) ?? RECOMMENDER_DATASETS[0];
+        const { inputs } = active.generate(seed);
+        const matrix = new Matrix(inputs);
+
+        const model = new Recommender()
+            .setNumberOfFactors(factors)
+            .setLearningRate(0.02)
+            .setRegularization(0.05)
+            .setSeed(seed)
+            .setNumberOfEpochs(0);
+        model.train(matrix); // initialise factors without stepping yet
+        model.setNumberOfEpochs(STEPS_PER_FRAME);
+
+        modelRef.current = model;
+        ratingsRef.current = inputs;
+        matrixRef.current = matrix;
+        epochRef.current = 0;
+        frameRef.current = 0;
+        setRunning(false);
+
+        const prediction = model.predict().toArray();
+        setPredicted(prediction);
+        setMetrics({ epoch: 0, rmse: observedRmse(prediction) });
+    }, [datasetId, factors, seed, observedRmse]);
+
+    useEffect(() => {
+        rebuild();
+    }, [rebuild]);
+
+    const step = useCallback(() => {
+        const model = modelRef.current;
+        const matrix = matrixRef.current;
+        if (!model || !matrix) return;
+
+        model.train(matrix);
+        epochRef.current += STEPS_PER_FRAME;
+
+        const prediction = model.predict().toArray();
+        setPredicted(prediction);
+
+        frameRef.current += 1;
+        if (frameRef.current % 2 === 0) {
+            setMetrics({ epoch: epochRef.current, rmse: observedRmse(prediction) });
+        }
+    }, [observedRmse]);
+
+    useAnimationFrame(step, running);
+
+    const handleStep = () => {
+        if (!running) step();
+    };
+    const handleReset = () => rebuild();
+    const handleDataset = (id: string) => {
+        setSelectedUser(0);
+        setDatasetId(id);
+    };
+
+    const ratings = ratingsRef.current;
+    const recommendations = predicted.length > 0
+        ? predicted[selectedUser]
+            .map((score, item) => ({ item, score }))
+            .filter(({ item }) => ratings[selectedUser]?.[item] === 0)
+            .sort((a, b) => b.score - a.score)
+            .slice(0, 3)
+        : [];
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <RunControls
+                    running={running}
+                    onToggle={() => setRunning(r => !r)}
+                    onStep={handleStep}
+                    onReset={handleReset}
+                />
+                <Select
+                    label="Ratings"
+                    value={datasetId}
+                    options={RECOMMENDER_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={handleDataset}
+                />
+                <Hint>{dataset.blurb}</Hint>
+                <Slider label="Taste factors (k)" value={factors} display={String(factors)} min={1} max={4} onChange={setFactors} />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+                <Hint>Click a name to see that person's top picks. Bright = predicted high; ★ = top suggestion.</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.gridWrap}>
+                    <div className={styles.grid} style={{ gridTemplateColumns: `84px repeat(${dataset.items.length}, 1fr)` }}>
+                        <div className={styles.corner} />
+                        {dataset.items.map(item => (
+                            <div key={item} className={styles.itemHead}>{item}</div>
+                        ))}
+
+                        {dataset.users.map((user, u) => (
+                            <Fragment key={user}>
+                                <button
+                                    className={`${styles.userHead} ${u === selectedUser ? styles.userActive : ''}`}
+                                    onClick={() => setSelectedUser(u)}
+                                >
+                                    {user}
+                                </button>
+                                {dataset.items.map((_, i) => {
+                                    const observed = ratings[u]?.[i] !== 0 && ratings[u]?.[i] !== undefined;
+                                    const value = observed ? ratings[u][i] : (predicted[u]?.[i] ?? 0);
+                                    const isTopPick = u === selectedUser && recommendations[0]?.item === i;
+                                    return (
+                                        <div
+                                            key={i}
+                                            className={`${styles.cell} ${observed ? styles.observed : styles.hidden} ${isTopPick ? styles.topPick : ''}`}
+                                            style={{ background: ratingColor(value), color: ratingTextColor(value) }}
+                                            title={observed ? `rated ${value}` : `predicted ${value.toFixed(1)}`}
+                                        >
+                                            {observed ? value : (isTopPick ? '★' : '')}
+                                        </div>
+                                    );
+                                })}
+                            </Fragment>
+                        ))}
+                    </div>
+                    <div className={styles.legend}>
+                        <span>bordered = rated</span>
+                        <span>plain = predicted</span>
+                        <span style={{ color: '#fbbf24' }}>★ top pick</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Epoch" value={String(metrics.epoch)} />
+                        <Metric label="RMSE" value={metrics.rmse.toFixed(2)} />
+                    </MetricsRow>
+
+                    <Card title={`Top picks · ${dataset.users[selectedUser]}`} subtitle="best untried items">
+                        {recommendations.length === 0 ? (
+                            <p className={styles.note}>This regular has tried everything on the menu.</p>
+                        ) : (
+                            <ul className={styles.pickList}>
+                                {recommendations.map(({ item, score }) => (
+                                    <li key={item} className={styles.pick}>
+                                        <span>{dataset.items[item]}</span>
+                                        <span className={styles.pickScore}>{score.toFixed(1)}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </Card>
+
+                    <Card title="Latent taste factors" subtitle="learned, not given">
+                        <p className={styles.note}>
+                            Press <strong>Train</strong> and watch the blanks fill in. Each person and each
+                            item gets a short vector of hidden factors; a prediction is how well a taste
+                            lines up with an item. With more <strong>factors</strong> the model captures
+                            finer taste — until, with too few ratings, it just memorises noise.
+                        </p>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/components/SupportVectorMachinePlayground.module.css
+++ b/site/src/components/SupportVectorMachinePlayground.module.css
@@ -1,0 +1,69 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.boundaryWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 1 / 1;
+}
+
+.boundary {
+    width: 100%;
+    height: 100%;
+}
+
+.legend {
+    position: absolute;
+    bottom: 10px;
+    left: 12px;
+    display: flex;
+    gap: 14px;
+    font-size: 12px;
+    background: rgba(11, 17, 32, 0.6);
+    padding: 4px 10px;
+    border-radius: 999px;
+    backdrop-filter: blur(4px);
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+.lossCanvas {
+    display: block;
+    width: 100%;
+    height: 150px;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/SupportVectorMachinePlayground.tsx
+++ b/site/src/components/SupportVectorMachinePlayground.tsx
@@ -1,0 +1,251 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { SupportVectorMachine, Matrix, type Kernel } from 'machine-learning';
+import type { Domain } from '../ml/datasets';
+import { SVM_DATASETS } from '../ml/svmDatasets';
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+import { fitCanvas } from '../viz/canvas';
+import { makeGrid, drawPoints, type Grid } from '../viz/decisionBoundary';
+import { paintMargins, drawSupportVectors } from '../viz/svm';
+import { drawLossCurve } from '../viz/lossCurve';
+import {
+    Card,
+    ControlPanel,
+    Hint,
+    Metric,
+    MetricsRow,
+    NumberField,
+    RunControls,
+    Select,
+    Slider,
+} from './controls/Controls';
+import styles from './SupportVectorMachinePlayground.module.css';
+
+const POINTS = 100;
+const GRID = 64;
+const SWEEPS_PER_FRAME = 1; // SMO sweeps per animation frame — the boundary tightens, then settles
+
+// C and gamma live on log sliders so the interesting range (fractions → tens) is easy to reach.
+const sliderToC = (slider: number) => Math.pow(10, -1 + 3 * (slider / 1000));
+const sliderToGamma = (slider: number) => Math.pow(10, -1 + 2 * (slider / 1000));
+
+interface TrainingData {
+    inputs: number[][];
+    targets: number[][];
+    inputMatrix: Matrix;
+}
+
+export function SupportVectorMachinePlayground() {
+    const [datasetId, setDatasetId] = useState(SVM_DATASETS[0].id);
+    const [kernel, setKernel] = useState<Kernel>('linear');
+    const [cSlider, setCSlider] = useState(700); // ≈ C = 12.6
+    const [gammaSlider, setGammaSlider] = useState(600); // ≈ gamma = 1.6
+    const [seed, setSeed] = useState(0);
+    const [running, setRunning] = useState(false);
+    const [metrics, setMetrics] = useState({ sweeps: 0, supportVectors: 0, acc: 0 });
+
+    const c = sliderToC(cSlider);
+    const gamma = sliderToGamma(gammaSlider);
+
+    const modelRef = useRef<SupportVectorMachine | null>(null);
+    const dataRef = useRef<TrainingData | null>(null);
+    const gridRef = useRef<Grid | null>(null);
+    const domainRef = useRef<Domain>(SVM_DATASETS[0].domain);
+    const lossRef = useRef<number[]>([]);
+    const sweepRef = useRef(0);
+    const offscreenRef = useRef<HTMLCanvasElement | null>(null);
+    const frameRef = useRef(0);
+
+    const boundaryCanvasRef = useRef<HTMLCanvasElement | null>(null);
+    const lossCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const drawAll = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        const grid = gridRef.current;
+        if (!model || !data || !grid) return;
+
+        const boundaryCanvas = boundaryCanvasRef.current;
+        if (boundaryCanvas) {
+            const { ctx, width, height } = fitCanvas(boundaryCanvas);
+            ctx.fillStyle = '#0b1120';
+            ctx.fillRect(0, 0, width, height);
+
+            const scores = model.predict(grid.matrix).toArray().map(row => row[0]);
+            if (!offscreenRef.current) offscreenRef.current = document.createElement('canvas');
+            paintMargins(offscreenRef.current, scores, grid.size);
+            ctx.imageSmoothingEnabled = true;
+            ctx.drawImage(offscreenRef.current, 0, 0, width, height);
+
+            const supportVectors = model.getSupportVectorIndices().map(i => data.inputs[i]);
+            drawSupportVectors(ctx, supportVectors, domainRef.current, width, height);
+            drawPoints(ctx, data.inputs, data.targets, domainRef.current, width, height);
+        }
+
+        const lossCanvas = lossCanvasRef.current;
+        if (lossCanvas) {
+            const { ctx, width, height } = fitCanvas(lossCanvas);
+            drawLossCurve(ctx, width, height, lossRef.current);
+        }
+    }, []);
+
+    const rebuild = useCallback(() => {
+        const dataset = SVM_DATASETS.find(d => d.id === datasetId) ?? SVM_DATASETS[0];
+        const { inputs, targets } = dataset.generate(seed, POINTS);
+
+        const model = new SupportVectorMachine()
+            .setKernel(kernel)
+            .setRegularization(c)
+            .setGamma(gamma)
+            .setSeed(seed)
+            .setNumberOfIterations(SWEEPS_PER_FRAME);
+
+        modelRef.current = model;
+        dataRef.current = { inputs, targets, inputMatrix: new Matrix(inputs) };
+        gridRef.current = makeGrid(dataset.domain, GRID);
+        domainRef.current = dataset.domain;
+        sweepRef.current = 0;
+        lossRef.current = [];
+
+        setMetrics({ sweeps: 0, supportVectors: 0, acc: 0 });
+        drawAll();
+    }, [datasetId, kernel, c, gamma, seed, drawAll]);
+
+    // Debounced so dragging C / gamma (each rebuilds the model) stays smooth.
+    useEffect(() => {
+        const timer = setTimeout(rebuild, 60);
+        return () => clearTimeout(timer);
+    }, [rebuild]);
+
+    const stats = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        if (!model || !data) return { hinge: 0, supportVectors: 0, acc: 0 };
+
+        const scores = model.predict(data.inputMatrix).toArray();
+        let correct = 0;
+        let hinge = 0;
+        for (let i = 0; i < scores.length; i++) {
+            const score = scores[i][0];
+            const label = data.targets[i][0] === 1 ? 1 : -1;
+            if ((score >= 0 ? 1 : 0) === data.targets[i][0]) correct++;
+            hinge += Math.max(0, 1 - label * score);
+        }
+        return {
+            hinge: hinge / scores.length,
+            supportVectors: model.getSupportVectorIndices().length,
+            acc: correct / scores.length,
+        };
+    }, []);
+
+    const step = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        if (!model || !data) return;
+
+        model.train(data.inputMatrix, new Matrix(data.targets));
+        sweepRef.current += SWEEPS_PER_FRAME;
+
+        const { hinge, supportVectors, acc } = stats();
+        lossRef.current.push(hinge);
+        if (lossRef.current.length > 1200) lossRef.current.shift();
+
+        drawAll();
+
+        frameRef.current += 1;
+        if (frameRef.current % 3 === 0) {
+            setMetrics({ sweeps: sweepRef.current, supportVectors, acc });
+        }
+    }, [drawAll, stats]);
+
+    useAnimationFrame(step, running);
+
+    const handleStep = () => {
+        if (!running) step();
+    };
+    const handleReset = () => {
+        setRunning(false);
+        rebuild();
+    };
+
+    const dataset = SVM_DATASETS.find(d => d.id === datasetId);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <RunControls
+                    running={running}
+                    onToggle={() => setRunning(r => !r)}
+                    onStep={handleStep}
+                    onReset={handleReset}
+                />
+                <Select
+                    label="Policy"
+                    value={datasetId}
+                    options={SVM_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={setDatasetId}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Select
+                    label="Kernel"
+                    value={kernel}
+                    options={[
+                        { value: 'linear', label: 'Linear (straight line)' },
+                        { value: 'rbf', label: 'RBF (curved)' },
+                    ]}
+                    onChange={value => setKernel(value as Kernel)}
+                />
+                <Slider
+                    label="C (margin softness)"
+                    value={cSlider}
+                    display={c < 1 ? c.toFixed(2) : c.toFixed(0)}
+                    min={0}
+                    max={1000}
+                    onChange={setCSlider}
+                />
+                {kernel === 'rbf' && (
+                    <Slider
+                        label="Gamma (reach)"
+                        value={gammaSlider}
+                        display={gamma.toFixed(2)}
+                        min={0}
+                        max={1000}
+                        onChange={setGammaSlider}
+                    />
+                )}
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.boundaryWrap}>
+                    <canvas ref={boundaryCanvasRef} className={styles.boundary} />
+                    <div className={styles.legend}>
+                        <span style={{ color: 'var(--accent)' }}>● no comp</span>
+                        <span style={{ color: 'var(--accent-2)' }}>● comp</span>
+                        <span style={{ color: '#f8fafc' }}>◯ support vector</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Sweeps" value={String(metrics.sweeps)} />
+                        <Metric label="Support vectors" value={String(metrics.supportVectors)} />
+                        <Metric label="Accuracy" value={`${(metrics.acc * 100).toFixed(0)}%`} />
+                    </MetricsRow>
+
+                    <Card title="The margin" subtitle="the widest empty street">
+                        <p className={styles.note}>
+                            The dark band between the colours is the <strong>margin</strong> — the empty
+                            street the SVM makes as wide as it can. Only the ringed{' '}
+                            <strong>support vectors</strong> touch its edges and pin it in place; every
+                            other point could be deleted and the boundary wouldn't move.
+                        </p>
+                    </Card>
+
+                    <Card title="Hinge loss" subtitle="penalty for points in the street">
+                        <canvas ref={lossCanvasRef} className={styles.lossCanvas} />
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/components/TimeSeriesPlayground.module.css
+++ b/site/src/components/TimeSeriesPlayground.module.css
@@ -1,0 +1,63 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(220px, 280px);
+    gap: 20px;
+    align-items: start;
+}
+
+.chartWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 16 / 10;
+}
+
+.chart {
+    width: 100%;
+    height: 100%;
+}
+
+.legend {
+    position: absolute;
+    bottom: 10px;
+    left: 12px;
+    display: flex;
+    gap: 14px;
+    font-size: 12px;
+    background: rgba(11, 17, 32, 0.6);
+    padding: 4px 10px;
+    border-radius: 999px;
+    backdrop-filter: blur(4px);
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/TimeSeriesPlayground.tsx
+++ b/site/src/components/TimeSeriesPlayground.tsx
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ExponentialSmoothing, Matrix } from 'machine-learning';
+import { TIME_SERIES_DATASETS } from '../ml/timeSeriesDatasets';
+import { fitCanvas } from '../viz/canvas';
+import { drawForecast } from '../viz/timeSeries';
+import { Card, Checkbox, ControlPanel, Hint, Metric, MetricsRow, Select, Slider } from './controls/Controls';
+import styles from './TimeSeriesPlayground.module.css';
+
+export function TimeSeriesPlayground() {
+    const [datasetId, setDatasetId] = useState(TIME_SERIES_DATASETS[0].id);
+    const [alphaSlider, setAlphaSlider] = useState(TIME_SERIES_DATASETS[0].alpha * 100);
+    const [betaSlider, setBetaSlider] = useState(TIME_SERIES_DATASETS[0].beta * 100);
+    const [gammaSlider, setGammaSlider] = useState(TIME_SERIES_DATASETS[0].gamma * 100);
+    const [weekly, setWeekly] = useState(true);
+    const [horizon, setHorizon] = useState(TIME_SERIES_DATASETS[0].horizon);
+    const [seed, setSeed] = useState(0);
+    const [mae, setMae] = useState(0);
+
+    const alpha = alphaSlider / 100;
+    const beta = betaSlider / 100;
+    const gamma = gammaSlider / 100;
+
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+    const historyRef = useRef<number[]>([]);
+    const fittedRef = useRef<number[]>([]);
+    const forecastRef = useRef<number[]>([]);
+
+    const draw = useCallback(() => {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        const { ctx, width, height } = fitCanvas(canvas);
+        ctx.fillStyle = '#0b1120';
+        ctx.fillRect(0, 0, width, height);
+        drawForecast(ctx, width, height, historyRef.current, fittedRef.current, forecastRef.current);
+    }, []);
+
+    const rebuild = useCallback(() => {
+        const dataset = TIME_SERIES_DATASETS.find(d => d.id === datasetId) ?? TIME_SERIES_DATASETS[0];
+        const { series } = dataset.generate(seed);
+
+        const model = new ExponentialSmoothing()
+            .setAlpha(alpha)
+            .setBeta(beta)
+            .setGamma(gamma)
+            .setSeasonLength(weekly ? dataset.seasonLength : 1);
+        model.train(new Matrix(series.map(v => [v])));
+
+        const fitted = model.getFitted().toArray().map(row => row[0]);
+        const forecast = model.predict(horizon).toArray().map(row => row[0]);
+
+        historyRef.current = series;
+        fittedRef.current = fitted;
+        forecastRef.current = forecast;
+
+        // In-sample mean absolute error, skipping the first season (warm-up).
+        const warmup = weekly ? dataset.seasonLength : 1;
+        let sum = 0;
+        let count = 0;
+        for (let i = warmup; i < series.length; i++) {
+            sum += Math.abs(fitted[i] - series[i]);
+            count++;
+        }
+        setMae(count > 0 ? sum / count : 0);
+        draw();
+    }, [datasetId, alpha, beta, gamma, weekly, horizon, seed, draw]);
+
+    // Debounced so dragging the smoothing sliders (each re-fits + redraws) stays smooth.
+    useEffect(() => {
+        const timer = setTimeout(rebuild, 60);
+        return () => clearTimeout(timer);
+    }, [rebuild]);
+
+    const handleDataset = (id: string) => {
+        const next = TIME_SERIES_DATASETS.find(d => d.id === id);
+        if (!next) return;
+        setDatasetId(next.id);
+        setAlphaSlider(next.alpha * 100);
+        setBetaSlider(next.beta * 100);
+        setGammaSlider(next.gamma * 100);
+        setHorizon(next.horizon);
+    };
+
+    const dataset = TIME_SERIES_DATASETS.find(d => d.id === datasetId);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <Select
+                    label="Daily demand"
+                    value={datasetId}
+                    options={TIME_SERIES_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={handleDataset}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Slider label="α · level" value={alphaSlider} display={alpha.toFixed(2)} min={1} max={100} onChange={setAlphaSlider} />
+                <Slider label="β · trend" value={betaSlider} display={beta.toFixed(2)} min={0} max={100} onChange={setBetaSlider} />
+                {weekly && <Slider label="γ · season" value={gammaSlider} display={gamma.toFixed(2)} min={0} max={100} onChange={setGammaSlider} />}
+                <Checkbox label="Weekly season (period 7)" checked={weekly} onChange={setWeekly} />
+                <Slider label="Forecast days" value={horizon} display={`${horizon} days`} min={3} max={28} onChange={setHorizon} />
+                <Hint>α weights recent days; β follows the trend; γ learns the weekly shape.</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.chartWrap}>
+                    <canvas ref={canvasRef} className={styles.chart} />
+                    <div className={styles.legend}>
+                        <span style={{ color: '#38bdf8' }}>▬ actual</span>
+                        <span style={{ color: '#fb923c' }}>▬ forecast</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Fit error (MAE)" value={mae.toFixed(1)} />
+                        <Metric label="Forecast" value={`${horizon} days`} />
+                    </MetricsRow>
+
+                    <Card title="Level, trend, season" subtitle="three running estimates">
+                        <p className={styles.note}>
+                            Smoothing keeps a running <strong>level</strong> (where demand is now), a{' '}
+                            <strong>trend</strong> (which way it's drifting), and a <strong>seasonal</strong>{' '}
+                            offset for each weekday. The forecast is just level + trend + the matching day's
+                            season — extended past the dashed "now" line.
+                        </p>
+                    </Card>
+
+                    <Card title="Turn off the season" subtitle="why order matters">
+                        <p className={styles.note}>
+                            Untick the weekly season and the forecast flattens into a trend line — it can no
+                            longer tell a Saturday from a Tuesday. That's the structure plain regression
+                            misses when it ignores the order of the days.
+                        </p>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/content/anomaly-detection.mdx
+++ b/site/src/content/anomaly-detection.mdx
@@ -1,0 +1,102 @@
+import { AnomalyDetectionPlayground } from '../components/AnomalyDetectionPlayground';
+
+# Chapter 16 — What doesn't fit
+
+> *Anomaly detection.* Nadia can't show a model examples of fraud — she barely has any, and tomorrow's
+> won't look like today's. So she models the one thing she has plenty of: normal.
+
+A few transactions in the books look *off* — a charge at 3am two towns over, a sudden order ten times
+the usual size. Nadia wants to catch them, but she's stuck. She can't train a classifier: fraud is
+rare, unlabelled, and shape-shifting — there's no tidy column of "this one was fraud" and no reason
+next month's scam resembles last month's. Every method in the ledger so far wanted either labels or
+groups. She has neither.
+
+## The wall: you can't learn a class you've barely seen
+
+A classifier needs examples of *both* sides, and clustering insists every point join some group. Both
+quietly assume the thing you're hunting is common enough to characterise. Fraud isn't. What Nadia
+*does* have is thousands of ordinary transactions — a dense, well-behaved crowd. The signal isn't in
+the rare events themselves; it's in how far they sit from everything ordinary.
+
+## The idea: model normal, flag the tails
+
+So she flips the problem. Don't model fraud — model **normal**, and flag whatever doesn't fit. Fit a
+single bell curve to the everyday transactions: a centre (the mean) and a spread (the covariance).
+Now score each transaction by how far out in the tails it lands; the ones past a cutoff are the
+anomalies.
+
+"Far" needs care, though. A transaction can be far from the centre in raw distance yet perfectly
+ordinary — if it sits along the direction the data naturally varies. So she measures distance in
+*standard deviations, in the data's own shape* — the **Mahalanobis distance**. Two steps along the
+grain is normal; two steps across it is alarming. Drag the **threshold** and watch the normal region
+(blue) tighten and more transactions flip to flagged (red):
+
+<div className="breakout">
+  <AnomalyDetectionPlayground />
+</div>
+
+## How it works: a bell curve and a warped ruler
+
+Training is just two summary statistics: the mean, and the covariance (with a hair of regularisation
+so it's always invertible), straight from the
+[`AnomalyDetector`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/unsupervised/AnomalyDetector.ts)
+source:
+
+```ts
+const covariance = covarianceMatrix(centered, d);
+for (let i = 0; i < d; i++) covariance[i][i] += 1e-6; // ridge: keep it invertible
+this.inverseCovariance = new Matrix(covariance).getInverse().toArray();
+```
+
+The inverse covariance is the "warped ruler." A point's score is its **Mahalanobis distance** —
+Euclidean distance bent by `Σ⁻¹` so it counts standard deviations rather than raw units:
+
+$$
+d_M(\mathbf{x}) = \sqrt{(\mathbf{x} - \boldsymbol{\mu})^{\top}\, \Sigma^{-1}\, (\mathbf{x} - \boldsymbol{\mu})}
+$$
+
+```ts
+// squared distance = diffᵀ · Σ⁻¹ · diff
+let squared = 0;
+for (let i = 0; i < difference.length; i++) {
+    let inner = 0;
+    for (let j = 0; j < difference.length; j++) inner += inverse[i][j] * difference[j];
+    squared += difference[i] * inner;
+}
+return Math.sqrt(Math.max(0, squared));
+```
+
+Anything past the threshold is flagged. That's the whole model: `score(x) > threshold ? anomaly : normal`.
+
+## Try it yourself
+
+- **Everyday transactions** — a round crowd of normal charges. The detector learns the blob; the
+  scattered wild ones light up red. Drop the threshold and the blue region shrinks until even
+  ordinary transactions start tripping it — that's the price of being too sensitive.
+- **Tilted normal** — spend and frequency rise together, so "normal" is a tilted ellipse. Find the
+  pair of points the same distance from the centre, one **along** the diagonal and one **across** it:
+  only the across-the-grain point gets flagged. That's Mahalanobis distance earning its keep — plain
+  Euclidean distance would wrongly flag both or neither.
+- **Two habits** — two separate crowds. One Gaussian has to span both, so its centre lands in the
+  empty gap between them and the "normal" ellipse bulges over territory where nobody actually shops.
+  Watch it miss the point.
+
+> **Field note — the threshold is a business call.** It's the precision/recall dial again. A missed
+> fraud (false negative) costs Nadia real money; a flagged-but-fine transaction (false positive)
+> annoys a good customer and wastes a review. Where she sets the cutoff depends entirely on which
+> mistake hurts more — and it rests on the assumption that her training data really was *mostly* normal.
+
+## What broke
+
+Modelling normal turned an impossible problem — *learn a class you've barely seen* — into an easy
+one, and Mahalanobis distance made it honour the real shape of ordinary. For a single, roughly-Gaussian
+crowd, it's hard to beat.
+
+But the **Two habits** dataset exposed the catch: real "normal" often has several modes, and one bell
+curve can't straddle them without inventing a normal region in the empty space between. (Fitting a
+*mixture* of Gaussians is the natural fix.) And there's a blind spot the playground can't show:
+the detector scores each transaction **in isolation**. It would never notice that two perfectly
+ordinary purchases are suspicious *together* — a coffee here and a big-ticket order across town
+minutes later. To catch that, Nadia needs to stop looking at points in space and start looking at
+what tends to happen *together*: which items share a basket, which events co-occur. That's a
+different question entirely.

--- a/site/src/content/association-rules.mdx
+++ b/site/src/content/association-rules.mdx
@@ -1,0 +1,107 @@
+import { AssociationRulesPlayground } from '../components/AssociationRulesPlayground';
+
+# Chapter 17 — What goes with what
+
+> *Association rules.* Every model so far read a row as a point with fixed features. A receipt isn't
+> a point — it's a basket of items. Nadia wants the patterns hiding in the baskets.
+
+Nadia has a year of receipts and a hunch she's leaving money on the counter. Which items sell
+*together*? If everyone who buys a croissant also buys a coffee, she can bundle them, reposition the
+pastry case, or train the till to suggest the pairing. The anomaly detector from last chapter looked
+at each transaction in isolation; this question is the opposite — it lives entirely in the
+**combinations**.
+
+## The wall: a receipt isn't a point in space
+
+Here every tool in the ledger stalls. Regression, clustering, the Gaussian detector — all of them
+need a row to be a point with the same fixed coordinates. A receipt is a *set*: three items today,
+one tomorrow, in any order, drawn from a menu of dozens. There's no x and y to measure, no distance
+to take. And the obvious approach — "just count which pairs show up together" — drowns instantly:
+coffee is on half the receipts, so it co-occurs with *everything*, and the genuinely interesting
+combos hide under a pile of coincidences.
+
+## The idea: support, then confidence, then lift
+
+So Nadia counts, but carefully, with three questions. First, **how often** does a combo actually
+appear? — its **support**. Keep only the combos common enough to matter. Then, of the receipts that
+have the first item, **how reliably** do they also have the second? — the **confidence**. And
+finally the catch that saves her from the coffee trap: is the pairing **more than chance**? — the
+**lift**, which divides the confidence by how popular the consequent is on its own.
+
+$$
+\text{support}(X) = \frac{\#\{\text{baskets} \supseteq X\}}{N}, \quad
+\text{conf}(A\!\to\!B) = \frac{\text{support}(A \cup B)}{\text{support}(A)}, \quad
+\text{lift} = \frac{\text{conf}(A\!\to\!B)}{\text{support}(B)}
+$$
+
+A lift above 1 means the two appear together *more* than their popularity alone would predict — a
+real pairing. Below 1 they actually repel. Below, items ring the circle and each arrow is a
+rule, thicker and brighter for higher lift. Drag the **support** and **confidence** bars and watch
+the coincidences burn away:
+
+<div className="breakout">
+  <AssociationRulesPlayground />
+</div>
+
+## How it works: the Apriori shortcut
+
+Counting *every* possible combo would explode — a menu of 30 items has over a billion subsets. The
+**Apriori** algorithm dodges that with one observation: *a combo can't be frequent unless every one
+of its sub-combos is frequent too.* So it builds frequent sets level by level — singles, then pairs
+grown only from frequent singles, then triples grown only from frequent pairs — never even
+considering a set built on a rare one. Straight from the
+[`AssociationRules`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/unsupervised/AssociationRules.ts)
+source:
+
+```ts
+for (let k = 2; k <= this.maxItemsetSize && current.length > 0; k++) {
+    const candidates = generateCandidates(current, frequentSingles); // grow each frequent set by one item
+    const next = [];
+    for (const candidate of candidates) {
+        let count = 0;
+        for (const basket of baskets) if (candidate.every(item => basket.has(item))) count++;
+        if (count >= minCount) { next.push(candidate); this.record(candidate, count / n); }
+    }
+    current = next; // only frequent sets seed the next, bigger level
+}
+```
+
+Then every frequent set is split into candidate rules, and the ones that clear the confidence bar
+are kept, scored by lift:
+
+```ts
+const confidence = itemset.support / this.support(antecedent);
+if (confidence >= this.minConfidence) {
+    const lift = confidence / this.support(consequent);
+    this.rules.push({ antecedent, consequent, support: itemset.support, confidence, lift });
+}
+```
+
+## Try it yourself
+
+- **Café receipts** — the planted combos light up as the boldest arrows: espresso↔croissant,
+  latte↔muffin, tea↔cookie. The web *is* the menu's hidden structure.
+- **Busy menu** — noisier, with overlapping habits. At a low support bar you get a tangle of weak,
+  probably-coincidental rules; raise support and confidence and the web thins down to the few
+  pairings actually worth acting on.
+- Watch the difference between **confidence** and **lift**. A rule into a very popular item can show
+  high confidence and still have lift near 1 — reliable, but no real pull. The thick arrows are the
+  ones with high *lift*: genuine affinities, not just popularity.
+
+> **Field note — don't be fooled by confidence alone.** "Anything → coffee" looks confident simply
+> because almost everyone buys coffee. Lift is the honest measure: it asks whether knowing about A
+> actually changes how likely B is. A bundle is only worth building when the lift says the two truly
+> travel together.
+
+## What broke
+
+Association rules turned a shoebox of receipts into a map of what-goes-with-what, and lift kept Nadia
+honest about which pairings are real. For arranging the counter and bundling the menu, it's exactly
+the right lens.
+
+But it's a portrait of the *average* customer, and that's its ceiling. Every rule is the same advice
+for everyone — "had a croissant? here's a coffee" — when her actual regulars are gloriously
+specific: the one who pairs tea with a bagel, the late-night cookie-and-espresso crowd. Those
+personal patterns never clear the support bar; they get averaged into the crowd and lost. To suggest
+the *right* thing to *each* person — to fill in what a particular customer would love but hasn't
+tried — Nadia needs to stop mining the crowd and start learning individual taste.

--- a/site/src/content/dbscan.mdx
+++ b/site/src/content/dbscan.mdx
@@ -1,0 +1,104 @@
+import { DBSCANPlayground } from '../components/DBSCANPlayground';
+
+# Chapter 14 — The stragglers
+
+> *DBSCAN.* Every grouping Nadia has built insists that everyone belongs somewhere. Some customers
+> simply don't — and those are the ones she most needs to see.
+
+A run of odd late-night card transactions shows up in the books — a clutch of charges that don't
+look like anyone's normal habits. Nadia tries to spot them by clustering, and every method buries
+them: k-means folds each oddball into whatever group is nearest; hierarchical chains them onto the
+edge of a real crowd. The very points she wants to flag — possible fraud, mistakes, one-off tourists
+— get camouflaged inside legitimate groups. She doesn't just want the groups. She wants what's
+*left over*.
+
+## The wall: every point gets a home, like it or not
+
+That's the shared blind spot of everything in Part 3 so far. k-means assigns all `m` points to some
+centroid; hierarchical clustering puts every leaf in the tree. Neither has a category for *"this
+one belongs to no group."* So a stray transaction doesn't get flagged — it gets absorbed, and quietly
+drags a centroid or a cluster boundary off true while it's at it. And on the **ring** of regulars
+sharing a centre, centroid distance is hopeless anyway.
+
+## The idea: let density draw the lines
+
+Nadia stops measuring distance to a centre and starts asking a local question: *is this customer in
+a crowd?* Pick a radius **epsilon** and a count **min points**. A point sitting in a dense pile —
+at least `minPoints` others within `epsilon` — is a **core** point:
+
+$$
+\big|\,\{\,q : \operatorname{dist}(p, q) \le \varepsilon\,\}\,\big| \ \ge\ \text{minPoints}
+\quad\Rightarrow\quad p \text{ is core.}
+$$
+
+Clusters then grow by **contagion**: start at a core point and sweep outward, and every time the
+sweep lands on *another* core point, its neighbours join the frontier too. A cluster becomes any
+blob, curve, or ring that stays dense the whole way through. Points the sweep can reach but that
+aren't themselves core are **border** points; points no sweep ever reaches are **noise** — and they
+stay noise, flagged, never forced into a group. Crucially, there's no `k`: the number of clusters is
+whatever the density leaves behind. Drag **epsilon** and watch groups and noise appear:
+
+<div className="breakout">
+  <DBSCANPlayground />
+</div>
+
+## How it works: core, reach, repeat
+
+The training loop walks each point, and when it finds an unclaimed core point it flood-fills a whole
+cluster out of it — pulling in more neighbours every time it crosses another core point. Straight
+from the
+[`DBSCAN`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/unsupervised/DBSCAN.ts)
+source:
+
+```ts
+const seeds = [...neighbours[p]];          // p is core → seed the cluster with its neighbourhood
+for (let s = 0; s < seeds.length; s++) {
+    const q = seeds[s];
+    if (this.labels[q] !== UNCLASSIFIED) continue;
+    this.labels[q] = clusterId;            // q is reachable → it joins the cluster
+    if (isCore[q]) {                       // …and if q is *also* dense, its neighbours join the hunt
+        for (const r of neighbours[q]) if (!queued.has(r)) { queued.add(r); seeds.push(r); }
+    }
+}
+```
+
+Whether a point is core is just a neighbour count against `minPoints`:
+
+```ts
+isCore.push(neighbours[i].length >= this.minPoints);
+```
+
+Anything still unclaimed when the dust settles is labelled noise. `predict` returns one integer per
+point — a cluster index, or `-1` for noise — so a straggler is reported as a straggler, not quietly
+shoved into the nearest group.
+
+## Try it yourself
+
+- **Regulars & oddballs** — two solid crowds dusted with one-off visitors. DBSCAN keeps the crowds
+  and marks the strays with a grey ✕. That's the late-night anomaly Nadia was hunting, finally
+  *separated* instead of absorbed.
+- **A ring of regulars** — a tight core inside a ring, sharing one centre. k-means can't split them;
+  DBSCAN sees two distinct dense regions and doesn't care that they're concentric.
+- **Blended habits** — the two crescents come out as two clean groups, no `k` and no linkage choice.
+- Now sweep **epsilon**. Too small and the crowds shatter into noise; too large and everything melts
+  into one blob that swallows the oddballs again. The good clustering lives in the middle — and
+  finding that middle is the whole art.
+
+> **Field note — epsilon is the hard part.** There's no `k` to set, but `epsilon` and `minPoints`
+> trade off in its place. A common recipe: sort every point's distance to its k-th nearest neighbour,
+> plot them, and look for the "elbow" — the distance where the curve kicks up is a good `epsilon`.
+> And `minPoints` is roughly "how big a pile counts as a crowd."
+
+## What broke
+
+DBSCAN gave Nadia the thing every earlier method refused: a clustering that finds dense groups of
+*any shape*, picks its own number of them, and hands back the leftovers as **noise** instead of
+hiding them. For separating regulars from oddballs, it's exactly right.
+
+But it leans on a single global `epsilon`, and that quietly assumes every group is **equally dense**.
+The instant her data has a tight knot of devotees next to a loose scatter of occasional visitors, no
+one `epsilon` fits both — tighten it and the loose group dissolves into noise; loosen it and the
+tight ones merge. And there's a deeper storm coming: Nadia's new taste survey rates each customer on
+**thirty** questions. In thirty dimensions, "distance" barely means anything — every point ends up
+roughly equidistant from every other — and she can't even *look* at the data to check. Before she can
+cluster that, she needs a way to squeeze thirty numbers down to two she can actually see.

--- a/site/src/content/hierarchical-clustering.mdx
+++ b/site/src/content/hierarchical-clustering.mdx
@@ -1,0 +1,108 @@
+import { HierarchicalClusteringPlayground } from '../components/HierarchicalClusteringPlayground';
+
+# Chapter 13 — A family tree of regulars
+
+> *Hierarchical clustering.* k-means made Nadia guess how many groups there were. What if she
+> didn't have to decide that until she'd seen the whole shape of her crowd?
+
+The segments from last chapter were useful — until Bea looked at them. *"Your 'morning regulars'
+aren't one thing,"* she says. *"There's the espresso-and-run lot and the sit-with-a-drip lot. And
+honestly those two are closer to each other than either is to the weekend crowd."* She's describing
+**types within types** — a hierarchy. And Nadia realises she never actually knew the right number of
+groups; she just typed `5` into k-means and took what it gave her.
+
+## The wall: k-means makes you commit, blindly
+
+k-means has to be told `k` before it knows anything, and the answer lurches as you change it: run it
+at 4 and at 6 and you don't get the 4-group answer with one group split — you get two *unrelated*
+groupings. Nothing tells Nadia which `k` is right, and nothing reveals that her big "morning" blob is
+really two. It hands back a flat list of groups and hides everything about how they relate.
+
+## The idea: build the tree first, choose the number later
+
+So Nadia turns it upside down. Don't start from `k` groups — start from **every customer in their
+own group**, then repeatedly fuse the **two closest groups** into one. Two espresso regulars merge
+first. Their little group later merges with the drip regulars into "morning." "Morning" eventually
+merges with "weekend" near the very top. Keep going until everyone is in one big group.
+
+The record of *what merged when* is a tree — a **dendrogram**. And here's the trick: she never has
+to pick a number in advance. She builds the whole tree once, then **slices it at a height** —
+slice low for many small groups, high for a few big ones. Drag the **k** slider and watch the cut
+line slide up and down the tree:
+
+<div className="breakout">
+  <HierarchicalClusteringPlayground />
+</div>
+
+## How it works: merge the closest, over and over
+
+The training loop is exactly that sentence — find the closest pair of clusters, merge them, repeat —
+straight from the
+[`HierarchicalClustering`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/unsupervised/HierarchicalClustering.ts)
+source:
+
+```ts
+while (active.size > 1) {
+    const [a, b, distance] = this.closestPair(active, distances);   // the two nearest groups
+    this.merges.push({ left: a, right: b, distance, /* … */ });     // record the join (a tree node)
+
+    // The merged group's distance to everyone else is a quick combination of the two old
+    // distances (Lance–Williams) — no need to revisit the raw customers.
+    for (const c of active) {
+        newDistances.set(c, this.linkageDistance(dist(a, c), dist(b, c), sizeA, sizeB));
+    }
+    // …retire a and b, add the merged group, continue.
+}
+```
+
+The one real choice is what *"closest"* means between two **groups** of points. That's the
+**linkage**, and it's the whole switch:
+
+```ts
+case 'single':   return Math.min(distanceAC, distanceBC);              // nearest pair of members
+case 'complete': return Math.max(distanceAC, distanceBC);              // farthest pair of members
+case 'average':  return (sizeA * distanceAC + sizeB * distanceBC) / (sizeA + sizeB); // mean pair
+```
+
+- **Single** links groups by their *closest* two members, so a chain of nearby points pulls a whole
+  group along — it can follow a curve, but a single stepping-stone customer can bridge two real
+  groups into one.
+- **Complete** links by the *farthest* pair, which keeps clusters tight and round.
+- **Average** sits in between.
+
+To read off `k` groups, you don't re-run anything — you cut the finished tree. The library replays
+just the first `n − k` merges with a union-find; whatever's still joined is a cluster. That's why
+moving the slider is instant: the tree is already built.
+
+## Try it yourself
+
+- **Three types** — the dendrogram has a tall empty stretch right before the final merges. That gap
+  *is* the signal: cut across it (k = 3) and you land exactly on the three real groups.
+- **Blended habits** — with **complete** linkage the two crescents get chopped straight across.
+  Switch to **single** and it threads along each curve like a string of beads — the round-blob
+  limit that beat k-means, beaten.
+- **A slow drift** — two crowds joined by a thin trickle of in-between regulars. **Complete** keeps
+  them as two; **single** *chains* right across the bridge and calls it one. Same data, and linkage
+  alone flips the answer — a real hazard to know about.
+
+> **Field note — read the gaps, not the leaves.** The natural number of clusters is written in the
+> dendrogram's **heights**: a big vertical jump before a merge means two groups that were far apart
+> got fused. Cut across the tallest such gap and you usually get the most honest grouping — a far
+> better guide than guessing `k` blind.
+
+## What broke
+
+Hierarchical clustering gave Nadia two things k-means couldn't: she no longer has to **guess the
+number** of groups up front, and with single linkage her groups no longer have to be **round**. The
+dendrogram even shows her the types-within-types Bea pointed out.
+
+But it has its own cracks. Building the tree compares every customer with every other, so it crawls
+once her list grows into the thousands. Single linkage's chaining means one stray regular can fuse
+two real crowds. And — the deeper problem — it still insists that **every customer belongs to some
+group**. The odd late-night visitor, the one-off tourist, the data glitch: hierarchical clustering
+sweeps each of them into whichever cluster happens to be nearest, the same way k-means did. Nadia
+still can't point at a thin scattering of oddballs and say *"those aren't a group — those are just
+noise, and that knot over there is the real cluster."*
+
+To do that, she'll need to stop thinking about distance to a centre or a neighbour, and start
+thinking about **density** — where customers pile up thickly, and where they're just stragglers.

--- a/site/src/content/k-means.mdx
+++ b/site/src/content/k-means.mdx
@@ -1,26 +1,51 @@
 import { KMeansPlayground } from '../components/KMeansPlayground';
 
-# k-Means Clustering
+# Chapter 12 — Who are my regulars?
 
-Every other model on this site is **supervised** — it learns from inputs paired with the right
-answers. k-means is different: it's **unsupervised**. You hand it a pile of points with _no
-labels_ and it discovers the groups on its own. Below is the real
-[`KMeans`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/unsupervised/KMeans.ts)
-clustering live — press **Train** and watch the centroids slide into place.
+> *k-Means clustering.* For the first time, Nadia faces a question with no answer key — and meets a
+> model that learns without one.
+
+Tomás leans on the counter with his order pad. *"Who even are your regulars? Group them so I know
+what to stock."* Nadia pulls up her customer list — months of it, every visitor a couple of numbers
+she can actually measure: roughly **how often they come in**, and **how much they spend** when they
+do. She can see, squinting, that they're not all the same. There are knots of similar people in
+there. She just can't name them.
+
+## The wall: there's no answer key
+
+She reaches for the ledger and stops cold. *Every* tool on those pages — the regression line, the
+trees, the forest, last chapter's beautiful margin — learned from an **answer key**: orders already
+marked comp or no-comp, batches already labelled rose or flopped. You showed the model the right
+answers and it learned to copy them.
+
+Here there are no right answers. Nobody has ever sorted her customers into groups. There's no column
+that says which type anyone is — the types don't even exist yet. They're *hiding* in the data,
+waiting to be found. Every model she owns needs to be **told** the answer, and there's no one to
+tell it.
+
+## The idea: let the groups find themselves
+
+So Nadia stops trying to predict a label and starts trying to **discover** one. Her reasoning is
+almost physical. Say there are `k` groups. Drop `k` pins onto the chart at random. Now repeat two
+moves until they stop moving:
+
+1. **Assign** — colour every customer by whichever pin is nearest.
+2. **Move** — slide each pin to the dead centre of the customers that just chose it.
+
+Move the pins and the nearest-customer colouring shifts; recolour and the centres want to move
+again. Round after round the pins drift until they settle into the middle of real knots of people.
+That's it — that's **k-means**, and the two-step dance is **Lloyd's algorithm**. Press **Train** and
+watch the segment centres migrate into place:
 
 <div className="breakout">
   <KMeansPlayground />
 </div>
 
-## Lloyd's algorithm
+## How it works: assign, move, repeat
 
-k-means starts by scattering `k` **centroids** onto random data points, then repeats two steps
-until nothing changes:
-
-1. **Assign** every point to its nearest centroid — those are the coloured regions.
-2. **Move** every centroid to the mean of the points now assigned to it.
-
-That's the whole training loop, straight from the source:
+The whole training loop is those two steps in a `while`-until-nothing-changes, straight from the
+[`KMeans`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/unsupervised/KMeans.ts)
+source:
 
 ```ts
 for (let iteration = 0; iteration < this.numberOfIterations; iteration++) {
@@ -34,35 +59,54 @@ for (let iteration = 0; iteration < this.numberOfIterations; iteration++) {
 }
 ```
 
-Because each round can only ever lower the total distance from points to their centroids, the
-**inertia** curve on the right falls monotonically and then flattens — that flat line is
-convergence.
-
-## No targets, just inputs
-
-Look at the signature: `train(inputs)` takes a single matrix. There is no `targets` argument
-anywhere, which is what makes this unsupervised. `predict` then hands back **one-hot membership**
-— a `1` in the column of each point's cluster:
+The tell-tale sign that this is a different *kind* of model is the signature: `train(inputs)` takes
+a single matrix. There is **no `targets` argument anywhere** — that's what "unsupervised" means.
+Afterwards `predict` hands back **one-hot membership**: a `1` in the column of each customer's group.
 
 ```ts
-kmeans.train(new Matrix([[0, 0], [0, 1], [10, 10], [10, 11]]));
-kmeans.predict(new Matrix([[0, 0], [10, 10]])); // e.g. [[1, 0], [0, 1]]
-kmeans.getCentroids();                          // the cluster centres themselves
+kmeans.train(new Matrix(customers));   // no labels — just the customers
+kmeans.predict(new Matrix(customers)); // e.g. [[0, 1, 0], [1, 0, 0], …] — each row's group
+kmeans.getCentroids();                 // the group centres: Nadia's customer "types"
 ```
 
-## Where it shines, and where it doesn't
+What's it actually minimising? The **inertia** — the total squared distance from every customer to
+the centre of their group:
 
-On the **blobs** datasets, k-means is near-perfect once `k` matches the number of real clusters.
-But it always carves the plane into straight-edged Voronoi cells around round centres, so:
+$$
+J = \sum_{i=1}^{m} \big\lVert\, \mathbf{x}_i - \boldsymbol{\mu}_{c(i)} \,\big\rVert^{2}
+$$
 
-- On **uniform scatter** there's no real structure — it still tiles the plane into `k` arbitrary cells.
-- On **two moons** the round-cluster assumption breaks: it slices each crescent in half instead of
-  following the curve.
+Each assign-step can only move a point to a *nearer* centre, and each move-step sits each centre
+where it's closest to its points, so neither step can ever raise `J`. That's why the **Inertia**
+curve on the right falls and then flattens — and that flat line is convergence.
 
-The starting centroids are random, so the **seed** matters: a bad initialisation can settle into a
-worse grouping. Nudge the seed slider and watch the final clusters — and the converged inertia —
-change.
+## Try it yourself
 
-> For clusters that curve, or labels you actually have, reach for a non-linear
-> [neural network](/machine-learning/neural-network) or the local voting of
-> [k-nearest neighbours](/machine-learning/nearest-neighbors).
+- **Three types** / **Five types** — set `k` to match and the centres slide straight into the knots
+  of customers. Now Nadia has names to give Tomás: the grab-and-go crowd, the weekend treaters, the
+  daily regulars.
+- **Festival day** — a street-fair crowd of one-offs with no real groups. k-means *still* hands back
+  `k` tidy-looking segments. A reminder: it will always find groups, whether or not any exist.
+- **Blended habits** — two habits that curl into each other. k-means assumes round, blobby groups,
+  so it slices the crescents straight across instead of following the curve. A real miss — hold onto
+  it.
+- Nudge the **seed** on any dataset. Because the pins start on random customers, a bad start can
+  settle into a visibly worse grouping — same data, different answer.
+
+> **Field note — how do you choose k?** You can't just pick the k with the lowest inertia: more
+> groups *always* lower it (at `k = m`, every customer is its own group and inertia hits zero).
+> Instead, plot inertia as you raise k and look for the **elbow** — the point where adding another
+> group stops buying much. That kink is usually the number of groups the data actually has.
+
+## What broke
+
+k-means gave Nadia her segments, and it did it with no answer key at all — the first model in the
+ledger to learn from raw data alone. But it leans on assumptions she can already feel straining.
+She had to **tell it `k`** before it knew anything; it only finds **round, similar-sized** groups,
+so the blended habits defeated it; and a single unlucky **starting seed** can land it in the wrong
+grouping entirely.
+
+Real customers won't always clump into neat circles. Some groups curve. Some are tiny and tucked
+inside a bigger one. Some are just a thin rim of stragglers around the edge — the odd late-night
+crowd she'd love to recognise. To find shapes like those, Nadia's going to need a way to grow groups
+that don't have to be round, and that don't make her guess their number in advance.

--- a/site/src/content/neural-network.mdx
+++ b/site/src/content/neural-network.mdx
@@ -1,151 +1,141 @@
 import { NeuralNetworkPlayground } from '../components/NeuralNetworkPlayground';
 
-# Neural Networks, from scratch
+# Chapter 20 — When the answer is a combination
 
-A neural network is a stack of simple parts that, together, can learn shapes a straight line
-never could. Below is a real one — the [`FeedforwardNeuralNetwork`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/supervised/FeedforwardNeuralNetwork.ts)
-from this library, training **live in your browser**. Press **Train** and watch the decision
-boundary bend itself around the data while the weights pulse and the loss falls.
+> *Neural networks.* Priya's interlude left Nadia with one neuron stuck forever on XOR. Then she
+> hits a café problem shaped exactly like it — and finally builds the brain.
+
+Nadia is designing pairings for the new menu — a coffee matched with a pastry — and testing which
+ones regulars actually love. Poring over the scores, she spots something her old tools can't touch:
+delight isn't *"stronger is better."* It's about the **match**. A bold, dark roast sings next to a
+rich, buttery pastry; a delicate cup wants a light, airy one. But cross them — bold coffee with a
+wispy pastry, or a mild cup beside something heavy — and it flops. Two dials, and the verdict flips
+on their **combination**.
+
+## The wall: neither cue means anything alone
+
+Every model in the ledger draws its verdict from "more of this, less of that." Here that's useless.
+Is a bold coffee good? *It depends entirely on the pastry.* Knowing one dial tells you nothing about
+the outcome without the other. Plotted out — strength on one axis, richness on the other — the hits
+sit in opposite corners (bold-bold and mild-mild) and the flops in the other two. That's **XNOR**,
+the exact shape the perceptron lurched on forever in the interlude. No single straight line can keep
+"both-or-neither" on one side. One neuron is one line, and one line cannot do this.
+
+## The idea: a layer to ask, a layer to combine
+
+So Nadia stops trying to draw the answer in one stroke and **stacks** neurons. The first layer is a
+row of simple neurons, each free to learn its own little question — *"is the coffee bold?"*, *"is the
+pastry rich?"* — each still just a straight line. Then a second layer takes **those answers as its
+inputs** and combines them into the final call. "Both bold-ish" and "both mild-ish" are easy to
+express once the first layer has carved the raw dials into intermediate features. The hidden neurons
+invent the features; the output neuron composes them. Stack enough and the boundary can bend into any
+shape at all. Press **Train** and watch it wrap itself around the data:
 
 <div className="breakout">
   <NeuralNetworkPlayground />
 </div>
 
-Everything below explains exactly what you just watched — and points at the lines of code that
-make it happen.
+## How it works: a stack of simple parts
 
-## The idea
-
-We have points on a plane, each belonging to class **0** or class **1**, and we want a function
-that takes a point $(x_1, x_2)$ and returns how likely it is to be class 1. A single straight
-line can only split the plane in two. The XNOR and spiral datasets above can't be split that way
-— so we stack several simple "neurons" into layers and let them bend the boundary.
-
-The network is just a list of layer sizes. `[2, 8, 1]` means two inputs, one hidden layer of
-eight neurons, and one output:
+The network is just a list of layer sizes. `[2, 8, 1]` is two inputs (the dials), one hidden layer of
+eight neurons, and one output (delight, 0–1) — the real
+[`FeedforwardNeuralNetwork`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/supervised/FeedforwardNeuralNetwork.ts)
+from this library:
 
 ```ts
 const net = new FeedforwardNeuralNetwork([2, 8, 1], /* seed */ 0);
 net.setLearningRate(1);
 net.train(inputs, targets); // inputs: N×2, targets: N×1
-net.predict(inputs);        // N×1, each in (0, 1)
+net.predict(inputs);        // N×1, each in (0, 1) — "how likely to delight"
 ```
 
-## A single neuron
-
-One neuron takes its inputs, multiplies each by a **weight**, adds a **bias**, and squashes the
-result through an **activation function**. With weights $w$, bias $b$, and inputs $x$:
+**One neuron** is the perceptron from the interlude with its hard switch softened: weighted sum,
+plus bias, squashed through a smooth **sigmoid** so the output reads like a probability and the
+boundary can be nudged by calculus.
 
 $$
-a = \sigma(w \cdot x + b), \qquad \sigma(z) = \frac{1}{1 + e^{-z}}
+a = \sigma(\mathbf{w}\cdot\mathbf{x} + b), \qquad \sigma(z) = \frac{1}{1 + e^{-z}}
 $$
-
-The sigmoid $\sigma$ maps any number into $(0, 1)$, so the output reads like a probability. In
-the library it's the default activation:
 
 ```ts
 private activationFunction = (value) => 1.0 / (1.0 + Math.exp(-value));
 ```
 
-Stack non-linear neurons and the network can carve out curved, even closed regions — which is
-exactly why the **Circles** dataset becomes learnable.
-
-## The forward pass
-
-To make a prediction, signal flows forward layer by layer: prepend a bias input, multiply by
-the layer's weight matrix, apply the activation, repeat. That's `forwardPropagate`:
+**The forward pass** sends signal through layer by layer — glue on a bias input, multiply by the
+layer's weights, squash, repeat:
 
 ```ts
-// Add bias nodes to the activations
-activations[layer].appendLeft(Matrix.ones(rows, 1));
-// Multiply by the weights to get each next-layer neuron's input
+activations[layer].appendLeft(Matrix.ones(rows, 1));                       // bias node
 incoming[layer + 1] = Matrix.multiply(activations[layer], weightMatrices[layer]);
-// Squash to get the next layer's output signal
 activations[layer + 1] = Matrix.transform(incoming[layer + 1], activationFunction);
 ```
 
-For `[2, 8, 1]` the shapes go `N×2 → N×8 → N×1`. The final column is the prediction you see
-shaded across the plane in the heatmap above.
+For `[2, 8, 1]` the shapes flow `N×2 → N×8 → N×1`; that last column is the delight score shaded
+across the plane in the heatmap.
 
-## Measuring wrongness: cross-entropy
-
-To improve, the network needs a number for how wrong it is. For probabilities we use
-**cross-entropy** (negative log-likelihood), averaged over the $m$ examples:
+**Measuring wrongness** uses **cross-entropy** (the same loss as logistic regression in Chapter 4) —
+gentle when confident-and-right, brutal when confident-and-wrong:
 
 $$
 L = -\frac{1}{m} \sum_{i=1}^{m} \Big[\, y_i \log \hat{y}_i + (1 - y_i)\log(1 - \hat{y}_i) \,\Big]
 $$
 
-That's the curve in the **Loss** panel. It's computed by `computeLoss`, which the playground
-samples every epoch:
+**Learning** is gradient descent, and the trick that makes it work in a deep stack is
+**backpropagation** — the answer to the very question that stumped the perceptron, *"how do you blame
+a neuron buried in the middle?"* Compute the error at the output, then pass it backwards through the
+transposed weight matrices so each weight learns its share of the blame, and step everything downhill:
 
 ```ts
-net.computeLoss(inputs, targets); // → average cross-entropy, lower is better
-```
-
-> Because of the $\log \hat{y}$ term, the output must live in $(0, 1)$ — which is why the output
-> layer uses a sigmoid. Swap in an activation that can output 0 or negatives and the loss breaks.
-
-## Learning: gradient descent and backpropagation
-
-Training nudges every weight a little in the direction that *reduces* the loss. The size of the
-nudge is the **learning rate** — the slider you've been dragging. Each step:
-
-$$
-w \leftarrow w - \eta \, \frac{\partial L}{\partial w}
-$$
-
-The partial derivatives come from **backpropagation**: compute the error at the output, then
-pass it backwards through the layers (using the transposed weight matrices) to find each
-weight's share of the blame. That's `calculateGradients` and `backPropagate`:
-
-```ts
-// Error at the output: how far predictions are from targets
-errors[last] = Matrix.subtract(activations[last], targets);
-// ...propagate backwards through transposed weights, then step downhill:
+errors[last] = Matrix.subtract(activations[last], targets);       // blame at the output
+// …propagate backwards through transposed weights, then:
 weightMatrices[layer].subtract(gradients[layer].multiply(learningRate));
 ```
 
-Because the weights persist on the network between calls, this playground sets the epoch count
-to **1** and calls `train()` once per animation frame — so you're literally watching one
-gradient-descent step per frame.
-
-## The bias trick
-
-Notice the `appendLeft(Matrix.ones(...))` above. Rather than track a separate bias term, we glue
-a constant column of `1`s onto the inputs; the bias then becomes just another weight in the
-matrix and rides along for free in the multiply. (The regression models in this library use the
-same trick.)
-
-## Smart initialization
-
-If every weight started at zero, every neuron would learn the same thing. They're seeded with
-small random values scaled by **Xavier/Glorot** initialization, which keeps the signal from
-exploding or vanishing as it flows through the layers:
+Three details make it behave. A **bias trick** — gluing a column of `1`s onto the inputs — lets the
+bias ride along as just another weight. **Xavier/Glorot initialization** seeds the weights small but
+not zero (all-zero and every neuron would learn the same thing), scaled to keep the signal from
+exploding or vanishing:
 
 ```ts
 const epsilon = Math.sqrt(6) / Math.sqrt(incomingNodes + outgoingNodes);
 weightMatrices.push(Matrix.rand(incomingNodes + 1, outgoingNodes, epsilon, seed));
 ```
 
-Because it's seeded, the same seed reproduces the exact same run — try changing the **seed** in
-the playground and watch a different path to the same solution.
-
-## Trust, but verify: gradient checking
-
-Backprop is easy to get subtly wrong. The library ships a `checkGradients()` method that nudges
-each weight by a tiny amount, measures how the loss actually changes (a finite-difference
-estimate of the gradient), and compares it to the analytic gradient — failing if they disagree by
-more than `1e-4`. That's the green **✓ Gradients verified** badge in the playground: a live proof
-that the math is implemented correctly.
+And because backprop is so easy to get subtly wrong, the library ships `checkGradients()`, which
+nudges each weight a hair, measures how the loss *actually* moves, and compares that to the analytic
+gradient — that's the green **✓ Gradients verified** badge: a live proof the math is right.
 
 ## Try it yourself
 
-- Switch to the **Spiral** and crank the **speed** — a deeper network slowly untangles the arms.
-- Drop the **learning rate** very low and watch the descent crawl; raise it too high and watch it
-  thrash.
-- Compare **Batch** vs **Mini-batch** vs **SGD** and see how the loss curve gets noisier.
+- **XNOR** is the matching-dials problem. A single line never solved it; give the network one hidden
+  layer and the boundary splits into the two diagonal pockets — exactly what beat the perceptron.
+- **Circles** and **Two moons** — preferences that curl around each other. Watch the boundary bend
+  into closed loops and crescents no line, tree, or smoother could draw.
+- **Spiral** is the showstopper: switch to a deeper network (`2 × 16`), raise the speed, and watch it
+  slowly untangle two wound-together tastes.
+- Drop the **learning rate** to a crawl, or crank it until the loss thrashes; compare **Batch** vs
+  **SGD**; nudge the **seed** to take a different path to the same solution.
 
-<div className="breakout">
-  <NeuralNetworkPlayground />
-</div>
+> **Field note — power cuts both ways.** A bigger network can learn anything in the training set —
+> including its noise. That's Chapter 3's overfitting with far more rope: the remedy is the same
+> (more data, hold-out checks, stopping early), and it's why "just add layers" isn't a free lunch.
+
+## What broke
+
+This is the most powerful tool in Nadia's ledger. It learns its *own* features instead of being
+handed them, and bends to any shape the data takes — the matching-dials pairing, the spiral, all of
+it. Everything earlier in the course is, in a sense, a neural network with the interesting parts
+removed.
+
+But that power has a bill. It's **hungry** — it wants far more labelled examples and compute than a
+line or a tree, and it will cheerfully memorise noise if you let it. It's a **black box** — try
+explaining a comped order by quoting a hidden weight. And, like every method in the ledger, it still
+expects a tidy **table of numbers**.
+
+That last limit is the real frontier. The café has gone wide — there's an app now, photos of latte
+art, written reviews, the order of each regular's visits over months. None of it is a neat row of
+features. Reading an *image* asks for a network that understands neighbouring pixels (convolutions);
+reading *text and sequences* asks for one with memory and attention. Those architectures — the
+machinery behind the model writing this very page — are where the story goes next, beyond the built
+pages of the ledger. But the engine inside them all is the one Nadia just built: stacked neurons,
+learning their own features, blame flowing backward.

--- a/site/src/content/pca.mdx
+++ b/site/src/content/pca.mdx
@@ -1,0 +1,105 @@
+import { PCAPlayground } from '../components/PCAPlayground';
+
+# Chapter 15 — Thirty questions, two axes
+
+> *Principal Component Analysis.* Nadia's new survey asks each customer thirty questions. She can't
+> picture thirty dimensions — and most of the questions are saying the same thing twice.
+
+To understand her regulars better, Nadia runs a taste survey: thirty questions, scored 1–5. *"Do you
+like it strong? Bitter? Do you add sugar? Order the dark roast?"* Now every customer is thirty
+numbers. She wants to cluster them, or at least *see* them — but a scatter plot has two axes, and she
+has thirty. Worse, the questions overlap: "likes it strong" and "likes the dark roast" rise and fall
+together. She's drowning in columns that mostly repeat each other.
+
+## The wall: you can't see thirty dimensions (and they lie)
+
+Her instinct is to just plot two of the questions and look. But which two? Pick any pair of the
+thirty and you get a smeared blob — each single question is a thin, noisy slice of the real picture.
+And the clustering tools from the last few chapters quietly fail her here too: in thirty dimensions
+every customer ends up roughly the same distance from every other (distance stops discriminating),
+and the redundant questions count the same trait three times over. She doesn't need to *pick* two of
+the thirty axes. She needs two *better* axes.
+
+## The idea: let the data choose the axes
+
+So Nadia stops choosing axes from the menu of questions and asks the data to draw its own. The key
+insight: the directions worth keeping are the ones the customers actually **vary** along. If "strong"
+and "dark roast" move together, that shared movement is really *one* underlying axis — call it
+"intensity-lover" — and she can replace both questions with their combined direction, losing almost
+nothing.
+
+That's PCA. It finds the single direction of greatest variance (the **first principal component**),
+then the greatest direction at a right angle to it (the second), and so on — each a blend of the
+original questions, ordered by how much of the spread it explains. Keep the top two and thirty
+columns become a picture. Below it's just two questions so you can watch it work; tick **Reduce to 1
+axis** and see the customers collapse onto the one that matters:
+
+<div className="breakout">
+  <PCAPlayground />
+</div>
+
+## How it works: the axes of variance
+
+The directions of greatest variance are the **eigenvectors of the covariance matrix** — the table of
+how every feature varies with every other. Center the data, build that matrix, and decompose it,
+straight from the
+[`PCA`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/unsupervised/PCA.ts)
+source:
+
+```ts
+// Covariance matrix: Cᵢⱼ = average product of centred features i and j (symmetric, d × d).
+const covariance = covarianceMatrix(centered, d);
+
+// Eigen-decompose it: each eigenvector is a direction, its eigenvalue the variance along it.
+const { values, vectors } = jacobiEigen(covariance);
+```
+
+Sort those eigenvectors by eigenvalue (variance), biggest first, keep the top `k`, and **projecting**
+a customer is just measuring how far along each kept axis they sit:
+
+```ts
+const centered = row.map((value, j) => value - this.mean[j]);
+return this.components.map(component => dot(centered, component)); // coordinates on each new axis
+```
+
+The eigenvalues double as a receipt. The fraction
+
+$$
+\text{explained variance}_i = \frac{\lambda_i}{\sum_j \lambda_j}
+$$
+
+tells you exactly how much of the picture each axis keeps — so "30 → 2" isn't a leap of faith, it's
+"PC1 and PC2 hold 94% of the variance; the other 28 axes were mostly noise."
+
+## Try it yourself
+
+- **Two tastes, one axis** — the two questions move together, so PC1 holds almost all the variance
+  (watch the percentage). Reduce to one axis and the points barely budge: the second question really
+  was redundant.
+- **Two crowds** — PC1 lines up with the gap between the groups. Flatten onto it and the two crowds
+  stay clearly apart — you threw away a dimension and kept the thing that mattered.
+- **No clear axis** — a round blob where neither direction dominates (PC1 ≈ PC2 ≈ 50%). Reduce here
+  and the points fall a long way onto the line: PCA is telling you, honestly, that there's nothing
+  safe to drop.
+
+> **Field note — how many components?** Plot the explained-variance ratios in order and watch where
+> the curve flattens (the "scree" elbow), or just keep enough components to cover ~90–95% of the
+> variance. Two is for *seeing*; for feeding another model you keep however many it takes to stop
+> throwing away signal.
+
+## What broke
+
+PCA turned Nadia's unmanageable thirty-question survey into a two-axis map she can actually plot and
+cluster — and it told her, in a single percentage, how much she kept. It's the quiet workhorse that
+makes high-dimensional data usable.
+
+But it only ever draws **straight** axes. PCA captures directions of variance, and "most variance"
+isn't always "most meaning" — a loud, high-variance question can dominate a component while the
+subtle signal she cares about hides in a low-variance direction it discards. It also can't unfold
+anything curved: hand it the two-moons shape and it just rotates it, never separates it.
+
+There's a more pointed use lurking here, though. PCA has, in effect, learned the *shape of a normal
+customer* — the few axes everyone varies along. So what about the customer who **doesn't** fit that
+shape, whose answers PCA can't rebuild from those two axes without a big error? That misfit might be
+a bad survey, a bot… or exactly the fraud signal Nadia keeps almost catching. Modelling "normal" to
+hunt the abnormal is the next problem.

--- a/site/src/content/perceptron.mdx
+++ b/site/src/content/perceptron.mdx
@@ -1,0 +1,65 @@
+import { PerceptronPlayground } from '../components/PerceptronPlayground';
+
+# Interlude — The Perceptron
+
+> Priya looks over Nadia's shoulder at the neural-network chapter she's about to start and grins:
+> *"Before you build a brain, you should meet the single brain cell — and the argument that nearly
+> killed the whole idea."*
+
+Nadia keeps hitting the same wall in different costumes. The logistic line that couldn't bend around
+two proofing methods. The straight fence that couldn't carve a spiral. The smoother that flattened a
+Saturday into a Tuesday. Every time, the limit was the same shape: *a single straight boundary isn't
+enough.* Priya tells her that boundary-drawing machine has a name, a birthday, and a scar.
+
+## One neuron: weighted sum, then fire
+
+The **perceptron** (Frank Rosenblatt, 1958) is the first artificial neuron, and it's almost
+insultingly simple. Take the inputs, multiply each by a weight, add a bias, and **fire** a `1` if the
+total clears zero — otherwise `0`. That's it. It's the same weighted sum as logistic regression from
+Chapter 4, with the soft sigmoid swapped for a hard on/off switch. Its boundary is, inevitably, a
+single straight line.
+
+It learns without any calculus at all — just a rule. Walk the examples; whenever it gets one wrong,
+shove the line a little toward that point. From the
+[`Perceptron`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/supervised/Perceptron.ts)
+source:
+
+```ts
+const error = labels[i] - prediction; // -1, 0, or +1
+if (error !== 0) {
+    for (let f = 0; f < featureCount; f++) weights[f] += learningRate * error * rows[i][f];
+    bias += learningRate * error;
+}
+```
+
+Rosenblatt proved that if the two classes *can* be split by a straight line, this rule will find one
+in a finite number of passes. The press ran wild — a machine that learns! — and imagined brains in
+boxes any year now.
+
+## Try it: AND, OR… and XOR
+
+Watch it learn the logic gates. **AND** and **OR** are one line away, so the boundary swings into
+place and the misclassified count drops to zero. Then switch to **XOR** — fire when *exactly one*
+input is high — and watch what happens:
+
+<div className="breakout">
+  <PerceptronPlayground />
+</div>
+
+On XOR the line never stops. The positive cases sit on *opposite* corners, so no straight cut can
+keep them on one side. The perceptron lurches back and forth forever, always at least one point
+wrong, never converging.
+
+## The scar
+
+In 1969, Marvin Minsky and Seymour Papert wrote a careful little book that proved exactly this: a
+single perceptron cannot learn XOR. It landed hard. Funding dried up, the hype curdled, and the field
+slid into one of its "AI winters." The cruel irony, Priya notes, is that the fix was already obvious
+on paper — *stack the neurons.* Feed the outputs of one layer of perceptrons into another, and the
+combination can carve XOR easily. What was missing was a practical way to *train* those inner
+neurons, since the perceptron's nudge-the-line rule doesn't know how to assign blame to a neuron
+buried in the middle.
+
+That missing piece — letting blame flow backward through the layers — is **backpropagation**, and
+it's what turns a pile of these single cells into something that can bend around any shape at all.
+Which is exactly where Nadia goes next.

--- a/site/src/content/recommender-systems.mdx
+++ b/site/src/content/recommender-systems.mdx
@@ -1,0 +1,98 @@
+import { RecommenderPlayground } from '../components/RecommenderPlayground';
+
+# Chapter 18 — Tastes, not crowds
+
+> *Recommender systems.* Association rules described the average customer. The loyalty app needs to
+> speak to *one* customer at a time — and suggest what they'll love but haven't tried.
+
+Nadia's building a loyalty app, and she wants it to feel like the café knows you: open it and it
+nudges you toward the thing you didn't order but would adore. Last chapter's rules can't do that —
+"croissant → coffee" is the same line for everyone. Mr Alvarez and Priya have wildly different
+tastes, and the recommendation should too. The trouble is, each regular has only ever tried a
+handful of the menu. Her ratings grid is mostly **blank**.
+
+## The wall: crowd rules can't see a person
+
+Association rules average everyone together, so anything personal dissolves: the one regular who
+pairs tea with a bagel never clears the support bar. And the obvious fix — hand-write each
+customer's taste — doesn't scale and goes stale. What Nadia has is a big, sparse grid of *who rated
+what*, and a need to fill the empty cells **per person**. Nothing so far fills blanks in a table by
+borrowing from similar rows and columns at once.
+
+## The idea: explain ratings as taste × profile
+
+So she assumes the ratings hide a simple structure. Give every customer a short vector of **latent
+taste factors** — how much they lean strong-vs-mild, sweet-vs-savoury, whatever the data implies —
+and give every item a profile in those same factors. A rating is then just how well a person's taste
+lines up with an item: their **dot product**. Learn both sets of vectors from the ratings you *do*
+have, and the very same dot product predicts the ones you don't — that's **matrix factorization**,
+the heart of collaborative filtering. Press **Train** and watch the blanks fill in; click a name for
+their top picks:
+
+<div className="breakout">
+  <RecommenderPlayground />
+</div>
+
+## How it works: factor the ratings matrix
+
+The model says the ratings matrix `R` is approximately a global average plus the product of a skinny
+**users × factors** matrix and a skinny **items × factors** one: `R ≈ μ + U Vᵀ`. It learns `U` and
+`V` by plain gradient descent over the *observed* ratings only — nudging each taste vector and each
+item vector toward the ratings it got wrong, shrinking them a little so it doesn't overfit. Straight
+from the
+[`Recommender`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/unsupervised/Recommender.ts)
+source:
+
+```ts
+const error = rating - this.globalMean - dot(userVector, itemVector);
+for (let f = 0; f < k; f++) {
+    const uf = userVector[f];
+    const vf = itemVector[f];
+    userVector[f] += lr * (error * vf - reg * uf); // move taste toward the item it mis-rated
+    itemVector[f] += lr * (error * uf - reg * vf); // and the item toward the taste
+}
+```
+
+Once the vectors settle, predicting any rating — including every blank — is one dot product:
+
+```ts
+this.itemFactors.map(itemVector => this.globalMean + dot(userVector, itemVector));
+```
+
+The lovely part: nobody *told* the model what the factors mean. It invents whatever hidden axes best
+explain the ratings — and "people who agree on what they've tried will agree on what they haven't"
+falls out for free.
+
+## Try it yourself
+
+- **The regulars** — train it and the empty cells fill with each person's predicted ratings, bright
+  where they'll likely love it. Click around: the strong-and-savoury crowd gets pointed at espresso
+  and bagels, the sweet tooths at cocoa and cookies — picks the app can actually make.
+- **Barely any data** — most of the grid is blank. Predictions still form, but they're shakier and
+  the RMSE settles higher: collaborative filtering leans on the crowd, and here there's less crowd
+  to lean on.
+- Slide **taste factors** up and down. One factor is a single taste axis; a few capture real
+  nuance — but push it high on sparse data and the model starts memorising the handful of ratings
+  it has instead of generalising (overfitting, again).
+
+> **Field note — the cold-start problem.** A brand-new customer who's rated nothing, or a new menu
+> item nobody's tried, has no vector to learn from — the model is blind to them. Real apps paper over
+> this by falling back to plain popularity ("our best-sellers") until enough ratings trickle in to
+> place the newcomer in taste-space.
+
+## What broke
+
+Matrix factorization gave Nadia exactly what the app needed: a personal guess for every regular,
+squeezed out of a grid that was mostly empty. It's the engine behind the recommendations you see
+everywhere.
+
+But notice what it leans on — and what it can't do. It's stuck on **cold starts**, blind to anyone
+new. Its notion of taste is a **dot product**, a fundamentally straight-line idea of how people and
+items relate. And, like everything in Part 3, it treats the world as one static **table of numbers**:
+who rated what, frozen in time.
+
+The café is about to outgrow that table. Nadia's opening a second location and an app, and the data
+coming in won't be tidy columns anymore — it'll be **photos** of latte art, **written reviews**,
+**sequences** of visits unfolding over weeks. None of it fits in a ratings grid, and a dot product
+can't bend around it. To go there she needs a model that learns its *own* features from raw, messy
+input — one that can bend curves no straight line, tree, or dot product ever could.

--- a/site/src/content/support-vector-machines.mdx
+++ b/site/src/content/support-vector-machines.mdx
@@ -1,0 +1,126 @@
+import { SupportVectorMachinePlayground } from '../components/SupportVectorMachinePlayground';
+
+# Chapter 11 — The widest street
+
+> *Support vector machines.* Every model Nadia has built draws *a* boundary. None of them ever asked
+> which boundary leaves the most room to be wrong.
+
+The comp policy works. Trees, forest, boosting — they all separate the orders she'd refund from the
+ones she wouldn't. But a regular complains: his order, a hair past the line, got refused, while his
+neighbour's near-identical one was comped. Nadia looks at her boundary and sees the problem. It runs
+*right alongside* a cluster of real cases, practically grazing them. One noisy new order and the
+call flips.
+
+She doesn't just want a line that separates today's orders. She wants the line that will still be
+right tomorrow — the one that keeps the **most distance** from every case it's seen.
+
+## The wall: any old separating line will do
+
+That's the thing none of her models optimised for. Logistic regression stops the moment it finds a
+line with low loss; a tree stops when its splits are pure. Show them the clean **Clear-cut** policy
+below and they'll happily settle on a boundary skimming one of the clouds — technically correct,
+dangerously close. There are infinitely many lines through that empty gap, and her old tools had no
+reason to prefer the safe one in the middle over a reckless one at the edge.
+
+## The idea: make the gap as wide as possible
+
+So Nadia flips the question around. Instead of *"find a line that separates them,"* she asks
+*"find the line with the widest empty street on either side of it."* Push the two borders of that
+street apart until each one bumps into the nearest orders. Those few orders it touches are the
+**support vectors** — they alone hold the boundary up. Every other order could vanish and the line
+wouldn't move an inch.
+
+The width of that street is the **margin**, and it has a tidy formula. If the boundary is
+`w · x + b = 0` and we scale things so the nearest points sit at `w · x + b = ±1`, the half-width of
+the street is `1 / ‖w‖`. Widening the margin means *shrinking* `‖w‖`:
+
+$$
+\min_{\mathbf{w},\,b}\ \tfrac{1}{2}\lVert \mathbf{w} \rVert^{2}
+\quad\text{subject to}\quad y_i\,(\mathbf{w}\cdot \mathbf{x}_i + b)\ \ge\ 1 .
+$$
+
+Real orders are messy, so a few are allowed to sit inside the street — for a price `C`. A small `C`
+buys a wider, calmer street at the cost of a few violations; a large `C` refuses to tolerate them
+and hugs the data tighter. Press **Train** and watch the street widen until the support vectors stop
+it:
+
+<div className="breakout">
+  <SupportVectorMachinePlayground />
+</div>
+
+## How it works: only the support vectors survive
+
+Solving that optimisation lands on a weight for every training order, `αᵢ`, and the punchline is
+that **almost all of them come out zero**. The only non-zero `αᵢ` belong to the support vectors —
+the orders on the street's edge. The boundary is built from *just those*, which is why the
+prediction sums over support vectors and ignores everything else:
+
+```ts
+let sum = this.bias;
+for (let k = 0; k < alphas.length; k++) {
+    if (alphas[k] !== 0) { // only support vectors contribute
+        sum += alphas[k] * this.labels[k] * this.applyKernel(this.inputs[k], point);
+    }
+}
+```
+
+The sign of that sum is the call — comp or no comp — and its size is how far past the margin the
+order sits.
+
+### The kernel trick: bending the street
+
+There's one move left, and it's the elegant one. Notice the prediction never touches an order's raw
+features directly — it only ever asks `applyKernel(a, b)`: *how similar are these two orders?* Swap
+out that one similarity function and the whole machine bends with it. The **linear** kernel is a
+plain dot product (a straight street). The **RBF** kernel scores similarity by distance, and that
+alone lets the boundary curve:
+
+```ts
+case 'rbf': {
+    let squaredDistance = 0;
+    for (let i = 0; i < a.length; i++) {
+        const difference = a[i] - b[i];
+        squaredDistance += difference * difference;
+    }
+    return Math.exp(-this.gamma * squaredDistance); // close orders ≈ 1, far ones ≈ 0
+}
+case 'linear':
+    return dotProduct(a, b);
+```
+
+That's the **kernel trick**: a curved boundary in Nadia's two features *is* a straight max-margin
+plane in a higher-dimensional space the kernel conjures up — and she never has to build that space,
+only score similarities in it.
+
+## Try it yourself
+
+- **Clear-cut** with the **linear** kernel — the street opens up dead-centre of the gap, far from
+  both clouds, balanced on just a few ringed support vectors. That centred line is the whole point.
+- **Borderline** — the clouds overlap and a few orders fall on the wrong side. Slide **C** down: the
+  margin widens and shrugs off the stragglers; slide it up and the street narrows as it strains to
+  catch every last one. More orders end up as support vectors as it tightens.
+- **Surrounded** — a pocket of always-comp orders ringed by ones that never are. The linear kernel
+  is hopeless; no straight street fits. Switch the kernel to **RBF** and the boundary wraps the
+  pocket like a lasso. Nudge **Gamma**: low and lazy draws a smooth ring, high and twitchy shrinks
+  it into tight bubbles around individual orders.
+
+> **Field note — gamma is a reach dial, and it overfits.** RBF's gamma sets how far one order's
+> influence carries. Low gamma = long reach = smooth, general boundaries. High gamma = each order
+> only sees its immediate neighbours, so the boundary fragments into little islands that memorise
+> the training set — the same overfitting from Chapter 3, wearing a kernel.
+
+## What broke
+
+The SVM is the most *principled* boundary Nadia has drawn: of all the lines that separate her
+orders, it picks the provably safest one, and the kernel trick bends it around shapes a straight
+line never could. It's fiddlier than boosting — you have to choose a kernel, then tune `C` and
+`gamma` — and it slows down on huge datasets, since it compares every pair of orders. But it works.
+
+And then Tomás the supplier asks her a question that stops her cold. *"Who even are your regulars?
+Group them so I know what to stock."* Nadia reaches for her tools and freezes. Every single model in
+the ledger — line, tree, forest, this beautiful margin — learned from an **answer key**: orders
+already labelled comp or no-comp, batches already marked rose or flopped. Nobody has labelled her
+customers. There's no column that says which group anyone belongs to. The groups don't exist yet —
+they're hiding in the data, waiting to be *found*.
+
+Every method she owns needs to be told the answer. She's about to need one that finds it alone.

--- a/site/src/content/time-series.mdx
+++ b/site/src/content/time-series.mdx
@@ -1,0 +1,103 @@
+import { TimeSeriesPlayground } from '../components/TimeSeriesPlayground';
+
+# Chapter 19 — Next week's order
+
+> *Time-series forecasting.* The café is growing, and Tomás the supplier wants the whole week's order
+> by 6am Monday. Nadia's old regression line treats every day as an island. Demand isn't islands —
+> it's a rhythm.
+
+This is where the café starts to *go wide*. Tomás won't deliver daily anymore — he needs one order,
+Monday morning, covering all seven days ahead. Get it wrong and Nadia either runs out on Saturday or
+bins a crate of stale croissants Sunday night. She has two years of daily sales and a strong feeling
+they're not random: weekends are always slammed, and the whole curve has been creeping upward as the
+café catches on.
+
+## The wall: a regression line can't hear a rhythm
+
+Her instinct is Chapter 1's tool — fit a line. But demand-vs-date misses everything that matters
+here. Fit a straight line through the dates and you capture the slow upward drift but flatten every
+weekend spike into the average. Ignore the dates and predict from temperature like before, and you
+lose the trend *and* the fact that **Saturday is always Saturday**. The deeper problem: regression
+treats the rows as an unordered bag of points. But in a time series the **order is the signal** —
+which day follows which, and that last week looks a lot like next week.
+
+## The idea: track level, trend, and season as you go
+
+So Nadia stops fitting one frozen line and starts *walking the days in order*, keeping three running
+estimates and nudging each as new days arrive:
+
+- the **level** — roughly where demand sits right now,
+- the **trend** — which way, and how fast, it's drifting,
+- the **season** — a repeating offset for each weekday (Saturday runs hot, Tuesday cold).
+
+Each update is an **exponential smoothing**: a blend of the newest day and everything before it,
+weighted so recent days count for more and the distant past fades. To forecast next Saturday she just
+adds them up: level, plus the trend stretched out to that day, plus Saturday's seasonal bump. Drag
+the sliders and watch the forecast (past the dashed "now" line) bend to fit:
+
+<div className="breakout">
+  <TimeSeriesPlayground />
+</div>
+
+## How it works: three exponential averages
+
+Walking the series, each day updates the three estimates — every new value mixed in with weight
+`α`/`β`/`γ`, the rest carried over from before. Straight from the
+[`ExponentialSmoothing`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/time-series/ExponentialSmoothing.ts)
+source (Holt-Winters):
+
+```ts
+const season = seasonals[t % m];
+fitted.push(previousLevel + previousTrend + season);                 // one-step-ahead forecast
+
+level    = α * (series[t] - season)        + (1 - α) * (previousLevel + previousTrend);
+trend    = β * (level - previousLevel)     + (1 - β) * previousTrend;
+seasonals[t % m] = γ * (series[t] - level) + (1 - γ) * season;
+```
+
+$$
+\hat{y}_{t+h} = \underbrace{\ell_t}_{\text{level}} + \underbrace{h\,b_t}_{\text{trend}} + \underbrace{s_{t+h-m}}_{\text{season}}
+$$
+
+Forecasting `h` days ahead is then just that sum — level, plus `h` steps of trend, plus the seasonal
+offset for the matching weekday:
+
+```ts
+const season = seasonals[(seriesLength + h - 1) % m];
+forecast.push([level + h * trend + season]);
+```
+
+The "exponential" part is the whole trick: because each estimate folds the newest reading into the
+old one, the influence of any past day decays geometrically — the model stays anchored to recent
+reality without forgetting the shape of the week.
+
+## Try it yourself
+
+- **Weekly rhythm** — the forecast doesn't flatten the weekends; it carries the Saturday spike right
+  into next week, nudged up by the gentle trend. That's all three estimates working together.
+- **Going up** — start with **β** at zero and the forecast visibly *lags*, trailing below the still-
+  climbing demand. Turn β up and the trend term catches it. This is the knob plain smoothing-without-
+  trend is missing.
+- **No real pattern** — a noisy flat line. Smoothing honestly gives you back the average; there's no
+  rhythm to project, and no slider will invent one.
+- Untick **Weekly season** on any dataset: the forecast collapses to a plain trend line that can't
+  tell a Saturday from a Tuesday — exactly the structure Chapter 1's regression threw away.
+
+> **Field note — α, β, γ are responsiveness dials.** High values chase the latest day (quick to
+> react, but jumpy on noise); low values stay smooth (steady, but slow to turn). And you must hand
+> the model the season's *length* — 7 for a weekly cycle — and trust that next week resembles the
+> recent past. When that assumption holds, it's hard to beat for the effort.
+
+## What broke
+
+Exponential smoothing gave Nadia a real forecast — trend, weekly rhythm and all — from nothing but
+the order of the days. For a single series with a steady shape, it's the right tool and barely costs
+anything.
+
+But look at what she had to *tell* it: that the cycle is seven days, that the parts add up, that
+tomorrow looks like last week. It forecasts that one demand line and nothing else — it can't fold in
+the weather, a holiday, a promo, or the latte-art photos and written reviews now pouring in from the
+new app. The café's data has outgrown a single tidy column. The patterns that matter next are tangled
+across many inputs at once — *delight and disaster hiding in combinations of cues*, the kind no
+straight line, tree, or smoother can carve apart. For that, Nadia finally needs a model that learns
+its own features and bends to any shape the data takes.

--- a/site/src/ml/anomalyDatasets.ts
+++ b/site/src/ml/anomalyDatasets.ts
@@ -1,0 +1,102 @@
+import type { Domain } from './datasets';
+import { gaussian, mulberry32 } from './rng';
+
+// 2-D transaction clouds for the anomaly-detection playground (Chapter 16). The bulk of each set is
+// "normal" — a Gaussian the detector fits — with a sprinkle of anomalies scattered wide (the fraud /
+// glitch / spoiled-batch points). The shapes vary what "normal" looks like: a round blob, a tilted
+// correlated one (where Mahalanobis earns its keep), and two clusters (where one Gaussian is a poor fit).
+export interface AnomalyDataset {
+    id: string;
+    label: string;
+    blurb: string;
+    domain: Domain;
+    threshold: number;
+    generate: (seed: number, n: number) => { inputs: number[][] };
+}
+
+const DOMAIN: Domain = { xMin: -3.2, xMax: 3.2, yMin: -3.2, yMax: 3.2 };
+
+/** Scatter `count` wide-ranging anomalies across the plane (kept clear of the dense centre). */
+function scatterAnomalies(rand: () => number, count: number, inputs: number[][]) {
+    let placed = 0;
+    while (placed < count) {
+        const x = (rand() * 2 - 1) * 2.9;
+        const y = (rand() * 2 - 1) * 2.9;
+        if (Math.hypot(x, y) > 1.6) {
+            inputs.push([x, y]);
+            placed++;
+        }
+    }
+}
+
+/** One round cloud of everyday transactions, plus a few wild outliers. */
+function everyday(seed: number, n: number) {
+    const rand = mulberry32(seed);
+    const anomalies = Math.floor(n * 0.08);
+    const inputs: number[][] = [];
+    for (let i = 0; i < n - anomalies; i++) {
+        inputs.push([gaussian(rand) * 0.6, gaussian(rand) * 0.6]);
+    }
+    scatterAnomalies(rand, anomalies, inputs);
+    return { inputs };
+}
+
+/** A strongly correlated cloud (spend and frequency rise together), plus outliers. */
+function tilted(seed: number, n: number) {
+    const rand = mulberry32(seed);
+    const anomalies = Math.floor(n * 0.08);
+    const angle = (35 * Math.PI) / 180;
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+    const inputs: number[][] = [];
+    for (let i = 0; i < n - anomalies; i++) {
+        const along = gaussian(rand) * 1.4;
+        const across = gaussian(rand) * 0.32;
+        inputs.push([along * cos - across * sin, along * sin + across * cos]);
+    }
+    scatterAnomalies(rand, anomalies, inputs);
+    return { inputs };
+}
+
+/** Two normal crowds — a single Gaussian can't model both at once (a teachable miss). */
+function twoHabits(seed: number, n: number) {
+    const rand = mulberry32(seed);
+    const anomalies = Math.floor(n * 0.06);
+    const normal = n - anomalies;
+    const half = Math.floor(normal / 2);
+    const inputs: number[][] = [];
+    for (let i = 0; i < normal; i++) {
+        const right = i >= half;
+        const cx = right ? 1.4 : -1.4;
+        inputs.push([cx + gaussian(rand) * 0.45, gaussian(rand) * 0.45]);
+    }
+    scatterAnomalies(rand, anomalies, inputs);
+    return { inputs };
+}
+
+export const ANOMALY_DATASETS: AnomalyDataset[] = [
+    {
+        id: 'everyday',
+        label: 'Everyday transactions',
+        blurb: 'A dense crowd of ordinary transactions with a few wild ones scattered around it. The detector learns the blob and flags whatever sits far outside it.',
+        domain: DOMAIN,
+        threshold: 3,
+        generate: everyday,
+    },
+    {
+        id: 'tilted',
+        label: 'Tilted normal',
+        blurb: 'Spend and frequency rise together, so "normal" is a tilted ellipse. Watch a point off the diagonal get flagged while one just as far along it stays normal — that\'s Mahalanobis distance, not plain distance.',
+        domain: DOMAIN,
+        threshold: 3,
+        generate: tilted,
+    },
+    {
+        id: 'two-habits',
+        label: 'Two habits',
+        blurb: 'Two separate crowds of regulars. One Gaussian has to straddle both, so its centre lands in the empty gap — and the model misjudges what\'s normal. A single bell curve is the wrong shape here.',
+        domain: DOMAIN,
+        threshold: 2.5,
+        generate: twoHabits,
+    },
+];

--- a/site/src/ml/associationDatasets.ts
+++ b/site/src/ml/associationDatasets.ts
@@ -1,0 +1,76 @@
+import { mulberry32 } from './rng';
+
+// "Basket" data for the association-rules playground (Chapter 17). Each row is one receipt; each
+// column is a menu item (1 = on the receipt). Baskets are built from planted combos plus a little
+// noise, so there are real "buys X also buys Y" patterns to discover — and enough noise that the
+// support/confidence thresholds actually matter.
+export interface AssociationDataset {
+    id: string;
+    label: string;
+    blurb: string;
+    items: string[];
+    minSupport: number;
+    minConfidence: number;
+    generate: (seed: number, n: number) => { inputs: number[][] };
+}
+
+const MENU = ['Espresso', 'Latte', 'Croissant', 'Muffin', 'Bagel', 'OJ', 'Cookie', 'Tea'];
+
+/** Build baskets from a set of planted combos (each added with `comboProbability`) plus item noise. */
+function basketGenerator(combos: number[][], comboProbability: number, noiseProbability: number) {
+    return (seed: number, n: number) => {
+        const rand = mulberry32(seed);
+        const itemCount = MENU.length;
+        const inputs: number[][] = [];
+
+        for (let t = 0; t < n; t++) {
+            const basket = new Set<number>();
+            for (const combo of combos) {
+                if (rand() < comboProbability) {
+                    for (const item of combo) {
+                        basket.add(item);
+                    }
+                }
+            }
+            for (let i = 0; i < itemCount; i++) {
+                if (rand() < noiseProbability) {
+                    basket.add(i);
+                }
+            }
+            // Avoid empty receipts — give a stray basket one random item.
+            if (basket.size === 0) {
+                basket.add(Math.floor(rand() * itemCount));
+            }
+
+            const row = new Array<number>(itemCount).fill(0);
+            for (const item of basket) {
+                row[item] = 1;
+            }
+            inputs.push(row);
+        }
+        return { inputs };
+    };
+}
+
+export const ASSOCIATION_DATASETS: AssociationDataset[] = [
+    {
+        id: 'cafe',
+        label: 'Café receipts',
+        blurb: 'Clean combos: espresso with a croissant, latte with a muffin, tea with a cookie, bagel with juice. The strong rules jump straight out.',
+        items: MENU,
+        minSupport: 0.12,
+        minConfidence: 0.5,
+        // [Espresso, Croissant], [Latte, Muffin], [Tea, Cookie], [Bagel, OJ]
+        generate: basketGenerator([[0, 2], [1, 3], [7, 6], [4, 5]], 0.32, 0.04),
+    },
+    {
+        id: 'busy',
+        label: 'Busy menu',
+        blurb: 'Weaker, overlapping habits and more noise. Crank the support and confidence bars up to burn off the coincidences and leave only the rules worth trusting.',
+        items: MENU,
+        minSupport: 0.1,
+        minConfidence: 0.5,
+        // overlapping combos (croissant shows up with both espresso and latte) + a 3-item habit
+        generate: basketGenerator([[0, 2], [1, 2], [1, 3], [7, 6], [0, 6], [4, 5, 3]], 0.22, 0.1),
+    },
+];

--- a/site/src/ml/clusteringDatasets.ts
+++ b/site/src/ml/clusteringDatasets.ts
@@ -2,9 +2,11 @@ import type { Domain } from './datasets';
 import { gaussian, mulberry32 } from './rng';
 
 /**
- * Unlabelled 2-D point clouds for the k-means playground. Unlike the supervised datasets these
- * carry **no targets** — clustering is unsupervised, so all the model ever sees is `inputs`.
- * `recommendedClusters` is the value of k that matches the data's natural structure.
+ * Unlabelled customer clouds for the k-means playground (Chapter 12). Each point is one of Nadia's
+ * customers, placed by two things she can measure — roughly *how often they come in* (x) and *how
+ * much they spend* (y). Unlike the supervised datasets these carry **no targets**: nobody has
+ * labelled anyone, so all the model ever sees is `inputs`. `recommendedClusters` is the value of k
+ * that matches the data's natural structure.
  */
 export interface ClusteringDataset {
     id: string;
@@ -35,7 +37,7 @@ function ringOfBlobs(count: number, radius = 0.95, spread = 0.16) {
     };
 }
 
-/** Uniform noise — no real clusters, so k-means just tiles the plane into Voronoi cells. */
+/** Uniform noise — no real segments, so k-means just tiles the plane into Voronoi cells. */
 function scatter(seed: number, n: number) {
     const rand = mulberry32(seed);
     const inputs: number[][] = [];
@@ -45,7 +47,7 @@ function scatter(seed: number, n: number) {
     return { inputs };
 }
 
-/** Two interleaving crescents — round-cluster k-means can't follow the curve (a teachable miss). */
+/** Two interleaving crescents — round-segment k-means can't follow the curve (a teachable miss). */
 function moons(seed: number, n: number) {
     const rand = mulberry32(seed);
     const inputs: number[][] = [];
@@ -64,32 +66,32 @@ function moons(seed: number, n: number) {
 export const CLUSTERING_DATASETS: ClusteringDataset[] = [
     {
         id: 'blobs5',
-        label: 'Five blobs',
-        blurb: 'Five tidy Gaussian clusters — k-means nails these when k matches.',
+        label: 'Five types',
+        blurb: 'Five tidy knots of customers — grab-and-go, regulars, weekend treaters, and so on. k-means nails them when k = 5.',
         domain: DOMAIN,
         recommendedClusters: 5,
         generate: ringOfBlobs(5),
     },
     {
         id: 'blobs3',
-        label: 'Three blobs',
-        blurb: 'Three well-separated clusters around a triangle. Try k = 3.',
+        label: 'Three types',
+        blurb: 'Three clearly separated kinds of customer. Try k = 3 and watch the centres settle into them.',
         domain: DOMAIN,
         recommendedClusters: 3,
         generate: ringOfBlobs(3, 0.85, 0.18),
     },
     {
         id: 'scatter',
-        label: 'Uniform scatter',
-        blurb: 'No real structure — k-means still partitions the plane into k Voronoi cells.',
+        label: 'Festival day',
+        blurb: 'A street-fair crowd of one-off visitors — no real segments at all. k-means still carves the plane into k arbitrary patches.',
         domain: { xMin: -1.3, xMax: 1.3, yMin: -1.3, yMax: 1.3 },
         recommendedClusters: 4,
         generate: scatter,
     },
     {
         id: 'moons',
-        label: 'Two moons',
-        blurb: 'Curved clusters. k-means assumes round blobs, so it splits the moons oddly.',
+        label: 'Blended habits',
+        blurb: 'Two habits that curl into one another (the morning crowd shading into the lunch crowd). k-means assumes round groups, so it slices the curve in half.',
         domain: { xMin: -1.5, xMax: 2.5, yMin: -1.2, yMax: 1.6 },
         recommendedClusters: 2,
         generate: moons,

--- a/site/src/ml/datasets.ts
+++ b/site/src/ml/datasets.ts
@@ -111,7 +111,7 @@ export const DATASETS: DatasetSpec[] = [
     {
         id: 'xnor',
         label: 'XNOR',
-        blurb: 'The classic. Two diagonal corners share a class — impossible for a straight line.',
+        blurb: 'The matching-dials pairing: delight when both cues agree (bold-bold or mild-mild), a flop when they clash. The "both-or-neither" shape the perceptron just failed on.',
         domain: LOGIC_DOMAIN,
         recommendedLr: 1,
         recommendedHidden: [8],
@@ -120,7 +120,7 @@ export const DATASETS: DatasetSpec[] = [
     {
         id: 'xor',
         label: 'XOR',
-        blurb: 'XNOR flipped. Same four points, opposite labels.',
+        blurb: 'The mirror image: a pairing works only when the two cues differ. Same four corners, opposite calls.',
         domain: LOGIC_DOMAIN,
         recommendedLr: 1,
         recommendedHidden: [8],
@@ -129,7 +129,7 @@ export const DATASETS: DatasetSpec[] = [
     {
         id: 'moons',
         label: 'Two moons',
-        blurb: 'Two interleaving crescents — the boundary curves beautifully as it learns.',
+        blurb: 'Two tastes that interleave like crescents — the boundary curves beautifully as it learns.',
         domain: { xMin: -1.5, xMax: 2.5, yMin: -1.2, yMax: 1.6 },
         recommendedLr: 3,
         recommendedHidden: [12],
@@ -138,7 +138,7 @@ export const DATASETS: DatasetSpec[] = [
     {
         id: 'circles',
         label: 'Circles',
-        blurb: 'A ring inside a ring. The network must learn a closed region.',
+        blurb: 'A core preference ringed by its opposite. The network has to learn a closed region.',
         domain: { xMin: -1.4, xMax: 1.4, yMin: -1.4, yMax: 1.4 },
         recommendedLr: 1,
         recommendedHidden: [8],
@@ -147,7 +147,7 @@ export const DATASETS: DatasetSpec[] = [
     {
         id: 'spiral',
         label: 'Spiral',
-        blurb: 'The showstopper. A deeper network untangles the two arms — give it a moment.',
+        blurb: 'The showstopper: two tastes wound tightly together. A deeper network untangles the arms — give it a moment.',
         domain: { xMin: -1.2, xMax: 1.2, yMin: -1.2, yMax: 1.2 },
         recommendedLr: 3,
         recommendedHidden: [16, 16],
@@ -156,7 +156,7 @@ export const DATASETS: DatasetSpec[] = [
     {
         id: 'blobs',
         label: 'Blobs',
-        blurb: 'Two well-separated clusters — even a tiny network nails it fast.',
+        blurb: 'Two clearly separate crowds — even a tiny network nails it fast.',
         domain: { xMin: -1.5, xMax: 1.5, yMin: -1.5, yMax: 1.5 },
         recommendedLr: 1,
         recommendedHidden: [8],

--- a/site/src/ml/dbscanDatasets.ts
+++ b/site/src/ml/dbscanDatasets.ts
@@ -1,0 +1,104 @@
+import type { Domain } from './datasets';
+import { gaussian, mulberry32 } from './rng';
+
+// Unlabelled customer clouds for the DBSCAN playground (Chapter 14). The shapes are chosen to show
+// what density-based clustering can do that k-means and hierarchical can't: find arbitrarily shaped
+// dense groups and, crucially, leave the stragglers *out* — flagged as noise rather than forced
+// into a group. `epsilon` / `minPoints` are sensible starting values for each set.
+export interface DbscanDataset {
+    id: string;
+    label: string;
+    blurb: string;
+    domain: Domain;
+    epsilon: number;
+    minPoints: number;
+    generate: (seed: number, n: number) => { inputs: number[][] };
+}
+
+const DOMAIN: Domain = { xMin: -1.4, xMax: 1.4, yMin: -1.4, yMax: 1.4 };
+
+/** Two tight crowds plus a sparse sprinkle of one-off / oddball customers scattered everywhere. */
+function blobsWithNoise(seed: number, n: number) {
+    const rand = mulberry32(seed);
+    const inputs: number[][] = [];
+    const noiseCount = Math.floor(n * 0.18);
+    const blobCount = n - noiseCount;
+    const half = Math.floor(blobCount / 2);
+
+    for (let i = 0; i < blobCount; i++) {
+        const right = i >= half;
+        const cx = right ? 0.7 : -0.7;
+        const cy = right ? 0.5 : -0.5;
+        inputs.push([cx + gaussian(rand) * 0.16, cy + gaussian(rand) * 0.16]);
+    }
+    for (let i = 0; i < noiseCount; i++) {
+        inputs.push([(rand() * 2 - 1) * 1.3, (rand() * 2 - 1) * 1.3]);
+    }
+    return { inputs };
+}
+
+/** Two interleaving crescents — DBSCAN traces each curve as one dense, connected group. */
+function moons(seed: number, n: number) {
+    const rand = mulberry32(seed);
+    const inputs: number[][] = [];
+    const half = Math.floor(n / 2);
+    for (let i = 0; i < n; i++) {
+        const upper = i < half;
+        const span = upper ? half : n - half;
+        const t = (Math.PI * (upper ? i : i - half)) / span;
+        const x = (upper ? Math.cos(t) : 1 - Math.cos(t)) + gaussian(rand) * 0.07;
+        const y = (upper ? Math.sin(t) : 0.5 - Math.sin(t)) + gaussian(rand) * 0.07;
+        inputs.push([x, y]);
+    }
+    return { inputs };
+}
+
+/** A tight core crowd encircled by a ring of regulars — two groups no centroid could separate. */
+function ring(seed: number, n: number) {
+    const rand = mulberry32(seed);
+    const inputs: number[][] = [];
+    const core = Math.floor(n * 0.4);
+    const ringCount = n - core;
+    for (let i = 0; i < n; i++) {
+        if (i < core) {
+            inputs.push([gaussian(rand) * 0.12, gaussian(rand) * 0.12]);
+        } else {
+            // Spread the ring points roughly evenly (with a little jitter) so the loop stays a single
+            // connected band — fully random angles leave gaps that fragment it.
+            const angle = ((i - core + (rand() - 0.5) * 0.7) / ringCount) * 2 * Math.PI;
+            const radius = 0.9 + gaussian(rand) * 0.05;
+            inputs.push([Math.cos(angle) * radius, Math.sin(angle) * radius]);
+        }
+    }
+    return { inputs };
+}
+
+export const DBSCAN_DATASETS: DbscanDataset[] = [
+    {
+        id: 'regulars-noise',
+        label: 'Regulars & oddballs',
+        blurb: 'Two solid crowds of regulars, dusted with one-off visitors. DBSCAN keeps the crowds and marks the strays as noise — the groups k-means was forced to swallow.',
+        domain: DOMAIN,
+        epsilon: 0.2,
+        minPoints: 4,
+        generate: blobsWithNoise,
+    },
+    {
+        id: 'moons',
+        label: 'Blended habits',
+        blurb: 'Two habits curling around each other. Density follows the curve, so each crescent comes out as one clean group — no linkage tuning, no k.',
+        domain: { xMin: -1.5, xMax: 2.5, yMin: -1.2, yMax: 1.6 },
+        epsilon: 0.22,
+        minPoints: 4,
+        generate: moons,
+    },
+    {
+        id: 'ring',
+        label: 'A ring of regulars',
+        blurb: 'A tight core crowd inside a ring of others. They share a centre, so k-means is hopeless — but they are two separate dense regions, which is all DBSCAN cares about.',
+        domain: DOMAIN,
+        epsilon: 0.18,
+        minPoints: 4,
+        generate: ring,
+    },
+];

--- a/site/src/ml/hierarchicalDatasets.ts
+++ b/site/src/ml/hierarchicalDatasets.ts
@@ -1,0 +1,97 @@
+import type { Domain } from './datasets';
+import { gaussian, mulberry32 } from './rng';
+
+// Unlabelled customer clouds for the hierarchical-clustering playground (Chapter 13). Same idea as
+// the k-means data — each point is a customer placed by two measured habits — but the shapes are
+// chosen to show what *linkage* changes: a clean nested tree, a curve single-linkage can follow,
+// and a bridge that single-linkage chains across while complete-linkage refuses to.
+export interface HierarchicalDataset {
+    id: string;
+    label: string;
+    blurb: string;
+    domain: Domain;
+    recommendedClusters: number;
+    generate: (seed: number, n: number) => { inputs: number[][] };
+}
+
+const DOMAIN: Domain = { xMin: -1.4, xMax: 1.4, yMin: -1.4, yMax: 1.4 };
+
+/** `count` Gaussian blobs whose centres sit evenly around a circle. */
+function ringOfBlobs(count: number, radius = 0.9, spread = 0.16) {
+    return (seed: number, n: number) => {
+        const rand = mulberry32(seed);
+        const centers = Array.from({ length: count }, (_, c) => {
+            const angle = (c / count) * 2 * Math.PI - Math.PI / 2;
+            return [radius * Math.cos(angle), radius * Math.sin(angle)];
+        });
+
+        const inputs: number[][] = [];
+        for (let i = 0; i < n; i++) {
+            const center = centers[i % count];
+            inputs.push([center[0] + gaussian(rand) * spread, center[1] + gaussian(rand) * spread]);
+        }
+        return { inputs };
+    };
+}
+
+/** Two interleaving crescents — single-linkage can trace the curve; complete-linkage chops it. */
+function moons(seed: number, n: number) {
+    const rand = mulberry32(seed);
+    const inputs: number[][] = [];
+    const half = Math.floor(n / 2);
+    for (let i = 0; i < n; i++) {
+        const upper = i < half;
+        const span = upper ? half : n - half;
+        const t = (Math.PI * (upper ? i : i - half)) / span;
+        const x = (upper ? Math.cos(t) : 1 - Math.cos(t)) + gaussian(rand) * 0.08;
+        const y = (upper ? Math.sin(t) : 0.5 - Math.sin(t)) + gaussian(rand) * 0.08;
+        inputs.push([x, y]);
+    }
+    return { inputs };
+}
+
+/** Two crowds joined by a thin trickle of in-between customers — the classic single-linkage trap. */
+function bridge(seed: number, n: number) {
+    const rand = mulberry32(seed);
+    const inputs: number[][] = [];
+    const bridgeCount = Math.floor(n * 0.16);
+    const blobCount = n - bridgeCount;
+    const half = Math.floor(blobCount / 2);
+
+    for (let i = 0; i < blobCount; i++) {
+        const right = i >= half;
+        const cx = right ? 0.85 : -0.85;
+        inputs.push([cx + gaussian(rand) * 0.17, gaussian(rand) * 0.17]);
+    }
+    for (let i = 0; i < bridgeCount; i++) {
+        inputs.push([(rand() * 2 - 1) * 0.85, gaussian(rand) * 0.05]);
+    }
+    return { inputs };
+}
+
+export const HIERARCHICAL_DATASETS: HierarchicalDataset[] = [
+    {
+        id: 'blobs3',
+        label: 'Three types',
+        blurb: 'Three clearly separate kinds of customer. The dendrogram shows a big gap before the final joins — slide k to 3 and the cut lands right in it.',
+        domain: DOMAIN,
+        recommendedClusters: 3,
+        generate: ringOfBlobs(3, 0.85, 0.17),
+    },
+    {
+        id: 'moons',
+        label: 'Blended habits',
+        blurb: 'Two habits curling around each other. Complete-linkage chops them straight across; switch to single-linkage and it follows the curve like a string of beads.',
+        domain: { xMin: -1.5, xMax: 2.5, yMin: -1.2, yMax: 1.6 },
+        recommendedClusters: 2,
+        generate: moons,
+    },
+    {
+        id: 'bridge',
+        label: 'A slow drift',
+        blurb: 'Two crowds linked by a thin trickle of in-between regulars. Single-linkage chains right across the bridge into one blob; complete-linkage keeps the two crowds apart.',
+        domain: DOMAIN,
+        recommendedClusters: 2,
+        generate: bridge,
+    },
+];

--- a/site/src/ml/pcaDatasets.ts
+++ b/site/src/ml/pcaDatasets.ts
@@ -1,0 +1,72 @@
+import type { Domain } from './datasets';
+import { gaussian, mulberry32 } from './rng';
+
+// 2-D customer clouds for the PCA playground (Chapter 15). Each point is a customer scored on two
+// survey questions; PCA finds the directions of greatest variance. Two questions is the most you
+// can *see* — but the same maths is what collapses a thirty-question survey to two axes. The shapes
+// vary how much one axis really matters: a tight diagonal (one axis is enough), two crowds along a
+// diagonal (reduction that keeps the split), and a near-round blob (nothing to reduce).
+export interface PcaDataset {
+    id: string;
+    label: string;
+    blurb: string;
+    domain: Domain;
+    generate: (seed: number, n: number) => { inputs: number[][] };
+}
+
+const DOMAIN: Domain = { xMin: -3, xMax: 3, yMin: -3, yMax: 3 };
+
+/** A Gaussian cloud stretched `s1` along a direction rotated `angleDeg`, and `s2` across it. */
+function correlatedCloud(angleDeg: number, s1: number, s2: number) {
+    return (seed: number, n: number) => {
+        const rand = mulberry32(seed);
+        const angle = (angleDeg * Math.PI) / 180;
+        const cos = Math.cos(angle);
+        const sin = Math.sin(angle);
+        const inputs: number[][] = [];
+        for (let i = 0; i < n; i++) {
+            const along = gaussian(rand) * s1;
+            const across = gaussian(rand) * s2;
+            inputs.push([along * cos - across * sin, along * sin + across * cos]);
+        }
+        return { inputs };
+    };
+}
+
+/** Two crowds offset along the diagonal — PC1 lines up with the gap between them. */
+function twoCrowds(seed: number, n: number) {
+    const rand = mulberry32(seed);
+    const inputs: number[][] = [];
+    const half = Math.floor(n / 2);
+    for (let i = 0; i < n; i++) {
+        const top = i < half;
+        const cx = top ? -1.1 : 1.1;
+        const cy = top ? -1.1 : 1.1;
+        inputs.push([cx + gaussian(rand) * 0.45, cy + gaussian(rand) * 0.45]);
+    }
+    return { inputs };
+}
+
+export const PCA_DATASETS: PcaDataset[] = [
+    {
+        id: 'one-axis',
+        label: 'Two tastes, one axis',
+        blurb: 'Two survey questions that move together — answer one and you basically know the other. PCA finds the single axis they share; projecting onto it barely loses a thing.',
+        domain: DOMAIN,
+        generate: correlatedCloud(35, 1.7, 0.28),
+    },
+    {
+        id: 'two-crowds',
+        label: 'Two crowds',
+        blurb: 'Two clusters strung along a diagonal. PC1 lines up with the gap, so flattening onto that one axis keeps the two crowds clearly apart — reduction that loses the noise, not the signal.',
+        domain: DOMAIN,
+        generate: twoCrowds,
+    },
+    {
+        id: 'round',
+        label: 'No clear axis',
+        blurb: 'A roughly round blob — the two questions are unrelated and vary about equally. Neither axis dominates, so squashing to one really would throw away half the picture. PCA is honest about that.',
+        domain: DOMAIN,
+        generate: correlatedCloud(20, 1.05, 0.95),
+    },
+];

--- a/site/src/ml/perceptronDatasets.ts
+++ b/site/src/ml/perceptronDatasets.ts
@@ -1,0 +1,57 @@
+import type { DataSet, Domain } from './datasets';
+import { gaussian, mulberry32 } from './rng';
+
+// Logic-gate clouds for the perceptron interlude. Four little clusters at the corners of the unit
+// square, labelled by a gate. AND and OR are linearly separable — one straight line splits them, so
+// the perceptron converges. XOR is not — no single line works, and the perceptron never settles.
+export interface GateDataset {
+    id: string;
+    label: string;
+    blurb: string;
+    domain: Domain;
+    generate: (seed: number, n: number) => DataSet;
+}
+
+const DOMAIN: Domain = { xMin: -0.4, xMax: 1.4, yMin: -0.4, yMax: 1.4 };
+const CORNERS = [[0, 0], [0, 1], [1, 0], [1, 1]];
+
+/** Four corner clusters, each labelled by `labels[corner]`. */
+function gate(labels: number[]) {
+    return (seed: number, n: number): DataSet => {
+        const rand = mulberry32(seed);
+        const inputs: number[][] = [];
+        const targets: number[][] = [];
+        const perCorner = Math.max(1, Math.floor(n / 4));
+        for (let c = 0; c < 4; c++) {
+            for (let j = 0; j < perCorner; j++) {
+                inputs.push([CORNERS[c][0] + gaussian(rand) * 0.11, CORNERS[c][1] + gaussian(rand) * 0.11]);
+                targets.push([labels[c]]);
+            }
+        }
+        return { inputs, targets };
+    };
+}
+
+export const GATE_DATASETS: GateDataset[] = [
+    {
+        id: 'and',
+        label: 'AND',
+        blurb: 'Fire only when both inputs are high — one corner positive. A single line separates it, so the perceptron locks on and the errors drop to zero.',
+        domain: DOMAIN,
+        generate: gate([0, 0, 0, 1]),
+    },
+    {
+        id: 'or',
+        label: 'OR',
+        blurb: 'Fire when either input is high — three corners positive. Still one line away, so the perceptron converges just fine.',
+        domain: DOMAIN,
+        generate: gate([0, 1, 1, 1]),
+    },
+    {
+        id: 'xor',
+        label: 'XOR',
+        blurb: 'Fire when exactly one input is high — opposite corners share a class. No straight line can split it, so the boundary lurches forever and the error never reaches zero. This is the wall.',
+        domain: DOMAIN,
+        generate: gate([0, 1, 1, 0]),
+    },
+];

--- a/site/src/ml/recommenderDatasets.ts
+++ b/site/src/ml/recommenderDatasets.ts
@@ -1,0 +1,79 @@
+import { gaussian, mulberry32 } from './rng';
+
+// Ratings data for the recommender playground (Chapter 18). A users × items matrix of 1–5 ratings
+// with 0 meaning "hasn't tried it" — the blanks matrix factorization fills in. Ratings are built
+// from a hidden 2-factor taste (drink strength × sweetness), so there's real structure for the model
+// to recover, then a chunk is hidden so there's something to recommend.
+export interface RecommenderDataset {
+    id: string;
+    label: string;
+    blurb: string;
+    users: string[];
+    items: string[];
+    generate: (seed: number) => { inputs: number[][] };
+}
+
+const USERS = ['Alvarez', 'Bea', 'Tomás', 'Priya', 'Sam', 'Iris', 'Owen', 'Mei', 'Dan'];
+const ITEMS = ['Espresso', 'Latte', 'Tea', 'Cocoa', 'Croissant', 'Muffin', 'Bagel', 'Cookie'];
+
+// Each item's hidden profile: [strength, sweetness], roughly in [-1, 1].
+const ITEM_PROFILES: number[][] = [
+    [1.0, -0.6], // Espresso
+    [0.6, 0.1], // Latte
+    [0.3, -0.2], // Tea
+    [-0.6, 0.9], // Cocoa
+    [-0.2, 0.5], // Croissant
+    [-0.3, 0.9], // Muffin
+    [-0.2, -0.7], // Bagel
+    [-0.4, 1.0], // Cookie
+];
+
+// A few taste archetypes users are drawn from: [strength preference, sweetness preference].
+const ARCHETYPES: number[][] = [
+    [1.0, -0.8], // strong & savoury
+    [-0.6, 1.0], // sweet tooth
+    [0.2, 0.2], // balanced
+    [0.3, -0.4], // light & savoury
+];
+
+function clampRating(value: number) {
+    return Math.max(1, Math.min(5, Math.round(value)));
+}
+
+function ratingsGenerator(hideProbability: number, tasteNoise: number) {
+    return (seed: number) => {
+        const rand = mulberry32(seed);
+        const inputs: number[][] = [];
+        for (let u = 0; u < USERS.length; u++) {
+            const base = ARCHETYPES[u % ARCHETYPES.length];
+            const taste = [base[0] + gaussian(rand) * tasteNoise, base[1] + gaussian(rand) * tasteNoise];
+            const row: number[] = [];
+            for (let i = 0; i < ITEMS.length; i++) {
+                const profile = ITEM_PROFILES[i];
+                const rating = clampRating(3 + 2 * (taste[0] * profile[0] + taste[1] * profile[1]));
+                row.push(rand() < hideProbability ? 0 : rating);
+            }
+            inputs.push(row);
+        }
+        return { inputs };
+    };
+}
+
+export const RECOMMENDER_DATASETS: RecommenderDataset[] = [
+    {
+        id: 'regulars',
+        label: 'The regulars',
+        blurb: 'Nine regulars, each with a clear taste — strong-and-savoury, sweet tooth, and so on. Half their menu is untried; the model learns each taste and fills the blanks.',
+        users: USERS,
+        items: ITEMS,
+        generate: ratingsGenerator(0.5, 0.18),
+    },
+    {
+        id: 'sparse',
+        label: 'Barely any data',
+        blurb: 'Most of the grid is blank and tastes are fuzzier. With so few ratings the predictions get shakier — collaborative filtering still leans on the crowd, but it has less to lean on.',
+        users: USERS,
+        items: ITEMS,
+        generate: ratingsGenerator(0.66, 0.3),
+    },
+];

--- a/site/src/ml/svmDatasets.ts
+++ b/site/src/ml/svmDatasets.ts
@@ -1,0 +1,84 @@
+import type { DataSet, Domain } from './datasets';
+import { gaussian, mulberry32 } from './rng';
+
+// Binary "should we comp this order?" datasets for Chapter 11 (support vector machines). The same
+// two features as the trees chapters — how long the customer waited (x) and how badly the order
+// went wrong (y), relative to normal — labelled comp (1) / no comp (0). The shapes are chosen to
+// show off the margin: a wide clean gap, a narrow noisy one, and a curved case only a kernel can
+// carve.
+export interface SvmDataset {
+    id: string;
+    label: string;
+    blurb: string;
+    domain: Domain;
+    /** Whether this set is meant to be split by a straight line ('linear') or needs a kernel ('rbf'). */
+    suggestedKernel: 'linear' | 'rbf';
+    generate: (seed: number, n: number) => DataSet;
+}
+
+const WIDE: Domain = { xMin: -1.6, xMax: 1.6, yMin: -1.6, yMax: 1.6 };
+
+// Two gaussian clouds on a diagonal: fine orders in one corner, disasters in the other.
+function blobs(offset: number, spread: number) {
+    return (seed: number, n: number): DataSet => {
+        const rand = mulberry32(seed);
+        const inputs: number[][] = [];
+        const targets: number[][] = [];
+        const half = Math.floor(n / 2);
+        for (let i = 0; i < n; i++) {
+            const comp = i >= half;
+            const cx = comp ? offset : -offset;
+            const cy = comp ? offset : -offset;
+            inputs.push([cx + gaussian(rand) * spread, cy + gaussian(rand) * spread]);
+            targets.push([comp ? 1 : 0]);
+        }
+        return { inputs, targets };
+    };
+}
+
+// A pocket of always-comp orders (one specific bad combination) ringed by orders that never get
+// comped — a closed curve no straight line can trace.
+function ring(seed: number, n: number): DataSet {
+    const rand = mulberry32(seed);
+    const inputs: number[][] = [];
+    const targets: number[][] = [];
+    const half = Math.floor(n / 2);
+    for (let i = 0; i < n; i++) {
+        const comp = i < half;
+        const radius = comp ? 0.45 * Math.sqrt(rand()) : 0.95 + rand() * 0.45;
+        const angle = rand() * 2 * Math.PI;
+        inputs.push([
+            Math.cos(angle) * radius + gaussian(rand) * 0.06,
+            Math.sin(angle) * radius + gaussian(rand) * 0.06,
+        ]);
+        targets.push([comp ? 1 : 0]);
+    }
+    return { inputs, targets };
+}
+
+export const SVM_DATASETS: SvmDataset[] = [
+    {
+        id: 'clear-cut',
+        label: 'Clear-cut',
+        blurb: 'Fine orders and outright disasters sit in opposite corners with a wide empty gap between. Many lines separate them — the SVM finds the one dead-centre.',
+        domain: WIDE,
+        suggestedKernel: 'linear',
+        generate: blobs(0.7, 0.22),
+    },
+    {
+        id: 'borderline',
+        label: 'Borderline',
+        blurb: 'The two clouds crowd together and a few cases land on the wrong side. Lower C to let the margin breathe through the noise; raise it to insist on every point.',
+        domain: WIDE,
+        suggestedKernel: 'linear',
+        generate: blobs(0.42, 0.5),
+    },
+    {
+        id: 'surrounded',
+        label: 'Surrounded',
+        blurb: 'A pocket of always-comp orders, ringed by ones that never are. A straight line is hopeless — switch the kernel to RBF and watch it wrap the pocket.',
+        domain: WIDE,
+        suggestedKernel: 'rbf',
+        generate: ring,
+    },
+];

--- a/site/src/ml/timeSeriesDatasets.ts
+++ b/site/src/ml/timeSeriesDatasets.ts
@@ -1,0 +1,69 @@
+import { gaussian, mulberry32 } from './rng';
+
+// Daily café-demand series for the time-series playground (Chapter 19). Each is eight weeks of one
+// number per day — built from a base level, an optional trend, a weekly rhythm (quiet midweek, busy
+// weekends), and noise — so exponential smoothing has a real level/trend/season to recover. The
+// recommended alpha/beta/gamma and forecast horizon are sensible starting points per series.
+export interface TimeSeriesDataset {
+    id: string;
+    label: string;
+    blurb: string;
+    alpha: number;
+    beta: number;
+    gamma: number;
+    seasonLength: number;
+    horizon: number;
+    generate: (seed: number) => { series: number[] };
+}
+
+const DAYS = 56; // eight weeks
+// Per-weekday offset (Mon…Sun): quiet start of the week, a Friday/Saturday rush, a calm Sunday.
+const WEEKLY = [-10, -7, -4, -2, 22, 34, 10];
+
+function demand(base: number, trend: number, weekly: number[], noise: number) {
+    return (seed: number) => {
+        const rand = mulberry32(seed);
+        const series: number[] = [];
+        for (let d = 0; d < DAYS; d++) {
+            const value = base + trend * d + weekly[d % 7] + gaussian(rand) * noise;
+            series.push(Math.max(0, Math.round(value)));
+        }
+        return { series };
+    };
+}
+
+export const TIME_SERIES_DATASETS: TimeSeriesDataset[] = [
+    {
+        id: 'weekly',
+        label: 'Weekly rhythm',
+        blurb: 'Demand drifts up gently but every week looks the same — quiet Monday, packed Saturday. Smoothing tracks the level and the weekly season together.',
+        alpha: 0.3,
+        beta: 0.05,
+        gamma: 0.4,
+        seasonLength: 7,
+        horizon: 14,
+        generate: demand(50, 0.15, WEEKLY, 4),
+    },
+    {
+        id: 'growing',
+        label: 'Going up',
+        blurb: 'The café is taking off — a strong upward trend under the same weekly rhythm. Without the trend term the forecast would lag behind reality; turn beta up and it keeps pace.',
+        alpha: 0.3,
+        beta: 0.15,
+        gamma: 0.4,
+        seasonLength: 7,
+        horizon: 14,
+        generate: demand(35, 0.7, WEEKLY, 5),
+    },
+    {
+        id: 'flat',
+        label: 'No real pattern',
+        blurb: 'Just a noisy flat line — no trend, no weekly shape worth speaking of. Smoothing can only sensibly return the average; there is nothing here to forecast.',
+        alpha: 0.3,
+        beta: 0,
+        gamma: 0.2,
+        seasonLength: 7,
+        horizon: 14,
+        generate: demand(50, 0, [0, 0, 0, 0, 0, 0, 0], 11),
+    },
+];

--- a/site/src/viz/anomaly.ts
+++ b/site/src/viz/anomaly.ts
@@ -1,0 +1,67 @@
+import type { Domain } from '../ml/datasets';
+
+const NORMAL: [number, number, number] = [56, 189, 248]; // sky
+const ANOMALY: [number, number, number] = [248, 113, 113]; // red
+
+/**
+ * Paints the anomaly map: each cell is coloured by its Mahalanobis score relative to the threshold.
+ * Inside the threshold (`ratio ≤ 1`) the cell is cool blue and fades out toward the boundary — the
+ * fitted "normal" region, an ellipse following the data's shape. Past it (`ratio > 1`) the cell
+ * turns red and deepens with distance, so the threshold ring where they meet reads as the decision
+ * boundary between normal and anomalous.
+ */
+export function paintAnomalyRegion(
+    offscreen: HTMLCanvasElement,
+    scores: number[],
+    threshold: number,
+    size: number,
+): void {
+    if (offscreen.width !== size || offscreen.height !== size) {
+        offscreen.width = size;
+        offscreen.height = size;
+    }
+    const ctx = offscreen.getContext('2d');
+    if (!ctx) return;
+
+    const image = ctx.createImageData(size, size);
+    for (let k = 0; k < scores.length; k++) {
+        const ratio = scores[k] / threshold;
+        const o = k * 4;
+        if (ratio <= 1) {
+            image.data[o] = NORMAL[0];
+            image.data[o + 1] = NORMAL[1];
+            image.data[o + 2] = NORMAL[2];
+            image.data[o + 3] = Math.round(25 + 60 * (1 - ratio)); // deepest at the centre
+        } else {
+            image.data[o] = ANOMALY[0];
+            image.data[o + 1] = ANOMALY[1];
+            image.data[o + 2] = ANOMALY[2];
+            image.data[o + 3] = Math.round(35 + Math.min(165, 110 * (ratio - 1)));
+        }
+    }
+    ctx.putImageData(image, 0, 0);
+}
+
+/** Draws the points: normal ones as sky dots, flagged anomalies as red dots with a white ring. */
+export function drawAnomalyPoints(
+    ctx: CanvasRenderingContext2D,
+    inputs: number[][],
+    flags: number[],
+    domain: Domain,
+    width: number,
+    height: number,
+): void {
+    for (let i = 0; i < inputs.length; i++) {
+        const px = ((inputs[i][0] - domain.xMin) / (domain.xMax - domain.xMin)) * width;
+        const py = (1 - (inputs[i][1] - domain.yMin) / (domain.yMax - domain.yMin)) * height;
+        const anomaly = flags[i] === 1;
+
+        ctx.beginPath();
+        ctx.arc(px, py, anomaly ? 4.5 : 3.5, 0, 2 * Math.PI);
+        ctx.fillStyle = anomaly ? '#f87171' : '#38bdf8';
+        ctx.fill();
+        ctx.lineWidth = anomaly ? 2 : 1.25;
+        ctx.strokeStyle = anomaly ? '#f8fafc' : 'rgba(11, 17, 32, 0.85)';
+        ctx.stroke();
+    }
+}

--- a/site/src/viz/association.ts
+++ b/site/src/viz/association.ts
@@ -1,0 +1,86 @@
+import type { AssociationRule } from 'machine-learning';
+
+/**
+ * Draws the **co-occurrence web**: menu items as labelled nodes around a circle, and each
+ * single-item → single-item rule as a curved arrow from antecedent to consequent. Stronger
+ * associations (higher lift) draw thicker and brighter, so the habits worth knowing pop out. Node
+ * size reflects how often each item is bought at all.
+ */
+export function drawAssociationWeb(
+    ctx: CanvasRenderingContext2D,
+    width: number,
+    height: number,
+    items: string[],
+    rules: AssociationRule[],
+    itemSupport: number[],
+): void {
+    const n = items.length;
+    const cx = width / 2;
+    const cy = height / 2;
+    const radius = Math.min(width, height) * 0.34;
+
+    const nodeAt = (i: number): [number, number] => {
+        const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
+        return [cx + radius * Math.cos(angle), cy + radius * Math.sin(angle)];
+    };
+
+    // Edges: pairwise rules only (single item → single item), strongest drawn last so they sit on top.
+    const pairwise = rules
+        .filter(rule => rule.antecedent.length === 1 && rule.consequent.length === 1)
+        .sort((a, b) => a.lift - b.lift);
+
+    for (const rule of pairwise) {
+        const [ax, ay] = nodeAt(rule.antecedent[0]);
+        const [bx, by] = nodeAt(rule.consequent[0]);
+
+        // Bow the curve so opposite directions (A→B vs B→A) don't overlap.
+        const midX = (ax + bx) / 2;
+        const midY = (ay + by) / 2;
+        const bow = rule.antecedent[0] < rule.consequent[0] ? 0.16 : -0.16;
+        const controlX = midX + (cy - midY) * 0 + (by - ay) * bow;
+        const controlY = midY + (ax - bx) * bow;
+
+        const intensity = Math.min(1, Math.max(0, (rule.lift - 1) / 1.5));
+        ctx.strokeStyle = `rgba(251, 146, 60, ${0.25 + 0.65 * intensity})`;
+        ctx.lineWidth = 1 + 4 * intensity;
+        ctx.beginPath();
+        ctx.moveTo(ax, ay);
+        ctx.quadraticCurveTo(controlX, controlY, bx, by);
+        ctx.stroke();
+
+        // Arrowhead near the consequent.
+        const angle = Math.atan2(by - controlY, bx - controlX);
+        const head = 8;
+        ctx.fillStyle = `rgba(251, 146, 60, ${0.4 + 0.6 * intensity})`;
+        ctx.beginPath();
+        ctx.moveTo(bx - head * Math.cos(angle - 0.4), by - head * Math.sin(angle - 0.4));
+        ctx.lineTo(bx, by);
+        ctx.lineTo(bx - head * Math.cos(angle + 0.4), by - head * Math.sin(angle + 0.4));
+        ctx.fill();
+    }
+
+    // Nodes + labels.
+    ctx.font = '12px ui-sans-serif, system-ui, sans-serif';
+    for (let i = 0; i < n; i++) {
+        const [x, y] = nodeAt(i);
+        const r = 5 + 10 * Math.min(1, itemSupport[i]);
+
+        ctx.beginPath();
+        ctx.arc(x, y, r, 0, 2 * Math.PI);
+        ctx.fillStyle = '#38bdf8';
+        ctx.fill();
+        ctx.lineWidth = 1.5;
+        ctx.strokeStyle = 'rgba(11, 17, 32, 0.85)';
+        ctx.stroke();
+
+        const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
+        const outward = Math.cos(angle);
+        const lx = x + outward * 14;
+        const ly = y + Math.sin(angle) * 14;
+        ctx.fillStyle = '#e2e8f0';
+        ctx.textAlign = outward >= 0 ? 'left' : 'right';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(items[i], lx, ly);
+    }
+    ctx.textAlign = 'left';
+}

--- a/site/src/viz/dbscan.ts
+++ b/site/src/viz/dbscan.ts
@@ -1,0 +1,70 @@
+import type { Domain } from '../ml/datasets';
+import { CLUSTER_RGB, clusterHex } from './clusters';
+
+/**
+ * Paints the density map into a size×size offscreen canvas. Each cell carries the integer label
+ * DBSCAN's `predict` returned: a cluster index gets that cluster's colour, while **noise** (`-1`)
+ * is left fully transparent so the dark backdrop shows through — the empty space between dense
+ * regions reads as exactly that, empty.
+ */
+export function paintDensity(offscreen: HTMLCanvasElement, labels: number[], size: number): void {
+    if (offscreen.width !== size || offscreen.height !== size) {
+        offscreen.width = size;
+        offscreen.height = size;
+    }
+    const ctx = offscreen.getContext('2d');
+    if (!ctx) return;
+
+    const image = ctx.createImageData(size, size);
+    for (let k = 0; k < labels.length; k++) {
+        const label = labels[k];
+        const o = k * 4;
+        if (label < 0) {
+            image.data[o + 3] = 0; // noise → transparent
+            continue;
+        }
+        const [r, g, b] = CLUSTER_RGB[label % CLUSTER_RGB.length];
+        image.data[o] = r;
+        image.data[o + 1] = g;
+        image.data[o + 2] = b;
+        image.data[o + 3] = 150;
+    }
+    ctx.putImageData(image, 0, 0);
+}
+
+/** Draws the points: clustered ones as filled coloured dots, noise as small grey ✕ marks. */
+export function drawDbscanPoints(
+    ctx: CanvasRenderingContext2D,
+    inputs: number[][],
+    labels: number[],
+    domain: Domain,
+    width: number,
+    height: number,
+): void {
+    for (let i = 0; i < inputs.length; i++) {
+        const px = ((inputs[i][0] - domain.xMin) / (domain.xMax - domain.xMin)) * width;
+        const py = (1 - (inputs[i][1] - domain.yMin) / (domain.yMax - domain.yMin)) * height;
+
+        if (labels[i] < 0) {
+            // Noise: a faint grey cross, clearly not part of any group.
+            const r = 3;
+            ctx.strokeStyle = 'rgba(148, 163, 184, 0.7)';
+            ctx.lineWidth = 1.5;
+            ctx.beginPath();
+            ctx.moveTo(px - r, py - r);
+            ctx.lineTo(px + r, py + r);
+            ctx.moveTo(px + r, py - r);
+            ctx.lineTo(px - r, py + r);
+            ctx.stroke();
+            continue;
+        }
+
+        ctx.beginPath();
+        ctx.arc(px, py, 3.5, 0, 2 * Math.PI);
+        ctx.fillStyle = clusterHex(labels[i]);
+        ctx.fill();
+        ctx.lineWidth = 1.25;
+        ctx.strokeStyle = 'rgba(11, 17, 32, 0.85)';
+        ctx.stroke();
+    }
+}

--- a/site/src/viz/dendrogram.ts
+++ b/site/src/viz/dendrogram.ts
@@ -1,0 +1,114 @@
+import { clusterHex } from './clusters';
+
+/** One merge of the dendrogram (matches the library's `getMergeHistory()` shape). */
+export interface DendrogramMerge {
+    left: number;
+    right: number;
+    distance: number;
+}
+
+/**
+ * Draws the dendrogram — the tree of merges hierarchical clustering builds. Leaves (the original
+ * `n` points) sit along the bottom; each merge is an inverted-U bracket drawn at the height
+ * (distance) the two groups joined, so taller brackets = groups that were farther apart.
+ *
+ * A dashed **cut line** marks where the tree is sliced for the current `k`: branches *below* it
+ * each sit inside one final cluster and are coloured to match the map, while the merges *above* it
+ * (the ones the cut discards) are greyed. Moving `k` slides that line — the whole point of the
+ * chapter: you pick the number of clusters by choosing a height, after the tree is built.
+ */
+export function drawDendrogram(
+    ctx: CanvasRenderingContext2D,
+    width: number,
+    height: number,
+    merges: DendrogramMerge[],
+    n: number,
+    k: number,
+    labels: number[],
+): void {
+    ctx.clearRect(0, 0, width, height);
+    if (n < 2 || merges.length === 0) return;
+
+    const padX = 10;
+    const padTop = 16;
+    const padBottom = 10;
+    const plotW = width - 2 * padX;
+    const plotH = height - padTop - padBottom;
+
+    const totalNodes = 2 * n - 1;
+    const childLeft = new Array<number>(totalNodes).fill(-1);
+    const childRight = new Array<number>(totalNodes).fill(-1);
+    const nodeHeight = new Array<number>(totalNodes).fill(0);
+    for (let t = 0; t < merges.length; t++) {
+        const id = n + t;
+        childLeft[id] = merges[t].left;
+        childRight[id] = merges[t].right;
+        nodeHeight[id] = merges[t].distance;
+    }
+    const root = n + merges.length - 1;
+    const maxHeight = nodeHeight[root] || 1;
+
+    // Lay out leaves left→right in tree order (no crossing branches); each internal node sits above
+    // the midpoint of its two children. `repLeaf` lets us colour a branch by its cluster.
+    const xpos = new Array<number>(totalNodes).fill(0);
+    const repLeaf = new Array<number>(totalNodes).fill(0);
+    let slot = 0;
+    const assign = (node: number): void => {
+        if (node < n) {
+            xpos[node] = (slot + 0.5) / n;
+            repLeaf[node] = node;
+            slot++;
+            return;
+        }
+        assign(childLeft[node]);
+        assign(childRight[node]);
+        xpos[node] = (xpos[childLeft[node]] + xpos[childRight[node]]) / 2;
+        repLeaf[node] = repLeaf[childLeft[node]];
+    };
+    assign(root);
+
+    const toX = (x: number) => padX + x * plotW;
+    const toY = (h: number) => padTop + (1 - h / maxHeight) * plotH; // height 0 at the bottom
+
+    const below = n - k; // the first `below` merges sit under the cut, inside single clusters
+
+    for (let t = 0; t < merges.length; t++) {
+        const id = n + t;
+        const left = childLeft[id];
+        const right = childRight[id];
+        const yMerge = toY(nodeHeight[id]);
+        const xLeft = toX(xpos[left]);
+        const xRight = toX(xpos[right]);
+
+        const inCluster = t < below;
+        ctx.strokeStyle = inCluster ? clusterHex(labels[repLeaf[id]]) : 'rgba(148, 163, 184, 0.55)';
+        ctx.lineWidth = inCluster ? 2 : 1.25;
+        ctx.beginPath();
+        ctx.moveTo(xLeft, toY(nodeHeight[left]));
+        ctx.lineTo(xLeft, yMerge);
+        ctx.moveTo(xRight, toY(nodeHeight[right]));
+        ctx.lineTo(xRight, yMerge);
+        ctx.moveTo(xLeft, yMerge);
+        ctx.lineTo(xRight, yMerge);
+        ctx.stroke();
+    }
+
+    // The cut sits between the last below-cut merge and the first above-cut one.
+    const lower = below > 0 ? nodeHeight[n + below - 1] : 0;
+    const upper = below < merges.length ? nodeHeight[n + below] : maxHeight * 1.05;
+    const cutY = toY((lower + upper) / 2);
+
+    ctx.strokeStyle = 'rgba(248, 250, 252, 0.7)';
+    ctx.lineWidth = 1;
+    ctx.setLineDash([5, 4]);
+    ctx.beginPath();
+    ctx.moveTo(padX, cutY);
+    ctx.lineTo(width - padX, cutY);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    ctx.fillStyle = 'rgba(248, 250, 252, 0.8)';
+    ctx.font = '11px ui-sans-serif, system-ui, sans-serif';
+    ctx.textBaseline = 'bottom';
+    ctx.fillText(`cut → ${k} cluster${k === 1 ? '' : 's'}`, padX + 2, cutY - 3);
+}

--- a/site/src/viz/pca.ts
+++ b/site/src/viz/pca.ts
@@ -1,0 +1,119 @@
+import type { Domain } from '../ml/datasets';
+
+// PCA scene colours.
+const POINT = '#38bdf8';   // data points (sky)
+const PC1_COLOR = '#fb923c'; // first principal component (amber)
+const PC2_COLOR = '#64748b'; // second component (slate)
+
+function toPx(x: number, y: number, domain: Domain, width: number, height: number): [number, number] {
+    const px = ((x - domain.xMin) / (domain.xMax - domain.xMin)) * width;
+    const py = (1 - (y - domain.yMin) / (domain.yMax - domain.yMin)) * height;
+    return [px, py];
+}
+
+/** The dashed line through the mean along PC1 — the axis points collapse onto when reducing to 1-D. */
+export function drawPc1Line(
+    ctx: CanvasRenderingContext2D,
+    mean: number[],
+    pc1: number[],
+    domain: Domain,
+    width: number,
+    height: number,
+): void {
+    const reach = 6; // long enough to span the plot
+    const [ax, ay] = toPx(mean[0] - pc1[0] * reach, mean[1] - pc1[1] * reach, domain, width, height);
+    const [bx, by] = toPx(mean[0] + pc1[0] * reach, mean[1] + pc1[1] * reach, domain, width, height);
+
+    ctx.strokeStyle = 'rgba(251, 146, 60, 0.45)';
+    ctx.lineWidth = 1;
+    ctx.setLineDash([5, 4]);
+    ctx.beginPath();
+    ctx.moveTo(ax, ay);
+    ctx.lineTo(bx, by);
+    ctx.stroke();
+    ctx.setLineDash([]);
+}
+
+/**
+ * Draws the data points, interpolated `t` of the way (0 → 1) toward their projection onto PC1. At
+ * `t = 0` they sit where they really are; at `t = 1` they've collapsed onto the PC1 line — the 2-D →
+ * 1-D reduction, made visible. Faint connectors show how far each point moved (the lost variance).
+ */
+export function drawPcaPoints(
+    ctx: CanvasRenderingContext2D,
+    points: number[][],
+    mean: number[],
+    pc1: number[],
+    domain: Domain,
+    width: number,
+    height: number,
+    t: number,
+): void {
+    for (const [x, y] of points) {
+        const scalar = (x - mean[0]) * pc1[0] + (y - mean[1]) * pc1[1];
+        const projX = mean[0] + scalar * pc1[0];
+        const projY = mean[1] + scalar * pc1[1];
+        const cx = x + (projX - x) * t;
+        const cy = y + (projY - y) * t;
+
+        if (t > 0.01) {
+            const [ox, oy] = toPx(x, y, domain, width, height);
+            const [px, py] = toPx(cx, cy, domain, width, height);
+            ctx.strokeStyle = 'rgba(148, 163, 184, 0.25)';
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.moveTo(ox, oy);
+            ctx.lineTo(px, py);
+            ctx.stroke();
+        }
+
+        const [dx, dy] = toPx(cx, cy, domain, width, height);
+        ctx.beginPath();
+        ctx.arc(dx, dy, 3.5, 0, 2 * Math.PI);
+        ctx.fillStyle = POINT;
+        ctx.fill();
+        ctx.lineWidth = 1.25;
+        ctx.strokeStyle = 'rgba(11, 17, 32, 0.85)';
+        ctx.stroke();
+    }
+}
+
+/**
+ * Draws the principal components as arrows from the mean, each ±2 standard deviations long, so the
+ * longer arrow (PC1) literally points along the data's main spread and the shorter one (PC2) across it.
+ */
+export function drawPcaAxes(
+    ctx: CanvasRenderingContext2D,
+    mean: number[],
+    components: number[][],
+    standardDeviations: number[],
+    domain: Domain,
+    width: number,
+    height: number,
+): void {
+    const colors = [PC1_COLOR, PC2_COLOR];
+    for (let c = Math.min(components.length, 2) - 1; c >= 0; c--) {
+        const unit = components[c];
+        const len = 2 * standardDeviations[c];
+        const [mx, my] = toPx(mean[0], mean[1], domain, width, height);
+        const [ex, ey] = toPx(mean[0] + unit[0] * len, mean[1] + unit[1] * len, domain, width, height);
+        const [sx, sy] = toPx(mean[0] - unit[0] * len, mean[1] - unit[1] * len, domain, width, height);
+
+        ctx.strokeStyle = colors[c];
+        ctx.lineWidth = c === 0 ? 3 : 2;
+        ctx.beginPath();
+        ctx.moveTo(sx, sy);
+        ctx.lineTo(ex, ey);
+        ctx.stroke();
+
+        // A small arrowhead on the positive end.
+        const angle = Math.atan2(ey - my, ex - mx);
+        const head = 9;
+        ctx.beginPath();
+        ctx.moveTo(ex, ey);
+        ctx.lineTo(ex - head * Math.cos(angle - 0.4), ey - head * Math.sin(angle - 0.4));
+        ctx.moveTo(ex, ey);
+        ctx.lineTo(ex - head * Math.cos(angle + 0.4), ey - head * Math.sin(angle + 0.4));
+        ctx.stroke();
+    }
+}

--- a/site/src/viz/perceptron.ts
+++ b/site/src/viz/perceptron.ts
@@ -1,0 +1,29 @@
+import type { Domain } from '../ml/datasets';
+
+/**
+ * Rings the misclassified points so the perceptron's mistakes are obvious — on XOR these never go
+ * away, which is the whole point of the interlude.
+ */
+export function drawMisclassified(
+    ctx: CanvasRenderingContext2D,
+    inputs: number[][],
+    labels: number[],
+    predictions: number[],
+    domain: Domain,
+    width: number,
+    height: number,
+): void {
+    for (let i = 0; i < inputs.length; i++) {
+        if (predictions[i] === labels[i]) {
+            continue;
+        }
+        const px = ((inputs[i][0] - domain.xMin) / (domain.xMax - domain.xMin)) * width;
+        const py = (1 - (inputs[i][1] - domain.yMin) / (domain.yMax - domain.yMin)) * height;
+
+        ctx.beginPath();
+        ctx.arc(px, py, 8, 0, 2 * Math.PI);
+        ctx.lineWidth = 2;
+        ctx.strokeStyle = '#f87171'; // red ring = "got this one wrong"
+        ctx.stroke();
+    }
+}

--- a/site/src/viz/recommender.ts
+++ b/site/src/viz/recommender.ts
@@ -1,0 +1,17 @@
+// Colour for a predicted rating (1–5): dim slate for low, bright amber for high — so the grid reads
+// like a heatmap of how much each user is predicted to like each item.
+const LOW: [number, number, number] = [51, 65, 85]; // slate-700
+const HIGH: [number, number, number] = [251, 191, 36]; // amber-400
+
+export function ratingColor(rating: number): string {
+    const t = Math.max(0, Math.min(1, (rating - 1) / 4));
+    const r = Math.round(LOW[0] + (HIGH[0] - LOW[0]) * t);
+    const g = Math.round(LOW[1] + (HIGH[1] - LOW[1]) * t);
+    const b = Math.round(LOW[2] + (HIGH[2] - LOW[2]) * t);
+    return `rgb(${r}, ${g}, ${b})`;
+}
+
+/** Dark text on bright (high-rating) cells, light text on dim ones — keeps the number readable. */
+export function ratingTextColor(rating: number): string {
+    return rating >= 3.5 ? '#1f2937' : '#e2e8f0';
+}

--- a/site/src/viz/svm.ts
+++ b/site/src/viz/svm.ts
@@ -1,0 +1,61 @@
+import type { Domain } from '../ml/datasets';
+
+// Class hues, matching the rest of the site: sky-blue = class 0 (no comp), amber = class 1 (comp).
+const C0: [number, number, number] = [56, 189, 248];
+const C1: [number, number, number] = [251, 146, 60];
+
+/**
+ * Paints the SVM decision scores into a size×size offscreen canvas. Unlike the logistic heatmap
+ * (which fades toward a 50% seam), this one renders the **margin** directly: each cell is coloured
+ * by the sign of the score `f` and its opacity ramps with `|f|`, clamped at the margin edge `|f| = 1`.
+ * Cells inside the street (`|f| < 1`) stay translucent over the dark backdrop, so the empty margin
+ * shows up as a dark band — and the wider the SVM's margin, the wider that band.
+ */
+export function paintMargins(offscreen: HTMLCanvasElement, scores: number[], size: number): void {
+    if (offscreen.width !== size || offscreen.height !== size) {
+        offscreen.width = size;
+        offscreen.height = size;
+    }
+    const ctx = offscreen.getContext('2d');
+    if (!ctx) return;
+
+    const image = ctx.createImageData(size, size);
+    for (let k = 0; k < scores.length; k++) {
+        const f = scores[k];
+        const [r, g, b] = f >= 0 ? C1 : C0;
+        const magnitude = Math.min(1, Math.abs(f)); // 0 at the boundary → 1 at/beyond the margin edge
+        const alpha = Math.round(30 + 205 * magnitude);
+        const o = k * 4;
+        image.data[o] = r;
+        image.data[o + 1] = g;
+        image.data[o + 2] = b;
+        image.data[o + 3] = alpha;
+    }
+    ctx.putImageData(image, 0, 0);
+}
+
+/**
+ * Rings the support vectors — the points the boundary actually balances on. Drawn as a bright
+ * hollow circle so the underlying class-coloured dot stays visible inside.
+ */
+export function drawSupportVectors(
+    ctx: CanvasRenderingContext2D,
+    points: number[][],
+    domain: Domain,
+    width: number,
+    height: number,
+): void {
+    for (const [x, y] of points) {
+        const px = ((x - domain.xMin) / (domain.xMax - domain.xMin)) * width;
+        const py = (1 - (y - domain.yMin) / (domain.yMax - domain.yMin)) * height;
+
+        ctx.beginPath();
+        ctx.arc(px, py, 8, 0, 2 * Math.PI);
+        ctx.lineWidth = 2.5;
+        ctx.strokeStyle = '#f8fafc';
+        ctx.stroke();
+        ctx.lineWidth = 1;
+        ctx.strokeStyle = 'rgba(11, 17, 32, 0.9)';
+        ctx.stroke();
+    }
+}

--- a/site/src/viz/timeSeries.ts
+++ b/site/src/viz/timeSeries.ts
@@ -1,0 +1,83 @@
+// Line-chart viz for the time-series playground: history, the in-sample fit, and the forecast.
+
+const HISTORY = '#38bdf8'; // sky — the actual past
+const FORECAST = '#fb923c'; // amber — the forecast ahead
+const FIT = 'rgba(251, 146, 60, 0.5)'; // faint amber — the fitted line over history
+
+/**
+ * Draws the series as a line chart: the actual `history` in sky, the model's one-step-ahead `fitted`
+ * line faintly over it, and the `forecast` continuing past a dashed "now" divider in amber. The y-axis
+ * auto-scales to all three so the forecast's seasonal swings stay on-canvas.
+ */
+export function drawForecast(
+    ctx: CanvasRenderingContext2D,
+    width: number,
+    height: number,
+    history: number[],
+    fitted: number[],
+    forecast: number[],
+): void {
+    const padX = 12;
+    const padY = 14;
+    const plotW = width - 2 * padX;
+    const plotH = height - 2 * padY;
+
+    const total = history.length + forecast.length;
+    if (total < 2) return;
+
+    const all = history.concat(fitted, forecast);
+    let min = Math.min(...all);
+    let max = Math.max(...all);
+    if (max - min < 1e-9) {
+        max = min + 1;
+    }
+    const margin = (max - min) * 0.08;
+    min -= margin;
+    max += margin;
+
+    const x = (i: number) => padX + (i / (total - 1)) * plotW;
+    const y = (v: number) => padY + (1 - (v - min) / (max - min)) * plotH;
+
+    const line = (values: number[], startIndex: number, color: string, dashed: boolean, lineWidth: number) => {
+        if (values.length === 0) return;
+        ctx.strokeStyle = color;
+        ctx.lineWidth = lineWidth;
+        ctx.setLineDash(dashed ? [5, 4] : []);
+        ctx.beginPath();
+        values.forEach((v, k) => {
+            const px = x(startIndex + k);
+            const py = y(v);
+            if (k === 0) ctx.moveTo(px, py);
+            else ctx.lineTo(px, py);
+        });
+        ctx.stroke();
+        ctx.setLineDash([]);
+    };
+
+    // The "now" divider between history and forecast.
+    const dividerX = x(history.length - 0.5);
+    ctx.strokeStyle = 'rgba(148, 163, 184, 0.4)';
+    ctx.lineWidth = 1;
+    ctx.setLineDash([3, 3]);
+    ctx.beginPath();
+    ctx.moveTo(dividerX, padY);
+    ctx.lineTo(dividerX, height - padY);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Fitted line over the history, then the actual history on top.
+    line(fitted, 0, FIT, false, 1.5);
+    line(history, 0, HISTORY, false, 2);
+
+    // Forecast, joined to the last actual point so the line is continuous.
+    const lastActual = history[history.length - 1];
+    line([lastActual, ...forecast], history.length - 1, FORECAST, true, 2);
+
+    // Dots on the forecast so individual future days read clearly.
+    ctx.fillStyle = FORECAST;
+    forecast.forEach((v, k) => {
+        ctx.beginPath();
+        ctx.arc(x(history.length + k), y(v), 2.5, 0, 2 * Math.PI);
+        ctx.fill();
+    });
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,6 +2,8 @@ export { default as DecisionTree } from "./machine-learning/supervised/DecisionT
 export type { DecisionTreeNode } from "./machine-learning/supervised/DecisionTree";
 export { default as FeedforwardNeuralNetwork } from "./machine-learning/supervised/FeedforwardNeuralNetwork";
 export { default as GradientBoosting } from "./machine-learning/supervised/GradientBoosting";
+export { default as HierarchicalClustering } from "./machine-learning/unsupervised/HierarchicalClustering";
+export type { Linkage, HierarchicalMerge } from "./machine-learning/unsupervised/HierarchicalClustering";
 export { default as KMeans } from "./machine-learning/unsupervised/KMeans";
 export { default as LinearRegression } from "./machine-learning/supervised/LinearRegression";
 export { default as LogisticRegression } from "./machine-learning/supervised/LogisticRegression";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -12,6 +12,7 @@ export { default as Matrix } from "./math/linear-algebra/Matrix";
 export { default as MulticlassLogisticRegression } from "./machine-learning/supervised/MulticlassLogisticRegression";
 export { default as NaiveBayes } from "./machine-learning/supervised/NaiveBayes";
 export { default as NearestNeighbors } from "./machine-learning/supervised/NearestNeighbors";
+export { default as PCA } from "./machine-learning/unsupervised/PCA";
 export { default as RandomForest } from "./machine-learning/supervised/RandomForest";
 export { default as SupportVectorMachine } from "./machine-learning/supervised/SupportVectorMachine";
 export type { Kernel } from "./machine-learning/supervised/SupportVectorMachine";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,4 +1,6 @@
 export { default as AnomalyDetector } from "./machine-learning/unsupervised/AnomalyDetector";
+export { default as AssociationRules } from "./machine-learning/unsupervised/AssociationRules";
+export type { AssociationRule, FrequentItemset } from "./machine-learning/unsupervised/AssociationRules";
 export { default as DBSCAN } from "./machine-learning/unsupervised/DBSCAN";
 export { default as DecisionTree } from "./machine-learning/supervised/DecisionTree";
 export type { DecisionTreeNode } from "./machine-learning/supervised/DecisionTree";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,6 +4,7 @@ export type { AssociationRule, FrequentItemset } from "./machine-learning/unsupe
 export { default as DBSCAN } from "./machine-learning/unsupervised/DBSCAN";
 export { default as DecisionTree } from "./machine-learning/supervised/DecisionTree";
 export type { DecisionTreeNode } from "./machine-learning/supervised/DecisionTree";
+export { default as ExponentialSmoothing } from "./machine-learning/time-series/ExponentialSmoothing";
 export { default as FeedforwardNeuralNetwork } from "./machine-learning/supervised/FeedforwardNeuralNetwork";
 export { default as GradientBoosting } from "./machine-learning/supervised/GradientBoosting";
 export { default as HierarchicalClustering } from "./machine-learning/unsupervised/HierarchicalClustering";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -17,5 +17,6 @@ export { default as NaiveBayes } from "./machine-learning/supervised/NaiveBayes"
 export { default as NearestNeighbors } from "./machine-learning/supervised/NearestNeighbors";
 export { default as PCA } from "./machine-learning/unsupervised/PCA";
 export { default as RandomForest } from "./machine-learning/supervised/RandomForest";
+export { default as Recommender } from "./machine-learning/unsupervised/Recommender";
 export { default as SupportVectorMachine } from "./machine-learning/supervised/SupportVectorMachine";
 export type { Kernel } from "./machine-learning/supervised/SupportVectorMachine";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,4 @@
+export { default as DBSCAN } from "./machine-learning/unsupervised/DBSCAN";
 export { default as DecisionTree } from "./machine-learning/supervised/DecisionTree";
 export type { DecisionTreeNode } from "./machine-learning/supervised/DecisionTree";
 export { default as FeedforwardNeuralNetwork } from "./machine-learning/supervised/FeedforwardNeuralNetwork";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -10,3 +10,5 @@ export { default as MulticlassLogisticRegression } from "./machine-learning/supe
 export { default as NaiveBayes } from "./machine-learning/supervised/NaiveBayes";
 export { default as NearestNeighbors } from "./machine-learning/supervised/NearestNeighbors";
 export { default as RandomForest } from "./machine-learning/supervised/RandomForest";
+export { default as SupportVectorMachine } from "./machine-learning/supervised/SupportVectorMachine";
+export type { Kernel } from "./machine-learning/supervised/SupportVectorMachine";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,4 @@
+export { default as AnomalyDetector } from "./machine-learning/unsupervised/AnomalyDetector";
 export { default as DBSCAN } from "./machine-learning/unsupervised/DBSCAN";
 export { default as DecisionTree } from "./machine-learning/supervised/DecisionTree";
 export type { DecisionTreeNode } from "./machine-learning/supervised/DecisionTree";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -17,6 +17,7 @@ export { default as MulticlassLogisticRegression } from "./machine-learning/supe
 export { default as NaiveBayes } from "./machine-learning/supervised/NaiveBayes";
 export { default as NearestNeighbors } from "./machine-learning/supervised/NearestNeighbors";
 export { default as PCA } from "./machine-learning/unsupervised/PCA";
+export { default as Perceptron } from "./machine-learning/supervised/Perceptron";
 export { default as RandomForest } from "./machine-learning/supervised/RandomForest";
 export { default as Recommender } from "./machine-learning/unsupervised/Recommender";
 export { default as SupportVectorMachine } from "./machine-learning/supervised/SupportVectorMachine";

--- a/src/lib/machine-learning/supervised/Perceptron.ts
+++ b/src/lib/machine-learning/supervised/Perceptron.ts
@@ -1,0 +1,117 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+
+/**
+ * The **perceptron** — a single artificial neuron, and the historical seed of every neural network.
+ * It computes one weighted sum of its inputs plus a bias, then fires (`1`) or doesn't (`0`) through
+ * a hard **step**: `output = (w · x + b ≥ 0) ? 1 : 0`. Its decision boundary is therefore a single
+ * straight line (or plane).
+ *
+ * It learns by the **perceptron rule**, not gradient descent: walk the examples, and whenever it
+ * gets one wrong, nudge the weights and bias *toward* that example's correct answer by
+ * `learningRate · (target − prediction) · x`. Rosenblatt's convergence theorem promises that if the
+ * two classes can be separated by a straight line, this finds such a line in a finite number of
+ * passes. The flip side — famously — is that if they *can't* (the XOR problem), it never settles: the
+ * line keeps lurching, forever. That limitation is exactly what stacking neurons into layers
+ * (a {@link FeedforwardNeuralNetwork}) overcomes.
+ *
+ * Targets are a single `0`/`1` column. Weights start at zero, so training is deterministic; like the
+ * other iterative models, repeated `train()` calls continue the same run (handy for animating the
+ * boundary as it learns).
+ *
+ * @example
+ * const perceptron = new Perceptron().setLearningRate(0.1).setNumberOfEpochs(20);
+ * perceptron.train(new Matrix([[0, 0], [0, 1], [1, 0], [1, 1]]), new Matrix([[0], [0], [0], [1]]));
+ * perceptron.predict(new Matrix([[1, 1]])).toArray(); // [[1]] — it learned AND
+ */
+export default class Perceptron {
+
+    private learningRate = 0.1;
+    private numberOfEpochs = 10;
+
+    private weights: number[];
+    private bias = 0;
+
+    public constructor () {}
+
+    public train (inputs: Matrix, targets: Matrix) {
+        const rows = inputs.toArray();
+        const labels = targets.toArray().map(row => (row[0] >= 0.5 ? 1 : 0));
+        const featureCount = rows.length > 0 ? rows[0].length : 0;
+
+        if (this.weights === undefined || this.weights.length !== featureCount) {
+            this.weights = new Array<number>(featureCount).fill(0);
+            this.bias = 0;
+        }
+
+        for (let epoch = 0; epoch < this.numberOfEpochs; epoch++) {
+            for (let i = 0; i < rows.length; i++) {
+                const prediction = this.activate(rows[i]);
+                const error = labels[i] - prediction; // -1, 0, or +1
+
+                if (error !== 0) {
+                    for (let f = 0; f < featureCount; f++) {
+                        this.weights[f] += this.learningRate * error * rows[i][f];
+                    }
+                    this.bias += this.learningRate * error;
+                }
+            }
+        }
+
+        return this;
+    }
+
+    /** The neuron's `0`/`1` output for each input row (step of the weighted sum). */
+    public predict (inputs: Matrix) {
+        return new Matrix(inputs.toArray().map(row => [this.activate(row)]));
+    }
+
+    public reset () {
+        this.weights = undefined;
+        this.bias = 0;
+        return this;
+    }
+
+    /* Parameter setters */
+
+    public setLearningRate (learningRate: number) {
+        this.learningRate = learningRate;
+        return this;
+    }
+
+    public setNumberOfEpochs (numberOfEpochs: number) {
+        this.numberOfEpochs = numberOfEpochs;
+        return this;
+    }
+
+    /* Parameter getters */
+
+    public getLearningRate () {
+        return this.learningRate;
+    }
+
+    public getNumberOfEpochs () {
+        return this.numberOfEpochs;
+    }
+
+    /** The learned weight per feature (a `1 × d` row), defining the orientation of the boundary line. */
+    public getWeights () {
+        return new Matrix([this.weights ? this.weights.slice() : []]);
+    }
+
+    public getBias () {
+        return this.bias;
+    }
+
+    /* Private methods */
+
+    private activate (row: number[]) {
+        if (this.weights === undefined) {
+            return 0;
+        }
+        let sum = this.bias;
+        for (let f = 0; f < this.weights.length; f++) {
+            sum += this.weights[f] * row[f];
+        }
+        return sum >= 0 ? 1 : 0;
+    }
+}

--- a/src/lib/machine-learning/supervised/SupportVectorMachine.ts
+++ b/src/lib/machine-learning/supervised/SupportVectorMachine.ts
@@ -1,0 +1,356 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+import mulberry32 from "../../math/random/mulberry32";
+
+/** The kernels the machine can score similarity with — a straight dot product, or one that bends space. */
+export type Kernel = "linear" | "rbf" | "polynomial";
+
+/**
+ * Binary **support vector machine**, trained with simplified SMO (sequential minimal optimization).
+ *
+ * Where logistic regression settles for *any* line that separates the two classes, an SVM hunts for
+ * the **max-margin** one — the boundary with the widest empty street between it and the nearest
+ * points. Only those nearest points, the **support vectors**, end up mattering; everything else
+ * could be deleted and the boundary wouldn't budge. The "softness" of the margin is set by `C`: a
+ * small `C` tolerates points inside the street (more slack, a wider, simpler boundary), a large `C`
+ * insists on getting them right.
+ *
+ * The whole thing is phrased in terms of a **kernel** — a similarity score between two points. With
+ * the `linear` kernel that's just the dot product and the boundary is a straight line. Swap in the
+ * `rbf` (Gaussian) or `polynomial` kernel — the **kernel trick** — and the very same algorithm
+ * carves curved boundaries no straight line could, without ever leaving the original features.
+ *
+ * Targets are a single column of `0`/`1` (like {@link LogisticRegression}); internally the classes
+ * are ±1. `predict` returns the raw **decision score** `f(x) = Σ αᵢ yᵢ K(xᵢ, x) + b` per row:
+ * its sign is the predicted class (≥ 0 → class 1) and its magnitude is how far past the margin the
+ * point sits. Training is deterministic for a fixed seed.
+ */
+export default class SupportVectorMachine {
+
+    private kernel: Kernel = "linear";
+    private regularization = 1;     // C — the soft-margin penalty for points inside/over the street
+    private gamma = 1;              // RBF width
+    private degree = 3;            // polynomial degree
+    private coefficient = 1;      // polynomial constant term (coef0)
+    private tolerance = 1e-3;     // KKT tolerance: how far a point may violate the margin before we act
+    private numberOfIterations = 20; // SMO sweeps over the data per train() call
+    private seed = 0;
+
+    // Learned state. The model is fully described by a coefficient αᵢ per training example (non-zero
+    // only for support vectors), the examples themselves, their ±1 labels, and the bias b.
+    private alphas: number[];
+    private bias = 0;
+    private inputs: number[][];
+    private labels: number[];
+    private kernelMatrix: number[][]; // cached Gram matrix K[i][j] over the training set
+
+    public constructor () {}
+
+    public train (inputs: Matrix, targets: Matrix) {
+        const rows = inputs.toArray();
+        const labels = targets.toArray().map(row => (row[0] >= 0.5 ? 1 : -1));
+        const exampleCount = rows.length;
+
+        // Initialise (or re-initialise when the dataset size changes) the dual coefficients. Like the
+        // regression models, repeated train() calls *continue* from where the last left off — handy
+        // for animating the optimisation a few sweeps at a time.
+        if (this.alphas === undefined || this.alphas.length !== exampleCount) {
+            this.alphas = new Array(exampleCount).fill(0);
+            this.bias = 0;
+            this.kernelMatrix = undefined;
+        }
+
+        this.inputs = rows;
+        this.labels = labels;
+
+        if (this.kernelMatrix === undefined) {
+            this.kernelMatrix = this.computeKernelMatrix(rows);
+        }
+
+        const random = mulberry32(this.seed);
+        for (let iteration = 0; iteration < this.numberOfIterations; iteration++) {
+            this.smoSweep(random);
+        }
+
+        return this;
+    }
+
+    public predict (inputs: Matrix) {
+        return new Matrix(inputs.toArray().map(row => [this.score(row)]));
+    }
+
+    public reset () {
+        this.alphas = undefined;
+        this.bias = 0;
+        this.kernelMatrix = undefined;
+        return this;
+    }
+
+    /* Parameter setters */
+
+    public setKernel (kernel: Kernel) {
+        this.kernel = kernel;
+        return this;
+    }
+
+    public setRegularization (regularization: number) {
+        this.regularization = regularization;
+        return this;
+    }
+
+    public setGamma (gamma: number) {
+        this.gamma = gamma;
+        return this;
+    }
+
+    public setDegree (degree: number) {
+        this.degree = degree;
+        return this;
+    }
+
+    public setCoefficient (coefficient: number) {
+        this.coefficient = coefficient;
+        return this;
+    }
+
+    public setTolerance (tolerance: number) {
+        this.tolerance = tolerance;
+        return this;
+    }
+
+    public setNumberOfIterations (numberOfIterations: number) {
+        this.numberOfIterations = numberOfIterations;
+        return this;
+    }
+
+    public setSeed (seed: number) {
+        this.seed = seed;
+        return this;
+    }
+
+    /* Parameter getters */
+
+    public getKernel () {
+        return this.kernel;
+    }
+
+    public getRegularization () {
+        return this.regularization;
+    }
+
+    public getGamma () {
+        return this.gamma;
+    }
+
+    public getDegree () {
+        return this.degree;
+    }
+
+    public getCoefficient () {
+        return this.coefficient;
+    }
+
+    public getTolerance () {
+        return this.tolerance;
+    }
+
+    public getNumberOfIterations () {
+        return this.numberOfIterations;
+    }
+
+    public getSeed () {
+        return this.seed;
+    }
+
+    public getBias () {
+        return this.bias;
+    }
+
+    /** Indices of the training rows that ended up as support vectors (a non-negligible αᵢ). */
+    public getSupportVectorIndices () {
+        if (this.alphas === undefined) {
+            return [];
+        }
+
+        const indices: number[] = [];
+        for (let i = 0; i < this.alphas.length; i++) {
+            if (this.alphas[i] > 1e-6) {
+                indices.push(i);
+            }
+        }
+        return indices;
+    }
+
+    /**
+     * Norm of the (implicit) weight vector, ‖w‖ = √(Σᵢ Σⱼ αᵢ αⱼ yᵢ yⱼ K(xᵢ, xⱼ)). The geometric
+     * margin — the half-width of the street — is `1 / ‖w‖`, so a *smaller* norm means a *wider*
+     * margin. Even with a non-linear kernel this is well defined (it lives in the kernel's feature
+     * space), it just stops being something you can draw as a single straight gap.
+     */
+    public getWeightNorm () {
+        const supportVectors = this.getSupportVectorIndices();
+        let sum = 0;
+        for (const i of supportVectors) {
+            for (const j of supportVectors) {
+                sum += this.alphas[i] * this.alphas[j] * this.labels[i] * this.labels[j] * this.kernelMatrix[i][j];
+            }
+        }
+        return Math.sqrt(Math.max(0, sum));
+    }
+
+    /* Private methods */
+
+    /**
+     * One SMO sweep. For each example whose margin violates the KKT conditions, pick a second
+     * example, then jointly nudge that pair of αs the most the box constraints `0 ≤ α ≤ C` allow —
+     * the smallest step the dual problem can take. Many such pairwise steps add up to the global
+     * max-margin solution. (Simplified SMO, after Platt 1998 / the CS229 notes: a random partner
+     * rather than the heuristic second-choice, which is plenty for teaching-scale data.)
+     */
+    private smoSweep (random: () => number) {
+        const exampleCount = this.inputs.length;
+        const alphas = this.alphas;
+        const labels = this.labels;
+        const kernelMatrix = this.kernelMatrix;
+        const c = this.regularization;
+        const tolerance = this.tolerance;
+
+        for (let i = 0; i < exampleCount; i++) {
+            const errorI = this.decision(i) - labels[i];
+
+            // Does example i break the KKT conditions enough to be worth a step?
+            if (!((labels[i] * errorI < -tolerance && alphas[i] < c) || (labels[i] * errorI > tolerance && alphas[i] > 0))) {
+                continue;
+            }
+
+            // A random partner j ≠ i, drawn uniformly.
+            let j = Math.floor(random() * (exampleCount - 1));
+            if (j >= i) {
+                j++;
+            }
+
+            const errorJ = this.decision(j) - labels[j];
+
+            const alphaIOld = alphas[i];
+            const alphaJOld = alphas[j];
+
+            // The box the pair must stay inside (so both αs keep 0 ≤ α ≤ C while αᵢyᵢ + αⱼyⱼ is held).
+            let low: number;
+            let high: number;
+            if (labels[i] !== labels[j]) {
+                low = Math.max(0, alphaJOld - alphaIOld);
+                high = Math.min(c, c + alphaJOld - alphaIOld);
+            } else {
+                low = Math.max(0, alphaIOld + alphaJOld - c);
+                high = Math.min(c, alphaIOld + alphaJOld);
+            }
+            if (low === high) {
+                continue;
+            }
+
+            // The second derivative of the objective along this pair; eta ≥ 0 means no proper minimum.
+            const eta = 2 * kernelMatrix[i][j] - kernelMatrix[i][i] - kernelMatrix[j][j];
+            if (eta >= 0) {
+                continue;
+            }
+
+            // Step αⱼ to the unconstrained optimum, then clip it back into the box.
+            let alphaJ = alphaJOld - (labels[j] * (errorI - errorJ)) / eta;
+            alphaJ = Math.min(high, Math.max(low, alphaJ));
+            if (Math.abs(alphaJ - alphaJOld) < 1e-5) {
+                continue;
+            }
+
+            // αᵢ moves the opposite way to keep the constraint Σ αₖyₖ = const intact.
+            const alphaI = alphaIOld + labels[i] * labels[j] * (alphaJOld - alphaJ);
+
+            alphas[i] = alphaI;
+            alphas[j] = alphaJ;
+
+            // Re-centre the bias so the two just-moved points sit correctly against the margin.
+            const biasI = this.bias - errorI - labels[i] * (alphaI - alphaIOld) * kernelMatrix[i][i] - labels[j] * (alphaJ - alphaJOld) * kernelMatrix[i][j];
+            const biasJ = this.bias - errorJ - labels[i] * (alphaI - alphaIOld) * kernelMatrix[i][j] - labels[j] * (alphaJ - alphaJOld) * kernelMatrix[j][j];
+
+            if (alphaI > 0 && alphaI < c) {
+                this.bias = biasI;
+            } else if (alphaJ > 0 && alphaJ < c) {
+                this.bias = biasJ;
+            } else {
+                this.bias = (biasI + biasJ) / 2;
+            }
+        }
+    }
+
+    /** Decision score for training example i, reusing the cached kernel matrix. */
+    private decision (i: number) {
+        const alphas = this.alphas;
+        const labels = this.labels;
+        const kernelRow = this.kernelMatrix;
+
+        let sum = this.bias;
+        for (let k = 0; k < alphas.length; k++) {
+            if (alphas[k] !== 0) {
+                sum += alphas[k] * labels[k] * kernelRow[k][i];
+            }
+        }
+        return sum;
+    }
+
+    /** Decision score for an arbitrary point — only the support vectors contribute. */
+    private score (point: number[]) {
+        const alphas = this.alphas;
+        if (alphas === undefined) {
+            return 0; // untrained: no boundary yet
+        }
+
+        let sum = this.bias;
+        for (let k = 0; k < alphas.length; k++) {
+            if (alphas[k] !== 0) {
+                sum += alphas[k] * this.labels[k] * this.applyKernel(this.inputs[k], point);
+            }
+        }
+        return sum;
+    }
+
+    private computeKernelMatrix (rows: number[][]) {
+        const exampleCount = rows.length;
+        const matrix: number[][] = [];
+        for (let i = 0; i < exampleCount; i++) {
+            matrix.push(new Array(exampleCount));
+        }
+        // K is symmetric, so only the upper triangle is computed and mirrored.
+        for (let i = 0; i < exampleCount; i++) {
+            for (let j = i; j < exampleCount; j++) {
+                const value = this.applyKernel(rows[i], rows[j]);
+                matrix[i][j] = value;
+                matrix[j][i] = value;
+            }
+        }
+        return matrix;
+    }
+
+    private applyKernel (a: number[], b: number[]) {
+        switch (this.kernel) {
+            case "rbf": {
+                let squaredDistance = 0;
+                for (let i = 0; i < a.length; i++) {
+                    const difference = a[i] - b[i];
+                    squaredDistance += difference * difference;
+                }
+                return Math.exp(-this.gamma * squaredDistance);
+            }
+            case "polynomial":
+                return Math.pow(dotProduct(a, b) + this.coefficient, this.degree);
+            case "linear":
+            default:
+                return dotProduct(a, b);
+        }
+    }
+}
+
+function dotProduct (a: number[], b: number[]) {
+    let sum = 0;
+    for (let i = 0; i < a.length; i++) {
+        sum += a[i] * b[i];
+    }
+    return sum;
+}

--- a/src/lib/machine-learning/time-series/ExponentialSmoothing.ts
+++ b/src/lib/machine-learning/time-series/ExponentialSmoothing.ts
@@ -1,0 +1,179 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+
+/**
+ * **Exponential smoothing** for time-series forecasting — Holt-Winters, the workhorse for "what
+ * happens next week?". Plain regression treats rows as an unordered bag of points; a time series is
+ * the opposite — the *order* is the signal, and the recent past matters more than the distant past.
+ * Exponential smoothing leans into that: every forecast is a weighted average of history where the
+ * weights fade exponentially into the past.
+ *
+ * It tracks up to three things, each its own running estimate updated as it walks the series:
+ * - **level** (`alpha`) — where the series is right now,
+ * - **trend** (`beta`) — which way and how fast it's drifting (set `beta = 0` to ignore trend), and
+ * - **seasonality** (`gamma`, `seasonLength`) — a repeating cycle, e.g. the weekly rhythm of a café
+ *   (`seasonLength = 7`); set `seasonLength` to 1 to ignore it.
+ *
+ * `train` takes the series as a column (one value per time step) and walks it once, settling those
+ * estimates. `predict(steps)` then extends them into the future: level, plus `steps` of trend, plus
+ * the matching point in the seasonal cycle. {@link getFitted} returns the one-step-ahead predictions
+ * over the history, for plotting the fit. Fully deterministic.
+ *
+ * @example
+ * const model = new ExponentialSmoothing().setAlpha(0.5).setSeasonLength(2);
+ * model.train(new Matrix([[10], [20], [10], [20], [10], [20]]));
+ * model.predict(2).toArray(); // ≈ [[10], [20]] — it learned the two-step cycle
+ */
+export default class ExponentialSmoothing {
+
+    private alpha = 0.5;     // level smoothing
+    private beta = 0;        // trend smoothing (0 → no trend term)
+    private gamma = 0.3;     // seasonal smoothing
+    private seasonLength = 1; // 1 → no seasonal term
+
+    private level = 0;
+    private trend = 0;
+    private seasonals: number[] = [];
+    private seriesLength = 0;
+    private fitted: number[] = [];
+
+    public constructor () {}
+
+    public train (inputs: Matrix) {
+        const series = inputs.toArray().map(row => row[0]);
+        const n = series.length;
+        const m = this.seasonLength;
+        const seasonal = m >= 2;
+        const useTrend = this.beta > 0;
+
+        this.seriesLength = n;
+        this.fitted = [];
+        this.seasonals = [];
+
+        if (n === 0) {
+            return this;
+        }
+
+        // Seed the estimates: level from the first season's average, trend from the gap to the next
+        // season, and one seasonal offset per phase.
+        let level: number;
+        let trend = 0;
+        const seasonals = new Array<number>(seasonal ? m : 0).fill(0);
+
+        if (seasonal) {
+            level = mean(series.slice(0, m));
+            if (useTrend && n >= 2 * m) {
+                trend = (mean(series.slice(m, 2 * m)) - mean(series.slice(0, m))) / m;
+            }
+            for (let i = 0; i < m; i++) {
+                seasonals[i] = series[i] - level;
+            }
+        } else {
+            level = series[0];
+            if (useTrend && n >= 2) {
+                trend = series[1] - series[0];
+            }
+        }
+
+        // Walk the series, updating level / trend / season and recording each one-step-ahead forecast.
+        for (let t = 0; t < n; t++) {
+            const previousLevel = level;
+            const previousTrend = trend;
+            const season = seasonal ? seasonals[t % m] : 0;
+
+            this.fitted.push(previousLevel + (useTrend ? previousTrend : 0) + season);
+
+            level = this.alpha * (series[t] - season) + (1 - this.alpha) * (previousLevel + (useTrend ? previousTrend : 0));
+            if (useTrend) {
+                trend = this.beta * (level - previousLevel) + (1 - this.beta) * previousTrend;
+            }
+            if (seasonal) {
+                seasonals[t % m] = this.gamma * (series[t] - level) + (1 - this.gamma) * season;
+            }
+        }
+
+        this.level = level;
+        this.trend = trend;
+        this.seasonals = seasonals;
+        return this;
+    }
+
+    /** Forecast the next `steps` values: level + accumulated trend + the matching seasonal offset. */
+    public predict (steps: number) {
+        const m = this.seasonLength;
+        const seasonal = m >= 2;
+        const useTrend = this.beta > 0;
+
+        const forecast: number[][] = [];
+        for (let h = 1; h <= steps; h++) {
+            const season = seasonal ? this.seasonals[(this.seriesLength + h - 1) % m] : 0;
+            forecast.push([this.level + (useTrend ? h * this.trend : 0) + season]);
+        }
+        return new Matrix(forecast);
+    }
+
+    /* Parameter setters */
+
+    public setAlpha (alpha: number) {
+        this.alpha = alpha;
+        return this;
+    }
+
+    public setBeta (beta: number) {
+        this.beta = beta;
+        return this;
+    }
+
+    public setGamma (gamma: number) {
+        this.gamma = gamma;
+        return this;
+    }
+
+    public setSeasonLength (seasonLength: number) {
+        this.seasonLength = seasonLength;
+        return this;
+    }
+
+    /* Parameter getters */
+
+    public getAlpha () {
+        return this.alpha;
+    }
+
+    public getBeta () {
+        return this.beta;
+    }
+
+    public getGamma () {
+        return this.gamma;
+    }
+
+    public getSeasonLength () {
+        return this.seasonLength;
+    }
+
+    /** The one-step-ahead predictions over the training series, for plotting the fit. */
+    public getFitted () {
+        return new Matrix(this.fitted.map(value => [value]));
+    }
+
+    /** The final level estimate (where the series ended up). */
+    public getLevel () {
+        return this.level;
+    }
+
+    /** The final trend estimate (per-step drift). */
+    public getTrend () {
+        return this.trend;
+    }
+}
+
+function mean (values: number[]) {
+    if (values.length === 0) {
+        return 0;
+    }
+    let sum = 0;
+    for (const value of values) {
+        sum += value;
+    }
+    return sum / values.length;
+}

--- a/src/lib/machine-learning/unsupervised/AnomalyDetector.ts
+++ b/src/lib/machine-learning/unsupervised/AnomalyDetector.ts
@@ -1,0 +1,129 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+
+/**
+ * **Anomaly detection** by fitting a multivariate Gaussian to the data and flagging the points it
+ * finds least likely. The premise is the mirror image of clustering: instead of asking "which group
+ * is this in?", it learns what **normal** looks like — a centre and a spread — and then asks "how
+ * far outside normal is this?". Rare events (fraud, a spoiled batch, a sensor glitch) sit far out in
+ * the tails and get flagged; the bulk of ordinary points do not.
+ *
+ * "How far out" is measured by the **Mahalanobis distance** — Euclidean distance warped by the data's
+ * covariance, so it counts standard deviations *in the data's own shape*, not raw units. A point two
+ * steps off along the direction the data naturally spreads is unremarkable; the same two steps across
+ * that grain is glaring. `train` estimates the mean and (slightly regularised) covariance; `score`
+ * returns each point's Mahalanobis distance; `predict` flags the ones past `threshold` as `1`,
+ * everything else `0`.
+ *
+ * Like the clustering models it takes inputs with **no targets** (it assumes the training data is
+ * mostly normal). Fully deterministic.
+ *
+ * @example
+ * const detector = new AnomalyDetector().setThreshold(3);
+ * detector.train(new Matrix([[0, 0], [1, 0], [0, 1], [-1, 0], [0, -1]]));
+ * detector.predict(new Matrix([[0, 0], [8, 8]])).toArray(); // [[0], [1]] — the far point is anomalous
+ */
+export default class AnomalyDetector {
+
+    private threshold = 3;
+
+    private mean: number[] = [];
+    private inverseCovariance: number[][] = [];
+
+    public constructor () {}
+
+    public train (inputs: Matrix) {
+        const rows = inputs.toArray();
+        const n = rows.length;
+        const d = n > 0 ? rows[0].length : 0;
+
+        this.mean = columnMeans(rows, d);
+        const centered = rows.map(row => row.map((value, j) => value - this.mean[j]));
+
+        // Covariance, with a small ridge on the diagonal so it's always invertible (e.g. when a
+        // feature is constant or two features are perfectly collinear).
+        const covariance = covarianceMatrix(centered, d);
+        for (let i = 0; i < d; i++) {
+            covariance[i][i] += 1e-6;
+        }
+
+        this.inverseCovariance = new Matrix(covariance).getInverse().toArray();
+        return this;
+    }
+
+    /** Mahalanobis distance of each input from the fitted centre — the anomaly score. */
+    public score (inputs: Matrix) {
+        return new Matrix(inputs.toArray().map(row => [this.mahalanobis(row)]));
+    }
+
+    /** Flags each input: `1` if its score exceeds `threshold` (anomalous), `0` otherwise. */
+    public predict (inputs: Matrix) {
+        return new Matrix(inputs.toArray().map(row => [this.mahalanobis(row) > this.threshold ? 1 : 0]));
+    }
+
+    /* Parameter setters */
+
+    public setThreshold (threshold: number) {
+        this.threshold = threshold;
+        return this;
+    }
+
+    /* Parameter getters */
+
+    public getThreshold () {
+        return this.threshold;
+    }
+
+    /** The fitted centre of "normal" (the per-feature mean). */
+    public getMean () {
+        return new Matrix([this.mean.slice()]);
+    }
+
+    /* Private methods */
+
+    private mahalanobis (row: number[]) {
+        const difference = row.map((value, j) => value - this.mean[j]);
+        const inverse = this.inverseCovariance;
+
+        // squared distance = diffᵀ · Σ⁻¹ · diff
+        let squared = 0;
+        for (let i = 0; i < difference.length; i++) {
+            let inner = 0;
+            for (let j = 0; j < difference.length; j++) {
+                inner += inverse[i][j] * difference[j];
+            }
+            squared += difference[i] * inner;
+        }
+
+        return Math.sqrt(Math.max(0, squared));
+    }
+}
+
+function columnMeans (rows: number[][], d: number) {
+    const means = new Array<number>(d).fill(0);
+    for (const row of rows) {
+        for (let j = 0; j < d; j++) {
+            means[j] += row[j];
+        }
+    }
+    return means.map(sum => (rows.length > 0 ? sum / rows.length : 0));
+}
+
+function covarianceMatrix (centered: number[][], d: number) {
+    const n = centered.length;
+    const covariance = Array.from({ length: d }, () => new Array<number>(d).fill(0));
+    for (const row of centered) {
+        for (let i = 0; i < d; i++) {
+            for (let j = i; j < d; j++) {
+                covariance[i][j] += row[i] * row[j];
+            }
+        }
+    }
+    const divisor = n > 1 ? n - 1 : 1;
+    for (let i = 0; i < d; i++) {
+        for (let j = i; j < d; j++) {
+            covariance[i][j] /= divisor;
+            covariance[j][i] = covariance[i][j];
+        }
+    }
+    return covariance;
+}

--- a/src/lib/machine-learning/unsupervised/AssociationRules.ts
+++ b/src/lib/machine-learning/unsupervised/AssociationRules.ts
@@ -1,0 +1,254 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+
+/** A frequent itemset: a set of item indices that co-occur in at least `minSupport` of baskets. */
+export interface FrequentItemset {
+    items: number[];
+    support: number;
+}
+
+/**
+ * An association rule `antecedent → consequent` with its three classic strength measures:
+ * - **support** — fraction of all baskets containing the whole rule (how common it is),
+ * - **confidence** — of baskets with the antecedent, the fraction that also have the consequent
+ *   (how reliable it is), and
+ * - **lift** — confidence divided by the consequent's own support (how much more often they appear
+ *   together than chance alone would predict; `> 1` means a real positive association).
+ */
+export interface AssociationRule {
+    antecedent: number[];
+    consequent: number[];
+    support: number;
+    confidence: number;
+    lift: number;
+}
+
+/**
+ * **Association rule mining** by the **Apriori** algorithm — the "market basket" model. Where every
+ * other method here treats a row as a point in space, this one treats it as a **basket**: a set of
+ * items that were bought (or events that happened) together. It hunts for the patterns *"customers
+ * who get X tend to also get Y"* — the coffee-and-croissant combos hiding in the receipts.
+ *
+ * Apriori works in two stages. First it finds the **frequent itemsets** — sets of items that appear
+ * together in at least `minSupport` of baskets — growing them one item at a time and leaning on the
+ * key shortcut that *a set can only be frequent if all of its subsets are* (so it never wastes time
+ * counting a pair whose halves are already rare). Then it turns each frequent itemset into candidate
+ * **rules** and keeps the ones whose `confidence` clears the bar, reporting support, confidence, and
+ * lift for each.
+ *
+ * Input is a binary **basket matrix**: one row per basket, one column per item, `1` if the basket
+ * holds that item. It takes no targets. `predict` completes a basket — for each row it scores the
+ * items *not* present by the confidence of the best rule that fires, i.e. "what to suggest next".
+ *
+ * @example
+ * const rules = new AssociationRules().setMinSupport(0.4).setMinConfidence(0.6);
+ * rules.train(new Matrix([[1, 1, 0], [1, 1, 1], [1, 0, 0], [1, 1, 0]]));
+ * rules.getRules(); // e.g. [{ antecedent: [1], consequent: [0], confidence: 1, lift: 1.33, … }]
+ */
+export default class AssociationRules {
+
+    private minSupport = 0.1;
+    private minConfidence = 0.5;
+    private maxItemsetSize = 3;
+
+    private itemCount = 0;
+    private frequentItemsets: FrequentItemset[] = [];
+    private rules: AssociationRule[] = [];
+    private supportByKey = new Map<string, number>();
+
+    public constructor () {}
+
+    public train (inputs: Matrix) {
+        const rows = inputs.toArray();
+        const n = rows.length;
+        this.itemCount = n > 0 ? rows[0].length : 0;
+
+        // Each basket as a set of the item indices it contains.
+        const baskets = rows.map(row => {
+            const set = new Set<number>();
+            for (let i = 0; i < row.length; i++) {
+                if (row[i] >= 0.5) {
+                    set.add(i);
+                }
+            }
+            return set;
+        });
+
+        const minCount = this.minSupport * n;
+        this.frequentItemsets = [];
+        this.supportByKey = new Map();
+
+        // Stage 1, level 1: the frequent single items.
+        const singleCounts = new Array<number>(this.itemCount).fill(0);
+        for (const basket of baskets) {
+            for (const item of basket) {
+                singleCounts[item]++;
+            }
+        }
+        const frequentSingles: number[] = [];
+        let current: number[][] = [];
+        for (let i = 0; i < this.itemCount; i++) {
+            if (n > 0 && singleCounts[i] >= minCount) {
+                frequentSingles.push(i);
+                current.push([i]);
+                this.record([i], singleCounts[i] / n);
+            }
+        }
+
+        // Stage 1, levels 2..maxItemsetSize: grow frequent sets one item at a time.
+        for (let k = 2; k <= this.maxItemsetSize && current.length > 0; k++) {
+            const candidates = generateCandidates(current, frequentSingles);
+            const next: number[][] = [];
+            for (const candidate of candidates) {
+                let count = 0;
+                for (const basket of baskets) {
+                    if (candidate.every(item => basket.has(item))) {
+                        count++;
+                    }
+                }
+                if (count >= minCount) {
+                    next.push(candidate);
+                    this.record(candidate, count / n);
+                }
+            }
+            current = next;
+        }
+
+        // Stage 2: turn frequent itemsets into rules that clear the confidence bar.
+        this.rules = [];
+        for (const itemset of this.frequentItemsets) {
+            if (itemset.items.length < 2) {
+                continue;
+            }
+            for (const antecedent of nonEmptyProperSubsets(itemset.items)) {
+                const consequent = itemset.items.filter(item => !antecedent.includes(item));
+                const confidence = itemset.support / this.support(antecedent);
+                if (confidence >= this.minConfidence) {
+                    const lift = confidence / this.support(consequent);
+                    this.rules.push({ antecedent, consequent, support: itemset.support, confidence, lift });
+                }
+            }
+        }
+        this.rules.sort((a, b) => b.lift - a.lift || b.confidence - a.confidence);
+
+        return this;
+    }
+
+    /**
+     * Basket completion: for each input basket, a score per item it does *not* already contain —
+     * the confidence of the strongest rule whose antecedent the basket satisfies and whose
+     * consequent is that item (0 if no rule fires, or the item is already present).
+     */
+    public predict (inputs: Matrix) {
+        return new Matrix(inputs.toArray().map(row => {
+            const present = new Set<number>();
+            for (let i = 0; i < row.length; i++) {
+                if (row[i] >= 0.5) {
+                    present.add(i);
+                }
+            }
+
+            const scores = new Array<number>(this.itemCount).fill(0);
+            for (const rule of this.rules) {
+                if (rule.consequent.length !== 1) {
+                    continue;
+                }
+                const item = rule.consequent[0];
+                if (present.has(item)) {
+                    continue;
+                }
+                if (rule.antecedent.every(a => present.has(a)) && rule.confidence > scores[item]) {
+                    scores[item] = rule.confidence;
+                }
+            }
+            return scores;
+        }));
+    }
+
+    /* Parameter setters */
+
+    public setMinSupport (minSupport: number) {
+        this.minSupport = minSupport;
+        return this;
+    }
+
+    public setMinConfidence (minConfidence: number) {
+        this.minConfidence = minConfidence;
+        return this;
+    }
+
+    public setMaxItemsetSize (maxItemsetSize: number) {
+        this.maxItemsetSize = maxItemsetSize;
+        return this;
+    }
+
+    /* Parameter getters */
+
+    public getMinSupport () {
+        return this.minSupport;
+    }
+
+    public getMinConfidence () {
+        return this.minConfidence;
+    }
+
+    public getMaxItemsetSize () {
+        return this.maxItemsetSize;
+    }
+
+    /** Every itemset that cleared `minSupport`, with its support. */
+    public getFrequentItemsets (): FrequentItemset[] {
+        return this.frequentItemsets.map(itemset => ({ items: itemset.items.slice(), support: itemset.support }));
+    }
+
+    /** Every rule that cleared `minConfidence`, sorted strongest (highest lift) first. */
+    public getRules (): AssociationRule[] {
+        return this.rules.map(rule => ({ ...rule, antecedent: rule.antecedent.slice(), consequent: rule.consequent.slice() }));
+    }
+
+    /* Private methods */
+
+    private record (items: number[], support: number) {
+        this.frequentItemsets.push({ items, support });
+        this.supportByKey.set(items.join(","), support);
+    }
+
+    private support (items: number[]) {
+        return this.supportByKey.get(items.join(",")) ?? 0;
+    }
+}
+
+/** Grow size-k candidates by adding each frequent single item to a frequent (k-1)-itemset. */
+function generateCandidates (previous: number[][], frequentSingles: number[]) {
+    const seen = new Set<string>();
+    const candidates: number[][] = [];
+    for (const itemset of previous) {
+        for (const item of frequentSingles) {
+            if (itemset.includes(item)) {
+                continue;
+            }
+            const candidate = [...itemset, item].sort((a, b) => a - b);
+            const key = candidate.join(",");
+            if (!seen.has(key)) {
+                seen.add(key);
+                candidates.push(candidate);
+            }
+        }
+    }
+    return candidates;
+}
+
+/** All subsets of a sorted itemset except the empty set and the whole set (order preserved). */
+function nonEmptyProperSubsets (items: number[]) {
+    const subsets: number[][] = [];
+    const total = 1 << items.length;
+    for (let mask = 1; mask < total - 1; mask++) {
+        const subset: number[] = [];
+        for (let i = 0; i < items.length; i++) {
+            if (mask & (1 << i)) {
+                subset.push(items[i]);
+            }
+        }
+        subsets.push(subset);
+    }
+    return subsets;
+}

--- a/src/lib/machine-learning/unsupervised/DBSCAN.ts
+++ b/src/lib/machine-learning/unsupervised/DBSCAN.ts
@@ -1,0 +1,184 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+
+/**
+ * **DBSCAN** (density-based spatial clustering of applications with noise) — clustering by *density*
+ * instead of distance to a centre. Where k-means and hierarchical clustering force every point into
+ * some group, DBSCAN's whole idea is that some points are just **noise**: stragglers and one-offs
+ * that belong to no cluster at all.
+ *
+ * Two knobs define "dense enough": a radius `epsilon` and a count `minPoints`. A point is a **core**
+ * point if at least `minPoints` points (itself included) lie within `epsilon`. Clusters grow by
+ * chaining through core points — any point within `epsilon` of a core joins its cluster — so a
+ * cluster can be any shape that stays dense (curves, rings, blobs). Points reachable from a core but
+ * not core themselves are **border** points; points reachable from no core are **noise**.
+ *
+ * Unlike k-means there is no `k`: the number of clusters falls out of the data. Like the other
+ * unsupervised models it is handed inputs with **no targets**. `predict` returns one integer label
+ * per row — `0..clusterCount-1` for a cluster, or `-1` for noise; a query point takes the cluster of
+ * its nearest core point if that core is within `epsilon`, otherwise noise.
+ *
+ * @example
+ * const dbscan = new DBSCAN().setEpsilon(0.5).setMinPoints(3);
+ * dbscan.train(new Matrix([[0, 0], [0.1, 0], [0, 0.1], [9, 9]]));
+ * dbscan.getLabels();        // e.g. [0, 0, 0, -1]  ← three dense points, one noise
+ * dbscan.getClusterCount();  // 1
+ */
+export default class DBSCAN {
+
+    /** Label for points that belong to no cluster. */
+    public static readonly NOISE = -1;
+
+    private epsilon = 0.5;
+    private minPoints = 4;
+
+    private points: number[][] = [];
+    private pointCount = 0;
+    private labels: number[] = [];
+    private coreIndices: number[] = [];
+    private clusterCount = 0;
+
+    public constructor () {}
+
+    public train (inputs: Matrix) {
+        const points = inputs.toArray();
+        const n = points.length;
+
+        this.points = points;
+        this.pointCount = n;
+        this.clusterCount = 0;
+        this.coreIndices = [];
+
+        const UNCLASSIFIED = -2;
+        this.labels = new Array<number>(n).fill(UNCLASSIFIED);
+
+        if (n === 0) {
+            return this;
+        }
+
+        // Pre-compute each point's epsilon-neighbourhood (including itself) and flag the core points.
+        const neighbours: number[][] = [];
+        const isCore: boolean[] = [];
+        for (let i = 0; i < n; i++) {
+            const nb: number[] = [];
+            for (let j = 0; j < n; j++) {
+                if (euclidean(points[i], points[j]) <= this.epsilon) {
+                    nb.push(j);
+                }
+            }
+            neighbours.push(nb);
+            isCore.push(nb.length >= this.minPoints);
+        }
+
+        let clusterId = 0;
+        for (let p = 0; p < n; p++) {
+            // Only an unclassified *core* point can start a new cluster; non-core points are left to
+            // be claimed as borders during expansion (or fall through to noise).
+            if (this.labels[p] !== UNCLASSIFIED || !isCore[p]) {
+                continue;
+            }
+
+            this.labels[p] = clusterId;
+
+            // Flood-fill the cluster: walk the neighbourhood, and wherever it passes through another
+            // core point, fold that point's neighbours into the frontier too.
+            const seeds = [...neighbours[p]];
+            const queued = new Set<number>(seeds);
+            for (let s = 0; s < seeds.length; s++) {
+                const q = seeds[s];
+                if (this.labels[q] !== UNCLASSIFIED) {
+                    continue;
+                }
+                this.labels[q] = clusterId;
+                if (isCore[q]) {
+                    for (const r of neighbours[q]) {
+                        if (!queued.has(r)) {
+                            queued.add(r);
+                            seeds.push(r);
+                        }
+                    }
+                }
+            }
+
+            clusterId++;
+        }
+
+        for (let i = 0; i < n; i++) {
+            if (this.labels[i] === UNCLASSIFIED) {
+                this.labels[i] = DBSCAN.NOISE;
+            }
+            if (isCore[i]) {
+                this.coreIndices.push(i);
+            }
+        }
+
+        this.clusterCount = clusterId;
+        return this;
+    }
+
+    /**
+     * One integer label per input row: `0..clusterCount-1` for a cluster, or `-1` for noise. A query
+     * is assigned the cluster of its nearest core point when that core lies within `epsilon`.
+     */
+    public predict (inputs: Matrix) {
+        const queries = inputs.toArray();
+        return new Matrix(queries.map(query => [this.labelFor(query)]));
+    }
+
+    /* Parameter setters */
+
+    public setEpsilon (epsilon: number) {
+        this.epsilon = epsilon;
+        return this;
+    }
+
+    public setMinPoints (minPoints: number) {
+        this.minPoints = minPoints;
+        return this;
+    }
+
+    /* Parameter getters */
+
+    public getEpsilon () {
+        return this.epsilon;
+    }
+
+    public getMinPoints () {
+        return this.minPoints;
+    }
+
+    /** The cluster label of each training point (`-1` for noise). */
+    public getLabels () {
+        return this.labels.slice();
+    }
+
+    /** How many clusters DBSCAN discovered (noise is not a cluster). */
+    public getClusterCount () {
+        return this.clusterCount;
+    }
+
+    /* Private methods */
+
+    private labelFor (query: number[]) {
+        let nearestDistance = Number.POSITIVE_INFINITY;
+        let nearestLabel = DBSCAN.NOISE;
+
+        for (const coreIndex of this.coreIndices) {
+            const distance = euclidean(query, this.points[coreIndex]);
+            if (distance < nearestDistance) {
+                nearestDistance = distance;
+                nearestLabel = this.labels[coreIndex];
+            }
+        }
+
+        return nearestDistance <= this.epsilon ? nearestLabel : DBSCAN.NOISE;
+    }
+}
+
+function euclidean (a: number[], b: number[]) {
+    let sum = 0;
+    for (let i = 0; i < a.length; i++) {
+        const difference = a[i] - b[i];
+        sum += difference * difference;
+    }
+    return Math.sqrt(sum);
+}

--- a/src/lib/machine-learning/unsupervised/HierarchicalClustering.ts
+++ b/src/lib/machine-learning/unsupervised/HierarchicalClustering.ts
@@ -1,0 +1,280 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+
+/** How the distance between two *clusters* is measured from the distances between their members. */
+export type Linkage = "single" | "complete" | "average";
+
+/**
+ * One merge in the dendrogram: the two nodes that joined, the distance at which they joined, and
+ * the size of the resulting cluster. Leaf nodes are ids `0..n-1` (the original points); merge `t`
+ * creates internal node id `n + t`. `distance` is non-decreasing across the merge sequence.
+ */
+export interface HierarchicalMerge {
+    left: number;
+    right: number;
+    distance: number;
+    size: number;
+}
+
+/**
+ * **Agglomerative hierarchical clustering** — the second unsupervised model. Where k-means needs to
+ * be told `k` up front and only finds round blobs, this one **grows** the groups bottom-up and
+ * defers the choice of how many: start with every point as its own cluster, then repeatedly merge
+ * the two **closest** clusters until only one remains. The whole history of merges is a tree — a
+ * **dendrogram** — and you read off any number of clusters by slicing it at a height.
+ *
+ * "Closest" depends on the **linkage**: `single` uses the nearest pair of members (so clusters can
+ * chain along curves), `complete` the farthest pair (compact, round-ish clusters), `average` the
+ * mean over all member pairs (a balance). Distances are merged efficiently with the Lance–Williams
+ * update, so the full tree costs one pass — after which cutting to any `k` is instant.
+ *
+ * Like {@link KMeans} it is handed inputs with **no targets**. `predict` returns one-hot cluster
+ * membership (the tree cut at {@link setNumberOfClusters}); a query point takes the cluster of its
+ * nearest training point, so the regions follow the data's shape rather than collapsing to round cells.
+ *
+ * @example
+ * const hc = new HierarchicalClustering().setNumberOfClusters(2).setLinkage('average');
+ * hc.train(new Matrix([[0, 0], [0, 1], [10, 10], [10, 11]]));
+ * hc.predict(new Matrix([[0, 0], [10, 10]])); // one-hot membership, e.g. [[1, 0], [0, 1]]
+ * hc.getMergeHistory();                        // the dendrogram, as a list of merges
+ */
+export default class HierarchicalClustering {
+
+    private numberOfClusters = 2;
+    private linkage: Linkage = "average";
+
+    private points: number[][] = [];
+    private pointCount = 0;
+    private merges: Merge[] = []; // length n-1, in merge order (ascending distance)
+
+    public constructor () {}
+
+    public train (inputs: Matrix) {
+        const points = inputs.toArray();
+        const n = points.length;
+
+        this.points = points;
+        this.pointCount = n;
+        this.merges = [];
+
+        if (n < 2) {
+            return this;
+        }
+
+        // Each point starts as its own active cluster. We track, per active cluster id: its size,
+        // a representative original point (for the union-find cut later), and its distance to every
+        // other active cluster.
+        const active = new Set<number>();
+        const size = new Map<number, number>();
+        const representative = new Map<number, number>();
+        const distances = new Map<number, Map<number, number>>();
+
+        for (let i = 0; i < n; i++) {
+            active.add(i);
+            size.set(i, 1);
+            representative.set(i, i);
+            distances.set(i, new Map());
+        }
+        for (let i = 0; i < n; i++) {
+            for (let j = i + 1; j < n; j++) {
+                const distance = euclidean(points[i], points[j]);
+                distances.get(i)!.set(j, distance);
+                distances.get(j)!.set(i, distance);
+            }
+        }
+
+        let nextId = n;
+        while (active.size > 1) {
+            const [a, b, distance] = this.closestPair(active, distances);
+            const newId = nextId++;
+            const sizeA = size.get(a)!;
+            const sizeB = size.get(b)!;
+
+            this.merges.push({
+                left: a,
+                right: b,
+                distance,
+                size: sizeA + sizeB,
+                representativeA: representative.get(a)!,
+                representativeB: representative.get(b)!,
+            });
+
+            // Lance–Williams: the merged cluster's distance to each other cluster is a simple
+            // combination of the two old distances, so we never revisit the raw points.
+            const newDistances = new Map<number, number>();
+            distances.set(newId, newDistances);
+            for (const c of active) {
+                if (c === a || c === b) {
+                    continue;
+                }
+                const merged = this.linkageDistance(distances.get(a)!.get(c)!, distances.get(b)!.get(c)!, sizeA, sizeB);
+                newDistances.set(c, merged);
+                distances.get(c)!.set(newId, merged);
+            }
+
+            size.set(newId, sizeA + sizeB);
+            representative.set(newId, representative.get(a)!);
+
+            active.delete(a);
+            active.delete(b);
+            active.add(newId);
+            distances.delete(a);
+            distances.delete(b);
+            for (const c of active) {
+                if (c !== newId) {
+                    distances.get(c)!.delete(a);
+                    distances.get(c)!.delete(b);
+                }
+            }
+        }
+
+        return this;
+    }
+
+    /**
+     * One-hot cluster membership (one column per cluster), the tree cut at `numberOfClusters`.
+     * Arbitrary query points are assigned the cluster of their nearest training point.
+     */
+    public predict (inputs: Matrix) {
+        const labels = this.clusterLabels(this.numberOfClusters);
+        const queries = inputs.toArray();
+
+        const outputs = Matrix.zeros(queries.length, this.numberOfClusters);
+        for (let i = 0; i < queries.length; i++) {
+            const nearest = this.nearestTrainingIndex(queries[i]);
+            outputs.setElement(i, labels[nearest], 1);
+        }
+        return outputs;
+    }
+
+    /* Parameter setters */
+
+    public setNumberOfClusters (numberOfClusters: number) {
+        this.numberOfClusters = numberOfClusters;
+        return this;
+    }
+
+    public setLinkage (linkage: Linkage) {
+        this.linkage = linkage;
+        return this;
+    }
+
+    /* Parameter getters */
+
+    public getNumberOfClusters () {
+        return this.numberOfClusters;
+    }
+
+    public getLinkage () {
+        return this.linkage;
+    }
+
+    /** The cluster index of each training point, for the tree cut at `numberOfClusters`. */
+    public getClusterLabels () {
+        return this.clusterLabels(this.numberOfClusters);
+    }
+
+    /** The full merge sequence (the dendrogram), in ascending order of merge distance. */
+    public getMergeHistory (): HierarchicalMerge[] {
+        return this.merges.map(merge => ({ left: merge.left, right: merge.right, distance: merge.distance, size: merge.size }));
+    }
+
+    /* Private methods */
+
+    /** The two active clusters separated by the smallest linkage distance. */
+    private closestPair (active: Set<number>, distances: Map<number, Map<number, number>>): [number, number, number] {
+        const ids = [...active];
+        let bestA = ids[0];
+        let bestB = ids[1];
+        let best = Number.POSITIVE_INFINITY;
+
+        for (let x = 0; x < ids.length; x++) {
+            for (let y = x + 1; y < ids.length; y++) {
+                const distance = distances.get(ids[x])!.get(ids[y])!;
+                if (distance < best) {
+                    best = distance;
+                    bestA = ids[x];
+                    bestB = ids[y];
+                }
+            }
+        }
+
+        return [bestA, bestB, best];
+    }
+
+    private linkageDistance (distanceAC: number, distanceBC: number, sizeA: number, sizeB: number) {
+        switch (this.linkage) {
+            case "single":
+                return Math.min(distanceAC, distanceBC);
+            case "complete":
+                return Math.max(distanceAC, distanceBC);
+            case "average":
+            default:
+                // UPGMA: weight each side by its cluster size so it tracks the true mean over pairs.
+                return (sizeA * distanceAC + sizeB * distanceBC) / (sizeA + sizeB);
+        }
+    }
+
+    /**
+     * Cuts the dendrogram to `k` clusters and labels every training point. Replaying the first
+     * `n − k` merges with a union-find leaves exactly `k` connected components; they are relabelled
+     * `0..k-1` in order of first appearance (stable colours).
+     */
+    private clusterLabels (k: number) {
+        const n = this.pointCount;
+        const parent = Array.from({ length: n }, (_, i) => i);
+
+        const find = (x: number): number => {
+            while (parent[x] !== x) {
+                parent[x] = parent[parent[x]];
+                x = parent[x];
+            }
+            return x;
+        };
+
+        const mergeCount = Math.min(this.merges.length, Math.max(0, n - k));
+        for (let t = 0; t < mergeCount; t++) {
+            parent[find(this.merges[t].representativeA)] = find(this.merges[t].representativeB);
+        }
+
+        const labelByRoot = new Map<number, number>();
+        let next = 0;
+        const labels = new Array<number>(n);
+        for (let i = 0; i < n; i++) {
+            const root = find(i);
+            if (!labelByRoot.has(root)) {
+                labelByRoot.set(root, next++);
+            }
+            labels[i] = labelByRoot.get(root)!;
+        }
+        return labels;
+    }
+
+    private nearestTrainingIndex (query: number[]) {
+        let nearestIndex = 0;
+        let nearestDistance = Number.POSITIVE_INFINITY;
+
+        for (let i = 0; i < this.points.length; i++) {
+            const distance = euclidean(query, this.points[i]);
+            if (distance < nearestDistance) {
+                nearestDistance = distance;
+                nearestIndex = i;
+            }
+        }
+        return nearestIndex;
+    }
+}
+
+/** Internal merge record — the public {@link HierarchicalMerge} plus the union-find representatives. */
+interface Merge extends HierarchicalMerge {
+    representativeA: number;
+    representativeB: number;
+}
+
+function euclidean (a: number[], b: number[]) {
+    let sum = 0;
+    for (let i = 0; i < a.length; i++) {
+        const difference = a[i] - b[i];
+        sum += difference * difference;
+    }
+    return Math.sqrt(sum);
+}

--- a/src/lib/machine-learning/unsupervised/PCA.ts
+++ b/src/lib/machine-learning/unsupervised/PCA.ts
@@ -1,0 +1,247 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+
+/**
+ * **Principal Component Analysis** — the library's dimensionality-reduction model. Clustering asks
+ * *"which group?"*; PCA asks a different unsupervised question: *"what are the few directions along
+ * which the data actually varies?"* Those directions — the **principal components** — let you
+ * squeeze many correlated features down to a handful you can plot, with the least information lost.
+ *
+ * It works by finding the axes of greatest variance. Centre the data, build its covariance matrix,
+ * and take that matrix's eigenvectors: the eigenvector with the largest eigenvalue is the direction
+ * the data spreads most (the 1st component), the next-largest is the best direction perpendicular to
+ * it, and so on. Keeping the top `k` and projecting onto them turns each `d`-dimensional row into a
+ * `k`-dimensional one. The eigenvalues say how much variance each component captures — so you can
+ * read off exactly how much you kept.
+ *
+ * Like the clustering models it takes inputs with **no targets**. `predict` returns the projection
+ * (one row of `k` numbers per input); {@link reconstruct} maps a projection back to the original
+ * space (lossily, unless `k` equals the feature count). Fully deterministic, with component signs
+ * normalised so repeated fits agree.
+ *
+ * @example
+ * const pca = new PCA().setNumberOfComponents(1);
+ * pca.train(new Matrix([[-2, -2], [-1, -1], [0, 0], [1, 1], [2, 2]]));
+ * pca.predict(new Matrix([[2, 2]]));        // ≈ [[2.83]]  — the single axis along the diagonal
+ * pca.getExplainedVarianceRatio();          // ≈ [1]       — that one axis holds all the variance
+ */
+export default class PCA {
+
+    private numberOfComponents = 2;
+
+    private mean: number[] = [];
+    private components: number[][] = [];   // top-k eigenvectors, one per row (k × d)
+    private explainedVariance: number[] = []; // top-k eigenvalues
+    private totalVariance = 0;             // sum of all eigenvalues
+
+    public constructor () {}
+
+    public train (inputs: Matrix) {
+        const rows = inputs.toArray();
+        const n = rows.length;
+        const d = n > 0 ? rows[0].length : 0;
+
+        this.mean = columnMeans(rows, d);
+        const centered = rows.map(row => row.map((value, j) => value - this.mean[j]));
+
+        // Covariance matrix: Cᵢⱼ = average product of centred features i and j (symmetric, d × d).
+        const covariance = covarianceMatrix(centered, d);
+
+        const { values, vectors } = jacobiEigen(covariance);
+
+        // Sort eigenpairs by variance (eigenvalue), largest first.
+        const order = values.map((value, index) => index).sort((a, b) => values[b] - values[a]);
+
+        this.totalVariance = values.reduce((sum, value) => sum + Math.max(0, value), 0);
+
+        const k = Math.min(this.numberOfComponents, d);
+        this.components = [];
+        this.explainedVariance = [];
+        for (let c = 0; c < k; c++) {
+            const index = order[c];
+            this.components.push(normaliseSign(vectors.map(row => row[index]))); // eigenvector = column of V
+            this.explainedVariance.push(Math.max(0, values[index]));
+        }
+
+        return this;
+    }
+
+    /** Projects each input onto the principal components: a `k`-dimensional row per input. */
+    public predict (inputs: Matrix) {
+        const rows = inputs.toArray();
+        return new Matrix(rows.map(row => this.project(row)));
+    }
+
+    /**
+     * Maps points back from component space to the original feature space. Round-tripping
+     * `reconstruct(predict(x))`-style is lossy unless `numberOfComponents` equals the feature count —
+     * the gap is exactly the information PCA discarded.
+     */
+    public reconstruct (inputs: Matrix) {
+        const rows = inputs.toArray();
+        return new Matrix(rows.map(row => this.project(row)).map(projection => this.unproject(projection)));
+    }
+
+    /* Parameter setters */
+
+    public setNumberOfComponents (numberOfComponents: number) {
+        this.numberOfComponents = numberOfComponents;
+        return this;
+    }
+
+    /* Parameter getters */
+
+    public getNumberOfComponents () {
+        return this.numberOfComponents;
+    }
+
+    /** The principal components themselves — one eigenvector per row (`k × d`). */
+    public getComponents () {
+        return new Matrix(this.components.map(component => component.slice()));
+    }
+
+    /** Variance captured by each kept component (its eigenvalue). */
+    public getExplainedVariance () {
+        return this.explainedVariance.slice();
+    }
+
+    /** Fraction of the data's total variance captured by each kept component. */
+    public getExplainedVarianceRatio () {
+        if (this.totalVariance === 0) {
+            return this.explainedVariance.map(() => 0);
+        }
+        return this.explainedVariance.map(value => value / this.totalVariance);
+    }
+
+    /** The per-feature mean subtracted before projecting. */
+    public getMean () {
+        return new Matrix([this.mean.slice()]);
+    }
+
+    /* Private methods */
+
+    private project (row: number[]) {
+        const centered = row.map((value, j) => value - this.mean[j]);
+        return this.components.map(component => dot(centered, component));
+    }
+
+    private unproject (projection: number[]) {
+        return this.mean.map((meanValue, j) => {
+            let value = meanValue;
+            for (let c = 0; c < this.components.length; c++) {
+                value += projection[c] * this.components[c][j];
+            }
+            return value;
+        });
+    }
+}
+
+function columnMeans (rows: number[][], d: number) {
+    const means = new Array<number>(d).fill(0);
+    for (const row of rows) {
+        for (let j = 0; j < d; j++) {
+            means[j] += row[j];
+        }
+    }
+    return means.map(sum => (rows.length > 0 ? sum / rows.length : 0));
+}
+
+function covarianceMatrix (centered: number[][], d: number) {
+    const n = centered.length;
+    const covariance = Array.from({ length: d }, () => new Array<number>(d).fill(0));
+    for (const row of centered) {
+        for (let i = 0; i < d; i++) {
+            for (let j = i; j < d; j++) {
+                covariance[i][j] += row[i] * row[j];
+            }
+        }
+    }
+    const divisor = n > 1 ? n - 1 : 1;
+    for (let i = 0; i < d; i++) {
+        for (let j = i; j < d; j++) {
+            covariance[i][j] /= divisor;
+            covariance[j][i] = covariance[i][j];
+        }
+    }
+    return covariance;
+}
+
+/**
+ * Eigendecomposition of a symmetric matrix by the **cyclic Jacobi** method: repeatedly apply a
+ * plane rotation that zeroes the largest off-diagonal pair, until the matrix is (numerically)
+ * diagonal. The diagonal then holds the eigenvalues and the accumulated rotations (`V`) hold the
+ * eigenvectors as columns. Clear and reliable for the small, symmetric covariance matrices here.
+ */
+function jacobiEigen (input: number[][]) {
+    const n = input.length;
+    const a = input.map(row => row.slice());
+    const v: number[][] = Array.from({ length: n }, (_, i) => Array.from({ length: n }, (_, j) => (i === j ? 1 : 0)));
+
+    for (let sweep = 0; sweep < 100; sweep++) {
+        let offDiagonal = 0;
+        for (let p = 0; p < n; p++) {
+            for (let q = p + 1; q < n; q++) {
+                offDiagonal += a[p][q] * a[p][q];
+            }
+        }
+        if (offDiagonal < 1e-20) {
+            break;
+        }
+
+        for (let p = 0; p < n; p++) {
+            for (let q = p + 1; q < n; q++) {
+                if (a[p][q] === 0) {
+                    continue;
+                }
+
+                const phi = 0.5 * Math.atan2(2 * a[p][q], a[q][q] - a[p][p]);
+                const c = Math.cos(phi);
+                const s = Math.sin(phi);
+
+                const app = a[p][p];
+                const aqq = a[q][q];
+                const apq = a[p][q];
+
+                a[p][p] = c * c * app - 2 * s * c * apq + s * s * aqq;
+                a[q][q] = s * s * app + 2 * s * c * apq + c * c * aqq;
+                a[p][q] = 0;
+                a[q][p] = 0;
+
+                for (let i = 0; i < n; i++) {
+                    if (i !== p && i !== q) {
+                        const aip = a[i][p];
+                        const aiq = a[i][q];
+                        a[i][p] = c * aip - s * aiq;
+                        a[p][i] = a[i][p];
+                        a[i][q] = s * aip + c * aiq;
+                        a[q][i] = a[i][q];
+                    }
+                    const vip = v[i][p];
+                    const viq = v[i][q];
+                    v[i][p] = c * vip - s * viq;
+                    v[i][q] = s * vip + c * viq;
+                }
+            }
+        }
+    }
+
+    return { values: a.map((row, i) => row[i]), vectors: v };
+}
+
+/** Fix an eigenvector's sign so its largest-magnitude entry is positive — makes fits reproducible. */
+function normaliseSign (vector: number[]) {
+    let maxIndex = 0;
+    for (let i = 1; i < vector.length; i++) {
+        if (Math.abs(vector[i]) > Math.abs(vector[maxIndex])) {
+            maxIndex = i;
+        }
+    }
+    return vector[maxIndex] < 0 ? vector.map(value => -value) : vector;
+}
+
+function dot (a: number[], b: number[]) {
+    let sum = 0;
+    for (let i = 0; i < a.length; i++) {
+        sum += a[i] * b[i];
+    }
+    return sum;
+}

--- a/src/lib/machine-learning/unsupervised/Recommender.ts
+++ b/src/lib/machine-learning/unsupervised/Recommender.ts
@@ -1,0 +1,203 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+import mulberry32 from "../../math/random/mulberry32";
+
+/**
+ * **Recommender** by matrix factorization — collaborative filtering, the "customers like you also
+ * liked…" model. Association rules found patterns true of the *average* customer; this learns each
+ * customer (and each item) individually, so it can suggest what *one specific person* would love but
+ * hasn't tried.
+ *
+ * The input is a sparse **ratings matrix**: one row per user, one column per item, the rating where
+ * it's known and `0` where it isn't (the gaps are the whole point — they're what we want to fill).
+ * The model explains the known ratings as a product of two skinny matrices, `R ≈ globalMean + U Vᵀ`:
+ * each user gets a short vector of **latent factors** (their taste — how much they lean "coffee vs
+ * tea", "sweet vs savoury", whatever the data implies) and each item gets one too (how much it
+ * embodies each factor). A predicted rating is just how well a user's taste lines up with an item's
+ * profile — the dot product — and *that* fills the blanks for items nobody told us about.
+ *
+ * Training is plain SGD over the observed entries (with L2 regularisation), so — like the regression
+ * models — repeated `train()` calls continue from where they left off. `predict()` returns the full
+ * completed ratings matrix; {@link recommend} ranks a user's unrated items by predicted score.
+ *
+ * @example
+ * const reco = new Recommender().setNumberOfFactors(2).setNumberOfEpochs(300);
+ * reco.train(new Matrix([[5, 5, 1, 0], [5, 0, 1, 1], [1, 1, 5, 5], [0, 1, 5, 5]]));
+ * reco.recommend(1); // user 1's unrated items, best first — predicts they'll love item 1
+ */
+export default class Recommender {
+
+    private numberOfFactors = 2;
+    private numberOfEpochs = 100;
+    private learningRate = 0.01;
+    private regularization = 0.05;
+    private seed = 0;
+
+    private userFactors: number[][];
+    private itemFactors: number[][];
+    private globalMean = 0;
+    private ratings: number[][] = [];
+
+    public constructor () {}
+
+    public train (inputs: Matrix) {
+        const ratings = inputs.toArray();
+        const userCount = ratings.length;
+        const itemCount = userCount > 0 ? ratings[0].length : 0;
+        this.ratings = ratings;
+
+        // Observed entries only (0 means "not rated yet" — those are what we're trying to predict).
+        const observed: [number, number, number][] = [];
+        for (let u = 0; u < userCount; u++) {
+            for (let i = 0; i < itemCount; i++) {
+                if (ratings[u][i] !== 0) {
+                    observed.push([u, i, ratings[u][i]]);
+                }
+            }
+        }
+
+        // Initialise factors (and the global mean) on the first train, like the regression models'
+        // hypothesis — so calling train() repeatedly continues the same optimisation.
+        if (this.userFactors === undefined || this.userFactors.length !== userCount || this.itemFactors.length !== itemCount) {
+            const random = mulberry32(this.seed);
+            this.userFactors = randomFactors(userCount, this.numberOfFactors, random);
+            this.itemFactors = randomFactors(itemCount, this.numberOfFactors, random);
+            this.globalMean = observed.length > 0 ? observed.reduce((sum, [, , r]) => sum + r, 0) / observed.length : 0;
+        }
+
+        const k = this.numberOfFactors;
+        const lr = this.learningRate;
+        const reg = this.regularization;
+
+        for (let epoch = 0; epoch < this.numberOfEpochs; epoch++) {
+            for (const [u, i, rating] of observed) {
+                const userVector = this.userFactors[u];
+                const itemVector = this.itemFactors[i];
+
+                const error = rating - this.globalMean - dot(userVector, itemVector);
+
+                // Step both vectors toward the residual, shrinking them a little (L2) as we go.
+                for (let f = 0; f < k; f++) {
+                    const uf = userVector[f];
+                    const vf = itemVector[f];
+                    userVector[f] += lr * (error * vf - reg * uf);
+                    itemVector[f] += lr * (error * uf - reg * vf);
+                }
+            }
+        }
+
+        return this;
+    }
+
+    /** The full completed ratings matrix: a predicted score for every user × item, gaps included. */
+    public predict () {
+        return new Matrix(this.userFactors.map(userVector =>
+            this.itemFactors.map(itemVector => this.globalMean + dot(userVector, itemVector)),
+        ));
+    }
+
+    /**
+     * A user's unrated items, ranked best-first by predicted score. `count` caps the list (default:
+     * all unrated items).
+     */
+    public recommend (userIndex: number, count?: number) {
+        const userVector = this.userFactors[userIndex];
+        const scored: { item: number; score: number }[] = [];
+        for (let i = 0; i < this.itemFactors.length; i++) {
+            if (this.ratings[userIndex][i] === 0) {
+                scored.push({ item: i, score: this.globalMean + dot(userVector, this.itemFactors[i]) });
+            }
+        }
+        scored.sort((a, b) => b.score - a.score);
+        return count === undefined ? scored : scored.slice(0, count);
+    }
+
+    public reset () {
+        this.userFactors = undefined;
+        this.itemFactors = undefined;
+        this.globalMean = 0;
+        return this;
+    }
+
+    /* Parameter setters */
+
+    public setNumberOfFactors (numberOfFactors: number) {
+        this.numberOfFactors = numberOfFactors;
+        return this;
+    }
+
+    public setNumberOfEpochs (numberOfEpochs: number) {
+        this.numberOfEpochs = numberOfEpochs;
+        return this;
+    }
+
+    public setLearningRate (learningRate: number) {
+        this.learningRate = learningRate;
+        return this;
+    }
+
+    public setRegularization (regularization: number) {
+        this.regularization = regularization;
+        return this;
+    }
+
+    public setSeed (seed: number) {
+        this.seed = seed;
+        return this;
+    }
+
+    /* Parameter getters */
+
+    public getNumberOfFactors () {
+        return this.numberOfFactors;
+    }
+
+    public getNumberOfEpochs () {
+        return this.numberOfEpochs;
+    }
+
+    public getLearningRate () {
+        return this.learningRate;
+    }
+
+    public getRegularization () {
+        return this.regularization;
+    }
+
+    public getSeed () {
+        return this.seed;
+    }
+
+    /** The learned latent vector for each user (users × factors). */
+    public getUserFactors () {
+        return new Matrix(this.userFactors.map(row => row.slice()));
+    }
+
+    /** The learned latent vector for each item (items × factors). */
+    public getItemFactors () {
+        return new Matrix(this.itemFactors.map(row => row.slice()));
+    }
+
+    public getGlobalMean () {
+        return this.globalMean;
+    }
+}
+
+function randomFactors (rows: number, factors: number, random: () => number) {
+    const matrix: number[][] = [];
+    for (let r = 0; r < rows; r++) {
+        const row = new Array<number>(factors);
+        for (let f = 0; f < factors; f++) {
+            row[f] = (random() * 2 - 1) * 0.1;
+        }
+        matrix.push(row);
+    }
+    return matrix;
+}
+
+function dot (a: number[], b: number[]) {
+    let sum = 0;
+    for (let i = 0; i < a.length; i++) {
+        sum += a[i] * b[i];
+    }
+    return sum;
+}

--- a/src/test/AnomalyDetector.test.ts
+++ b/src/test/AnomalyDetector.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import AnomalyDetector from '../lib/machine-learning/unsupervised/AnomalyDetector';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+import { ANOMALY_NORMAL, ANOMALY_CORRELATED } from './helpers/fixtures';
+
+describe('AnomalyDetector', () => {
+
+    it('flags a far-out point and leaves normal ones alone', () => {
+        const model = new AnomalyDetector().setThreshold(3);
+        model.train(new Matrix(ANOMALY_NORMAL));
+
+        const flags = model.predict(new Matrix([[0, 0], [0.5, 0.5], [8, 8]])).toArray().map(row => row[0]);
+        expect(flags).toEqual([0, 0, 1]);
+    });
+
+    it('scores points farther from the centre as more anomalous', () => {
+        const model = new AnomalyDetector().train(new Matrix(ANOMALY_NORMAL));
+
+        const scores = model.score(new Matrix([[0, 0], [2, 2], [6, 6]])).toArray().map(row => row[0]);
+        expect(scores[0]).toBeLessThan(scores[1]);
+        expect(scores[1]).toBeLessThan(scores[2]);
+        expect(scores[0]).toBeLessThan(0.5); // near the centre → barely anomalous
+    });
+
+    it('uses Mahalanobis distance: across the grain is more anomalous than along it', () => {
+        const model = new AnomalyDetector().train(new Matrix(ANOMALY_CORRELATED));
+
+        const along = model.score(new Matrix([[2, 2]])).toArray()[0][0];   // along y = x
+        const across = model.score(new Matrix([[2, -2]])).toArray()[0][0]; // same Euclidean distance, across the grain
+        expect(across).toBeGreaterThan(along);
+    });
+
+    it('lowering the threshold flags more points', () => {
+        const queries = new Matrix([[0, 0], [2, 2], [3, 3], [5, 5]]);
+        const flagged = (t: number) => {
+            const model = new AnomalyDetector().setThreshold(t).train(new Matrix(ANOMALY_NORMAL));
+            return model.predict(queries).toArray().reduce((sum, row) => sum + row[0], 0);
+        };
+        expect(flagged(1.5)).toBeGreaterThanOrEqual(flagged(4));
+    });
+
+    it('centres on the data mean', () => {
+        const model = new AnomalyDetector().train(new Matrix([[0, 10], [2, 14], [4, 18]]));
+        expect(model.getMean().toArray()).toEqual([[2, 14]]);
+    });
+
+    it('is deterministic and chains setters', () => {
+        const run = () => new AnomalyDetector().setThreshold(2.5).train(new Matrix(ANOMALY_NORMAL)).score(new Matrix(ANOMALY_NORMAL)).toArray();
+        expect(run()).toEqual(run());
+
+        const model = new AnomalyDetector();
+        expect(model.getThreshold()).toBe(3);
+        expect(model.setThreshold(2)).toBe(model);
+        expect(model.getThreshold()).toBe(2);
+    });
+});

--- a/src/test/AssociationRules.test.ts
+++ b/src/test/AssociationRules.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import AssociationRules from '../lib/machine-learning/unsupervised/AssociationRules';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+import { ASSOCIATION_INPUTS } from './helpers/fixtures';
+
+const ruleKey = (a: number[], c: number[]) => `${a.join(',')}=>${c.join(',')}`;
+
+describe('AssociationRules', () => {
+
+    it('finds the confident "1 → 0" rule', () => {
+        const model = new AssociationRules().setMinSupport(0.5).setMinConfidence(0.6);
+        model.train(new Matrix(ASSOCIATION_INPUTS));
+
+        const rules = model.getRules();
+        const oneToZero = rules.find(r => ruleKey(r.antecedent, r.consequent) === '1=>0');
+        expect(oneToZero).toBeDefined();
+        expect(oneToZero!.confidence).toBeCloseTo(1, 6);    // every basket with item 1 also has item 0
+        expect(oneToZero!.support).toBeCloseTo(4 / 6, 6);   // {0,1} in 4 of 6 baskets
+        expect(oneToZero!.lift).toBeCloseTo(1.2, 6);        // 1.0 / (5/6)
+    });
+
+    it('records {0,1} as a frequent itemset with the right support', () => {
+        const model = new AssociationRules().setMinSupport(0.5).setMinConfidence(0.6);
+        model.train(new Matrix(ASSOCIATION_INPUTS));
+
+        const itemset = model.getFrequentItemsets().find(s => s.items.join(',') === '0,1');
+        expect(itemset).toBeDefined();
+        expect(itemset!.support).toBeCloseTo(4 / 6, 6);
+    });
+
+    it('drops the weaker direction as the confidence bar rises', () => {
+        const model = new AssociationRules().setMinSupport(0.5).setMinConfidence(0.9);
+        model.train(new Matrix(ASSOCIATION_INPUTS));
+
+        const keys = model.getRules().map(r => ruleKey(r.antecedent, r.consequent));
+        expect(keys).toContain('1=>0');     // confidence 1.0 survives
+        expect(keys).not.toContain('0=>1'); // confidence 0.8 does not
+    });
+
+    it('finds fewer itemsets as the support bar rises', () => {
+        const count = (minSupport: number) =>
+            new AssociationRules().setMinSupport(minSupport).train(new Matrix(ASSOCIATION_INPUTS)).getFrequentItemsets().length;
+        expect(count(0.9)).toBeLessThan(count(0.3));
+    });
+
+    it('completes a basket: given item 1, suggests item 0', () => {
+        const model = new AssociationRules().setMinSupport(0.5).setMinConfidence(0.6);
+        model.train(new Matrix(ASSOCIATION_INPUTS));
+
+        const scores = model.predict(new Matrix([[0, 1, 0, 0]])).toArray()[0];
+        expect(scores[0]).toBeCloseTo(1, 6); // item 0 recommended with confidence 1.0
+        expect(scores[1]).toBe(0);           // item 1 is already in the basket
+    });
+
+    it('round-trips its hyperparameters and chains setters', () => {
+        const model = new AssociationRules();
+        expect(model.getMinSupport()).toBe(0.1);
+        expect(model.getMinConfidence()).toBe(0.5);
+
+        const returned = model.setMinSupport(0.2).setMinConfidence(0.7).setMaxItemsetSize(2);
+        expect(returned).toBe(model);
+        expect(model.getMinSupport()).toBe(0.2);
+        expect(model.getMinConfidence()).toBe(0.7);
+        expect(model.getMaxItemsetSize()).toBe(2);
+    });
+});

--- a/src/test/DBSCAN.test.ts
+++ b/src/test/DBSCAN.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import DBSCAN from '../lib/machine-learning/unsupervised/DBSCAN';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+import { DBSCAN_INPUTS, DBSCAN_EXPECTED_LABELS } from './helpers/fixtures';
+
+describe('DBSCAN', () => {
+
+    it('finds the dense clusters and flags the outlier as noise', () => {
+        const model = new DBSCAN().setEpsilon(0.5).setMinPoints(3);
+        model.train(new Matrix(DBSCAN_INPUTS));
+
+        expect(model.getLabels()).toEqual(DBSCAN_EXPECTED_LABELS);
+        expect(model.getClusterCount()).toBe(2);
+    });
+
+    it('predicts the same labels for the training points', () => {
+        const model = new DBSCAN().setEpsilon(0.5).setMinPoints(3);
+        model.train(new Matrix(DBSCAN_INPUTS));
+
+        const predicted = model.predict(new Matrix(DBSCAN_INPUTS)).toArray().map(row => row[0]);
+        expect(predicted).toEqual(DBSCAN_EXPECTED_LABELS);
+    });
+
+    it('assigns a near point to a cluster and a far point to noise', () => {
+        const model = new DBSCAN().setEpsilon(0.5).setMinPoints(3);
+        model.train(new Matrix(DBSCAN_INPUTS));
+
+        const predicted = model.predict(new Matrix([[0.05, 0.05], [20, 20]])).toArray().map(row => row[0]);
+        expect(predicted[0]).toBe(0); // inside blob A
+        expect(predicted[1]).toBe(DBSCAN.NOISE); // nowhere near a core point
+    });
+
+    it('merges everything into one cluster as epsilon grows', () => {
+        const model = new DBSCAN().setEpsilon(100).setMinPoints(3);
+        model.train(new Matrix(DBSCAN_INPUTS));
+
+        // With a huge radius every point is a core neighbour of every other, so it's all one cluster.
+        expect(model.getClusterCount()).toBe(1);
+        expect(model.getLabels().every(label => label === 0)).toBe(true);
+    });
+
+    it('calls everything noise when minPoints is unreachable', () => {
+        const model = new DBSCAN().setEpsilon(0.5).setMinPoints(50);
+        model.train(new Matrix(DBSCAN_INPUTS));
+
+        expect(model.getClusterCount()).toBe(0);
+        expect(model.getLabels().every(label => label === DBSCAN.NOISE)).toBe(true);
+    });
+
+    it('is deterministic', () => {
+        const run = () => {
+            const model = new DBSCAN().setEpsilon(0.5).setMinPoints(3);
+            model.train(new Matrix(DBSCAN_INPUTS));
+            return model.getLabels();
+        };
+        expect(run()).toEqual(run());
+    });
+
+    it('round-trips its hyperparameters and chains setters', () => {
+        const model = new DBSCAN();
+        expect(model.getEpsilon()).toBe(0.5);
+        expect(model.getMinPoints()).toBe(4);
+
+        const returned = model.setEpsilon(0.3).setMinPoints(6);
+        expect(returned).toBe(model);
+        expect(model.getEpsilon()).toBe(0.3);
+        expect(model.getMinPoints()).toBe(6);
+    });
+});

--- a/src/test/ExponentialSmoothing.test.ts
+++ b/src/test/ExponentialSmoothing.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import ExponentialSmoothing from '../lib/machine-learning/time-series/ExponentialSmoothing';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+import { TS_CONSTANT, TS_TREND, TS_SEASONAL } from './helpers/fixtures';
+
+const flat = (matrix: Matrix) => matrix.toArray().map(row => row[0]);
+
+describe('ExponentialSmoothing', () => {
+
+    it('forecasts a constant series as that constant', () => {
+        const model = new ExponentialSmoothing().setAlpha(0.5);
+        model.train(new Matrix(TS_CONSTANT));
+
+        for (const value of flat(model.predict(3))) {
+            expect(value).toBeCloseTo(5, 6);
+        }
+    });
+
+    it('extends a linear trend upward when trend smoothing is on', () => {
+        const model = new ExponentialSmoothing().setAlpha(0.5).setBeta(0.5);
+        model.train(new Matrix(TS_TREND));
+
+        const forecast = flat(model.predict(3));
+        // The series ends at 6 and climbs by ~1 each step, so the forecast keeps climbing.
+        expect(forecast[0]).toBeGreaterThan(6);
+        expect(forecast[1]).toBeGreaterThan(forecast[0]);
+        expect(forecast[2]).toBeGreaterThan(forecast[1]);
+        expect(model.getTrend()).toBeGreaterThan(0.5);
+    });
+
+    it('ignores trend by default (a flat forecast for the same trend series)', () => {
+        const model = new ExponentialSmoothing().setAlpha(0.5); // beta defaults to 0
+        model.train(new Matrix(TS_TREND));
+
+        const forecast = flat(model.predict(2));
+        expect(forecast[0]).toBeCloseTo(forecast[1], 6); // no trend term → flat
+    });
+
+    it('learns a repeating seasonal cycle', () => {
+        const model = new ExponentialSmoothing().setAlpha(0.5).setGamma(0.5).setSeasonLength(2);
+        model.train(new Matrix(TS_SEASONAL));
+
+        const forecast = flat(model.predict(4));
+        // Series ends on a "20"; next should continue 10, 20, 10, 20.
+        expect(forecast[0]).toBeCloseTo(10, 4);
+        expect(forecast[1]).toBeCloseTo(20, 4);
+        expect(forecast[2]).toBeCloseTo(10, 4);
+        expect(forecast[3]).toBeCloseTo(20, 4);
+    });
+
+    it('produces one fitted value per training point', () => {
+        const model = new ExponentialSmoothing().train(new Matrix(TS_SEASONAL));
+        expect(model.getFitted().getRowCount()).toBe(TS_SEASONAL.length);
+    });
+
+    it('round-trips its hyperparameters and chains setters', () => {
+        const model = new ExponentialSmoothing();
+        expect(model.getAlpha()).toBe(0.5);
+        expect(model.getBeta()).toBe(0);
+        expect(model.getSeasonLength()).toBe(1);
+
+        const returned = model.setAlpha(0.3).setBeta(0.2).setGamma(0.4).setSeasonLength(7);
+        expect(returned).toBe(model);
+        expect(model.getAlpha()).toBe(0.3);
+        expect(model.getBeta()).toBe(0.2);
+        expect(model.getGamma()).toBe(0.4);
+        expect(model.getSeasonLength()).toBe(7);
+    });
+});

--- a/src/test/HierarchicalClustering.test.ts
+++ b/src/test/HierarchicalClustering.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import HierarchicalClustering from '../lib/machine-learning/unsupervised/HierarchicalClustering';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+import { KMEANS_INPUTS, HIERARCHICAL_LINE_INPUTS } from './helpers/fixtures';
+
+describe('HierarchicalClustering', () => {
+
+    it('cuts two well-separated blobs into the right two groups', () => {
+        const model = new HierarchicalClustering().setNumberOfClusters(2);
+        model.train(new Matrix(KMEANS_INPUTS));
+
+        const labels = model.getClusterLabels();
+        // Points 0–2 are the origin blob, 3–5 the far blob.
+        expect(labels[0]).toBe(labels[1]);
+        expect(labels[1]).toBe(labels[2]);
+        expect(labels[3]).toBe(labels[4]);
+        expect(labels[4]).toBe(labels[5]);
+        expect(labels[0]).not.toBe(labels[3]);
+    });
+
+    it('records n-1 merges with non-decreasing heights, for every linkage', () => {
+        for (const linkage of ['single', 'complete', 'average'] as const) {
+            const model = new HierarchicalClustering().setLinkage(linkage);
+            model.train(new Matrix(KMEANS_INPUTS));
+
+            const merges = model.getMergeHistory();
+            expect(merges.length).toBe(KMEANS_INPUTS.length - 1);
+            for (let t = 1; t < merges.length; t++) {
+                expect(merges[t].distance).toBeGreaterThanOrEqual(merges[t - 1].distance - 1e-9);
+            }
+            // The final merge folds everything into one cluster of size n.
+            expect(merges[merges.length - 1].size).toBe(KMEANS_INPUTS.length);
+        }
+    });
+
+    it('merges the closest points first (unambiguous line)', () => {
+        const model = new HierarchicalClustering().setLinkage('single');
+        model.train(new Matrix(HIERARCHICAL_LINE_INPUTS));
+
+        const merges = model.getMergeHistory();
+        // The 0–1 pair (distance 1) is the closest, so it merges first.
+        expect(merges[0].distance).toBeCloseTo(1, 9);
+        expect(new Set([merges[0].left, merges[0].right])).toEqual(new Set([0, 1]));
+        // Heights climb as clusters get coarser: 1 (0–1) → 2 (join point 2) → 5 (join point 8).
+        expect(merges.map(m => m.distance)).toEqual([1, 2, 5]);
+    });
+
+    it('single vs complete linkage land the same 2-cut but at different heights', () => {
+        const single = new HierarchicalClustering().setLinkage('single');
+        const complete = new HierarchicalClustering().setLinkage('complete');
+        single.train(new Matrix(KMEANS_INPUTS));
+        complete.train(new Matrix(KMEANS_INPUTS));
+
+        const top = (model: HierarchicalClustering) => model.getMergeHistory().slice(-1)[0].distance;
+        // Complete linkage measures clusters by their farthest pair, so the final join sits higher.
+        expect(top(complete)).toBeGreaterThan(top(single));
+    });
+
+    it('predicts one-hot membership with k columns summing to 1', () => {
+        const model = new HierarchicalClustering().setNumberOfClusters(2);
+        model.train(new Matrix(KMEANS_INPUTS));
+
+        const predictions = model.predict(new Matrix(KMEANS_INPUTS));
+        expect(predictions.getColumnCount()).toBe(2);
+        for (const row of predictions.toArray()) {
+            expect(row.reduce((a, b) => a + b, 0)).toBe(1);
+        }
+    });
+
+    it('is deterministic', () => {
+        const run = () => {
+            const model = new HierarchicalClustering().setNumberOfClusters(3).setLinkage('average');
+            model.train(new Matrix(KMEANS_INPUTS));
+            return model.getClusterLabels();
+        };
+        expect(run()).toEqual(run());
+    });
+
+    it('round-trips its hyperparameters and chains setters', () => {
+        const model = new HierarchicalClustering();
+        expect(model.getNumberOfClusters()).toBe(2);
+        expect(model.getLinkage()).toBe('average');
+
+        const returned = model.setNumberOfClusters(4).setLinkage('complete');
+        expect(returned).toBe(model);
+        expect(model.getNumberOfClusters()).toBe(4);
+        expect(model.getLinkage()).toBe('complete');
+    });
+});

--- a/src/test/PCA.test.ts
+++ b/src/test/PCA.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import PCA from '../lib/machine-learning/unsupervised/PCA';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+import { PCA_DIAGONAL_INPUTS } from './helpers/fixtures';
+
+const SQRT_HALF = Math.SQRT1_2; // 0.7071…
+
+describe('PCA', () => {
+
+    it('finds the diagonal as the first principal component', () => {
+        const model = new PCA().setNumberOfComponents(2);
+        model.train(new Matrix(PCA_DIAGONAL_INPUTS));
+
+        const [pc1] = model.getComponents().toArray();
+        // PC1 points along y = x (sign normalised to positive): ~[0.707, 0.707].
+        expect(Math.abs(pc1[0])).toBeCloseTo(SQRT_HALF, 6);
+        expect(Math.abs(pc1[1])).toBeCloseTo(SQRT_HALF, 6);
+        expect(Math.sign(pc1[0])).toBe(Math.sign(pc1[1])); // both components share a sign on this line
+    });
+
+    it('reports almost all variance on the first component', () => {
+        const model = new PCA().setNumberOfComponents(2);
+        model.train(new Matrix(PCA_DIAGONAL_INPUTS));
+
+        const ratio = model.getExplainedVarianceRatio();
+        expect(ratio[0]).toBeCloseTo(1, 6);
+        expect(ratio[1]).toBeCloseTo(0, 6);
+        expect(ratio[0] + ratio[1]).toBeCloseTo(1, 6);
+    });
+
+    it('projects to k dimensions', () => {
+        const model = new PCA().setNumberOfComponents(1);
+        model.train(new Matrix(PCA_DIAGONAL_INPUTS));
+
+        const projected = model.predict(new Matrix(PCA_DIAGONAL_INPUTS));
+        expect(projected.getColumnCount()).toBe(1);
+        expect(projected.getRowCount()).toBe(PCA_DIAGONAL_INPUTS.length);
+        // The point (2, 2) sits sqrt(8) ≈ 2.83 along the diagonal from the centre (the origin here).
+        expect(Math.abs(projected.toArray()[4][0])).toBeCloseTo(Math.sqrt(8), 6);
+    });
+
+    it('reconstructs a 1-D shadow that lands back on the line (data is genuinely 1-D)', () => {
+        const model = new PCA().setNumberOfComponents(1);
+        model.train(new Matrix(PCA_DIAGONAL_INPUTS));
+
+        // The data lies exactly on y = x, so even a single component rebuilds it with no loss.
+        const reconstructed = model.reconstruct(new Matrix(PCA_DIAGONAL_INPUTS)).toArray();
+        reconstructed.forEach((row, i) => {
+            expect(row[0]).toBeCloseTo(PCA_DIAGONAL_INPUTS[i][0], 6);
+            expect(row[1]).toBeCloseTo(PCA_DIAGONAL_INPUTS[i][1], 6);
+        });
+    });
+
+    it('reconstructs losslessly when keeping every component', () => {
+        const inputs = new Matrix([[1, 2], [3, 1], [-2, 4], [0, -3], [2, 2]]);
+        const model = new PCA().setNumberOfComponents(2);
+        model.train(inputs);
+
+        const reconstructed = model.reconstruct(inputs).toArray();
+        inputs.toArray().forEach((row, i) => {
+            expect(reconstructed[i][0]).toBeCloseTo(row[0], 6);
+            expect(reconstructed[i][1]).toBeCloseTo(row[1], 6);
+        });
+    });
+
+    it('centres on the data mean', () => {
+        const model = new PCA().train(new Matrix([[0, 10], [2, 14], [4, 18]]));
+        expect(model.getMean().toArray()).toEqual([[2, 14]]);
+    });
+
+    it('is deterministic and chains setters', () => {
+        const run = () => new PCA().setNumberOfComponents(1).train(new Matrix(PCA_DIAGONAL_INPUTS)).predict(new Matrix(PCA_DIAGONAL_INPUTS)).toArray();
+        expect(run()).toEqual(run());
+
+        const model = new PCA();
+        expect(model.getNumberOfComponents()).toBe(2);
+        expect(model.setNumberOfComponents(3)).toBe(model);
+        expect(model.getNumberOfComponents()).toBe(3);
+    });
+});

--- a/src/test/Perceptron.test.ts
+++ b/src/test/Perceptron.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import Perceptron from '../lib/machine-learning/supervised/Perceptron';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+import { GATE_INPUTS, AND_TARGETS, OR_TARGETS, XOR_TARGETS } from './helpers/fixtures';
+
+const classify = (targets: number[][]) => {
+    const model = new Perceptron().setLearningRate(0.1).setNumberOfEpochs(100);
+    model.train(new Matrix(GATE_INPUTS), new Matrix(targets));
+    return model.predict(new Matrix(GATE_INPUTS)).toArray();
+};
+
+describe('Perceptron', () => {
+
+    it('learns AND (linearly separable)', () => {
+        expect(classify(AND_TARGETS)).toEqual(AND_TARGETS);
+    });
+
+    it('learns OR (linearly separable)', () => {
+        expect(classify(OR_TARGETS)).toEqual(OR_TARGETS);
+    });
+
+    it('cannot solve XOR — one neuron is one straight line', () => {
+        // No matter how long it trains, a single perceptron mis-labels at least one XOR point.
+        const predictions = classify(XOR_TARGETS);
+        const wrong = predictions.filter((row, i) => row[0] !== XOR_TARGETS[i][0]).length;
+        expect(wrong).toBeGreaterThan(0);
+    });
+
+    it('is deterministic (zero-initialised)', () => {
+        expect(classify(AND_TARGETS)).toEqual(classify(AND_TARGETS));
+    });
+
+    it('exposes a weight per feature and round-trips its hyperparameters', () => {
+        const model = new Perceptron();
+        expect(model.getLearningRate()).toBe(0.1);
+
+        const returned = model.setLearningRate(0.5).setNumberOfEpochs(30);
+        expect(returned).toBe(model);
+        expect(model.getLearningRate()).toBe(0.5);
+        expect(model.getNumberOfEpochs()).toBe(30);
+
+        model.train(new Matrix(GATE_INPUTS), new Matrix(AND_TARGETS));
+        expect(model.getWeights().getColumnCount()).toBe(2);
+    });
+});

--- a/src/test/Recommender.test.ts
+++ b/src/test/Recommender.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import Recommender from '../lib/machine-learning/unsupervised/Recommender';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+import { RECOMMENDER_INPUTS } from './helpers/fixtures';
+
+const trained = () => {
+    const model = new Recommender().setNumberOfFactors(2).setNumberOfEpochs(500).setLearningRate(0.02).setRegularization(0.02).setSeed(0);
+    model.train(new Matrix(RECOMMENDER_INPUTS));
+    return model;
+};
+
+describe('Recommender', () => {
+
+    it('fills hidden ratings in line with the user\'s taste group', () => {
+        const predictions = trained().predict().toArray();
+
+        // User 1 (group A) hid item 1 → should predict high; user 3 (group B) hid item 0 → low.
+        expect(predictions[1][1]).toBeGreaterThan(3.5);
+        expect(predictions[3][0]).toBeLessThan(2.5);
+        // User 0's hidden item 3 (a group-B item) should come out low.
+        expect(predictions[0][3]).toBeLessThan(2.5);
+    });
+
+    it('reconstructs the observed ratings closely', () => {
+        const predictions = trained().predict().toArray();
+        let error = 0;
+        let count = 0;
+        RECOMMENDER_INPUTS.forEach((row, u) => row.forEach((rating, i) => {
+            if (rating !== 0) {
+                error += Math.abs(predictions[u][i] - rating);
+                count++;
+            }
+        }));
+        expect(error / count).toBeLessThan(0.5); // mean absolute error on known ratings
+    });
+
+    it('recommends a user\'s unrated items, best first, and never a rated one', () => {
+        const model = trained();
+        const recommendations = model.recommend(1); // user 1 has rated items 0, 2, 3; item 1 is open
+
+        expect(recommendations.map(r => r.item)).toEqual([1]); // only the unrated item
+        // Scores are sorted descending.
+        for (let i = 1; i < recommendations.length; i++) {
+            expect(recommendations[i - 1].score).toBeGreaterThanOrEqual(recommendations[i].score);
+        }
+    });
+
+    it('exposes latent factors of the right shape', () => {
+        const model = trained();
+        expect(model.getUserFactors().getRowCount()).toBe(4);
+        expect(model.getUserFactors().getColumnCount()).toBe(2);
+        expect(model.getItemFactors().getRowCount()).toBe(4);
+        expect(model.getItemFactors().getColumnCount()).toBe(2);
+    });
+
+    it('is deterministic for a fixed seed', () => {
+        expect(trained().predict().toArray()).toEqual(trained().predict().toArray());
+    });
+
+    it('round-trips its hyperparameters and chains setters', () => {
+        const model = new Recommender();
+        expect(model.getNumberOfFactors()).toBe(2);
+
+        const returned = model.setNumberOfFactors(3).setNumberOfEpochs(50).setLearningRate(0.05).setRegularization(0.1).setSeed(7);
+        expect(returned).toBe(model);
+        expect(model.getNumberOfFactors()).toBe(3);
+        expect(model.getNumberOfEpochs()).toBe(50);
+        expect(model.getLearningRate()).toBe(0.05);
+        expect(model.getRegularization()).toBe(0.1);
+        expect(model.getSeed()).toBe(7);
+    });
+});

--- a/src/test/SupportVectorMachine.test.ts
+++ b/src/test/SupportVectorMachine.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import SupportVectorMachine from '../lib/machine-learning/supervised/SupportVectorMachine';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+import {
+    SVM_LINEAR_INPUTS,
+    SVM_LINEAR_TARGETS,
+    SVM_LINEAR_EXPECTED_CLASSES,
+    XNOR_INPUTS,
+    SVM_XOR_TARGETS,
+    SVM_XOR_EXPECTED_CLASSES,
+} from './helpers/fixtures';
+
+/** The sign of the decision score is the predicted class: ≥ 0 → class 1, otherwise class 0. */
+const classes = (scores: number[][]) => scores.map(row => (row[0] >= 0 ? 1 : 0));
+
+describe('SupportVectorMachine', () => {
+
+    it('separates a linearly separable set with a linear kernel', () => {
+        const model = new SupportVectorMachine().setKernel('linear').setRegularization(10).setNumberOfIterations(50);
+        model.train(new Matrix(SVM_LINEAR_INPUTS), new Matrix(SVM_LINEAR_TARGETS));
+
+        const scores = model.predict(new Matrix(SVM_LINEAR_INPUTS)).toArray();
+        expect(classes(scores)).toEqual(SVM_LINEAR_EXPECTED_CLASSES);
+    });
+
+    it('keeps only the boundary-hugging points as support vectors', () => {
+        const model = new SupportVectorMachine().setKernel('linear').setRegularization(10).setNumberOfIterations(50);
+        model.train(new Matrix(SVM_LINEAR_INPUTS), new Matrix(SVM_LINEAR_TARGETS));
+
+        const supportVectors = model.getSupportVectorIndices();
+        // At least one from each class anchors the margin, but not every point should be a support vector.
+        expect(supportVectors.length).toBeGreaterThanOrEqual(2);
+        expect(supportVectors.length).toBeLessThan(SVM_LINEAR_INPUTS.length);
+    });
+
+    it('solves XOR with an RBF kernel where a linear kernel cannot', () => {
+        const inputs = new Matrix(XNOR_INPUTS);
+        const targets = new Matrix(SVM_XOR_TARGETS);
+
+        const linear = new SupportVectorMachine().setKernel('linear').setRegularization(10).setNumberOfIterations(80);
+        linear.train(inputs, targets);
+        const linearClasses = classes(linear.predict(inputs).toArray());
+
+        const rbf = new SupportVectorMachine().setKernel('rbf').setGamma(1).setRegularization(100).setNumberOfIterations(200);
+        rbf.train(inputs, targets);
+        const rbfClasses = classes(rbf.predict(inputs).toArray());
+
+        expect(rbfClasses).toEqual(SVM_XOR_EXPECTED_CLASSES);
+        expect(linearClasses).not.toEqual(SVM_XOR_EXPECTED_CLASSES);
+    });
+
+    it('widens the margin (shrinks ‖w‖) when C is smaller', () => {
+        // Overlapping classes along x: two points (the last in each row) sit on the wrong side, so the
+        // problem is *not* linearly separable and the soft-margin C genuinely bites.
+        const overlapInputs = new Matrix([[-1, 0], [-0.7, 0], [-0.4, 0], [-0.2, 0], [1, 0], [0.7, 0], [0.4, 0], [0.2, 0]]);
+        const overlapTargets = new Matrix([[0], [0], [0], [1], [1], [1], [1], [0]]);
+
+        const norm = (c: number) => {
+            const model = new SupportVectorMachine().setKernel('linear').setRegularization(c).setNumberOfIterations(200);
+            model.train(overlapInputs, overlapTargets);
+            return model.getWeightNorm();
+        };
+
+        // A looser penalty tolerates more slack, so the optimiser is free to pick a wider street.
+        expect(norm(0.05)).toBeLessThan(norm(50));
+    });
+
+    it('is deterministic for a fixed seed', () => {
+        const train = () => {
+            const model = new SupportVectorMachine().setKernel('rbf').setGamma(1).setRegularization(10).setSeed(7).setNumberOfIterations(60);
+            model.train(new Matrix(SVM_LINEAR_INPUTS), new Matrix(SVM_LINEAR_TARGETS));
+            return model.predict(new Matrix(SVM_LINEAR_INPUTS)).toArray();
+        };
+
+        expect(train()).toEqual(train());
+    });
+
+    it('round-trips its hyperparameters and chains setters', () => {
+        const model = new SupportVectorMachine();
+        expect(model.getKernel()).toBe('linear');
+        expect(model.getRegularization()).toBe(1);
+
+        const returned = model
+            .setKernel('polynomial')
+            .setRegularization(5)
+            .setGamma(0.5)
+            .setDegree(2)
+            .setCoefficient(0)
+            .setTolerance(1e-4)
+            .setNumberOfIterations(100)
+            .setSeed(3);
+
+        expect(returned).toBe(model);
+        expect(model.getKernel()).toBe('polynomial');
+        expect(model.getRegularization()).toBe(5);
+        expect(model.getGamma()).toBe(0.5);
+        expect(model.getDegree()).toBe(2);
+        expect(model.getCoefficient()).toBe(0);
+        expect(model.getTolerance()).toBe(1e-4);
+        expect(model.getNumberOfIterations()).toBe(100);
+        expect(model.getSeed()).toBe(3);
+    });
+});

--- a/src/test/helpers/fixtures.ts
+++ b/src/test/helpers/fixtures.ts
@@ -78,6 +78,13 @@ export const SVM_LINEAR_EXPECTED_CLASSES = [1, 1, 1, 1, 0, 0, 0, 0];
 export const SVM_XOR_TARGETS = [[0], [1], [1], [0]];
 export const SVM_XOR_EXPECTED_CLASSES = [0, 1, 1, 0];
 
+/**
+ * Four points on a line for hierarchical clustering: a tight pair at 0–1, a lone point at 3, and a
+ * far point at 8. The merge order is unambiguous (0–1 first, then 2 joins, then 3 last), which lets
+ * tests pin the dendrogram's shape and its non-decreasing merge heights.
+ */
+export const HIERARCHICAL_LINE_INPUTS = [[0, 0], [1, 0], [3, 0], [8, 0]];
+
 /** Two well-separated blobs for clustering: three points near the origin, three near (10, 10). */
 export const KMEANS_INPUTS = [[0, 0], [1, 0], [0, 1], [10, 10], [11, 10], [10, 11]];
 /** The mean of each blob — what the two centroids should converge to. */

--- a/src/test/helpers/fixtures.ts
+++ b/src/test/helpers/fixtures.ts
@@ -60,6 +60,24 @@ export const TREE_TARGETS = [[1, 0], [1, 0], [1, 0], [0, 1], [1, 0], [0, 1], [1,
 /** Expected class per row (argmax): only the two "both high" rows are class 1. */
 export const TREE_EXPECTED_CLASSES = [[0], [0], [0], [1], [0], [1], [0], [0]];
 
+/**
+ * Support vector machine — a cleanly separable 2D set: class 1 sits in the upper-right, class 0 in
+ * the lower-right's mirror (lower-left). A straight max-margin line (roughly x + y = 0) splits them
+ * with room to spare, so a linear-kernel SVM nails every point and only the inner points become
+ * support vectors. Targets are a single 0/1 column, like logistic regression.
+ */
+export const SVM_LINEAR_INPUTS = [[2, 2], [3, 3], [3, 1], [1, 3], [-2, -2], [-3, -3], [-3, -1], [-1, -3]];
+export const SVM_LINEAR_TARGETS = [[1], [1], [1], [1], [0], [0], [0], [0]];
+export const SVM_LINEAR_EXPECTED_CLASSES = [1, 1, 1, 1, 0, 0, 0, 0];
+
+/**
+ * XOR — the textbook non-linearly-separable problem (opposite corners share a class). No straight
+ * line can split it, so a linear SVM fails; an RBF kernel carves it cleanly. Reuses {@link
+ * XNOR_INPUTS} for the four corners with XOR targets.
+ */
+export const SVM_XOR_TARGETS = [[0], [1], [1], [0]];
+export const SVM_XOR_EXPECTED_CLASSES = [0, 1, 1, 0];
+
 /** Two well-separated blobs for clustering: three points near the origin, three near (10, 10). */
 export const KMEANS_INPUTS = [[0, 0], [1, 0], [0, 1], [10, 10], [11, 10], [10, 11]];
 /** The mean of each blob — what the two centroids should converge to. */

--- a/src/test/helpers/fixtures.ts
+++ b/src/test/helpers/fixtures.ts
@@ -5,6 +5,12 @@
 export const XNOR_INPUTS = [[0, 0], [0, 1], [1, 0], [1, 1]];
 export const XNOR_TARGETS = [[1], [0], [0], [1]];
 
+/** The four logic-gate inputs, with AND / OR / XOR labels. AND and OR are linearly separable; XOR is not. */
+export const GATE_INPUTS = [[0, 0], [0, 1], [1, 0], [1, 1]];
+export const AND_TARGETS = [[0], [0], [0], [1]];
+export const OR_TARGETS = [[0], [1], [1], [1]];
+export const XOR_TARGETS = [[0], [1], [1], [0]];
+
 /** A perfectly linear relationship: y = 1000 + 200 * x. */
 export const LINEAR_INPUTS = [[5], [7], [9], [11], [13]];
 export const LINEAR_TARGETS = [[2000], [2400], [2800], [3200], [3600]];

--- a/src/test/helpers/fixtures.ts
+++ b/src/test/helpers/fixtures.ts
@@ -85,6 +85,18 @@ export const SVM_XOR_EXPECTED_CLASSES = [0, 1, 1, 0];
  */
 export const HIERARCHICAL_LINE_INPUTS = [[0, 0], [1, 0], [3, 0], [8, 0]];
 
+/**
+ * DBSCAN: two tight blobs and one far-flung outlier. With epsilon 0.5 / minPoints 3, each blob is a
+ * dense cluster and the lone point at (10, 0) is reachable from nobody — so it's labelled noise (-1).
+ */
+export const DBSCAN_INPUTS = [
+    [0, 0], [0.1, 0], [0, 0.1], [0.1, 0.1],
+    [5, 5], [5.1, 5], [5, 5.1], [5.1, 5.1],
+    [10, 0],
+];
+/** Expected labels: blob A = cluster 0, blob B = cluster 1, the outlier = noise. */
+export const DBSCAN_EXPECTED_LABELS = [0, 0, 0, 0, 1, 1, 1, 1, -1];
+
 /** Two well-separated blobs for clustering: three points near the origin, three near (10, 10). */
 export const KMEANS_INPUTS = [[0, 0], [1, 0], [0, 1], [10, 10], [11, 10], [10, 11]];
 /** The mean of each blob — what the two centroids should converge to. */

--- a/src/test/helpers/fixtures.ts
+++ b/src/test/helpers/fixtures.ts
@@ -104,6 +104,16 @@ export const DBSCAN_EXPECTED_LABELS = [0, 0, 0, 0, 1, 1, 1, 1, -1];
  */
 export const PCA_DIAGONAL_INPUTS = [[-2, -2], [-1, -1], [0, 0], [1, 1], [2, 2]];
 
+/** Anomaly detection: a tight, roughly round cloud of "normal" points around the origin. */
+export const ANOMALY_NORMAL = [[0, 0], [1, 0], [0, 1], [-1, 0], [0, -1], [1, 1], [-1, -1], [0.5, -0.5]];
+
+/**
+ * Anomaly detection on a correlated cloud (points hug the line y = x). Used to show the Mahalanobis
+ * distance respects the data's shape: a point off the diagonal is far more anomalous than one the
+ * same Euclidean distance away *along* it.
+ */
+export const ANOMALY_CORRELATED = [[-2, -2.1], [-1, -0.9], [0, 0.1], [1, 1.1], [2, 1.9], [-1.5, -1.6], [1.5, 1.4], [0.5, 0.6]];
+
 /** Two well-separated blobs for clustering: three points near the origin, three near (10, 10). */
 export const KMEANS_INPUTS = [[0, 0], [1, 0], [0, 1], [10, 10], [11, 10], [10, 11]];
 /** The mean of each blob — what the two centroids should converge to. */

--- a/src/test/helpers/fixtures.ts
+++ b/src/test/helpers/fixtures.ts
@@ -141,6 +141,11 @@ export const RECOMMENDER_INPUTS = [
     [0, 1, 5, 5],
 ];
 
+/** Time series (one value per time step, as a column): a flat line, a rising trend, a 2-step cycle. */
+export const TS_CONSTANT = [[5], [5], [5], [5], [5]];
+export const TS_TREND = [[1], [2], [3], [4], [5], [6]];
+export const TS_SEASONAL = [[10], [20], [10], [20], [10], [20], [10], [20]];
+
 /** Two well-separated blobs for clustering: three points near the origin, three near (10, 10). */
 export const KMEANS_INPUTS = [[0, 0], [1, 0], [0, 1], [10, 10], [11, 10], [10, 11]];
 /** The mean of each blob — what the two centroids should converge to. */

--- a/src/test/helpers/fixtures.ts
+++ b/src/test/helpers/fixtures.ts
@@ -97,6 +97,13 @@ export const DBSCAN_INPUTS = [
 /** Expected labels: blob A = cluster 0, blob B = cluster 1, the outlier = noise. */
 export const DBSCAN_EXPECTED_LABELS = [0, 0, 0, 0, 1, 1, 1, 1, -1];
 
+/**
+ * PCA: five points lying exactly on the line y = x. All the variance is along one diagonal axis, so
+ * the first principal component should be ~[0.707, 0.707] and capture ~100% of the variance; the
+ * second captures ~0. A clean, fully determined case for the eigendecomposition.
+ */
+export const PCA_DIAGONAL_INPUTS = [[-2, -2], [-1, -1], [0, 0], [1, 1], [2, 2]];
+
 /** Two well-separated blobs for clustering: three points near the origin, three near (10, 10). */
 export const KMEANS_INPUTS = [[0, 0], [1, 0], [0, 1], [10, 10], [11, 10], [10, 11]];
 /** The mean of each blob — what the two centroids should converge to. */

--- a/src/test/helpers/fixtures.ts
+++ b/src/test/helpers/fixtures.ts
@@ -114,6 +114,20 @@ export const ANOMALY_NORMAL = [[0, 0], [1, 0], [0, 1], [-1, 0], [0, -1], [1, 1],
  */
 export const ANOMALY_CORRELATED = [[-2, -2.1], [-1, -0.9], [0, 0.1], [1, 1.1], [2, 1.9], [-1.5, -1.6], [1.5, 1.4], [0.5, 0.6]];
 
+/**
+ * Association rules: a tiny basket matrix over 4 items (columns 0–3), 6 baskets. Item 1 almost
+ * always rides along with item 0, so "1 → 0" is a confident rule. Supports: 0 in 5/6 baskets,
+ * 1 in 4/6, {0,1} in 4/6 — so confidence(1→0)=1.0, confidence(0→1)=0.8.
+ */
+export const ASSOCIATION_INPUTS = [
+    [1, 1, 0, 0],
+    [1, 1, 1, 0],
+    [1, 1, 0, 0],
+    [0, 0, 1, 1],
+    [1, 0, 1, 0],
+    [1, 1, 0, 1],
+];
+
 /** Two well-separated blobs for clustering: three points near the origin, three near (10, 10). */
 export const KMEANS_INPUTS = [[0, 0], [1, 0], [0, 1], [10, 10], [11, 10], [10, 11]];
 /** The mean of each blob — what the two centroids should converge to. */

--- a/src/test/helpers/fixtures.ts
+++ b/src/test/helpers/fixtures.ts
@@ -128,6 +128,19 @@ export const ASSOCIATION_INPUTS = [
     [1, 1, 0, 1],
 ];
 
+/**
+ * Recommender: a 4-user × 4-item ratings matrix with two clear taste groups (0 = not rated yet).
+ * Users 0–1 love items 0–1 and dislike 2–3; users 2–3 are the opposite. A few ratings are hidden
+ * so matrix factorization has blanks to fill — and the group structure says exactly what they
+ * should be (e.g. user 1's hidden item 1 → high; user 3's hidden item 0 → low).
+ */
+export const RECOMMENDER_INPUTS = [
+    [5, 5, 1, 0],
+    [5, 0, 1, 1],
+    [1, 1, 5, 5],
+    [0, 1, 5, 5],
+];
+
 /** Two well-separated blobs for clustering: three points near the origin, three near (10, 10). */
 export const KMEANS_INPUTS = [[0, 0], [1, 0], [0, 1], [10, 10], [11, 10], [10, 11]];
 /** The mean of each blob — what the two centroids should converge to. */


### PR DESCRIPTION
Takes the library from **0.6.0 → 0.7.0**, adding nine algorithms and turning the whole built library into a woven, café-narrated course (Parts 0–4 of the Drifting Leaf plan in `docs/course-plan.md`). Every chapter ships a Nadia-voiced tutorial + a live playground.

## New algorithms (each: library class + tests + demo + README + dataset + viz + playground + MDX chapter)
| Ch | Algorithm | Method |
|----|-----------|--------|
| 11 | `SupportVectorMachine` | max-margin via simplified SMO; linear/RBF/poly kernels |
| 13 | `HierarchicalClustering` | agglomerative, Lance–Williams, dendrogram |
| 14 | `DBSCAN` | density-based clustering + noise |
| 15 | `PCA` | covariance + a Jacobi eigensolver |
| 16 | `AnomalyDetector` | multivariate Gaussian / Mahalanobis |
| 17 | `AssociationRules` | Apriori (support / confidence / lift) |
| 18 | `Recommender` | matrix factorization (collaborative filtering) |
| 19 | `ExponentialSmoothing` | Holt-Winters time-series forecasting |
| —  | `Perceptron` | single neuron (interlude into neural nets) |

## Course weave
- All built algorithms (Ch 0–20 + the Perceptron interlude) now follow the per-chapter template (Problem → Wall → Idea → How It Works → Try It → What Broke), each "what broke" handing off to the next.
- **k-Means (Ch 12)** and the **Neural Network (Ch 20)** were re-themed from their older generic tutorials into café chapters — no algorithm changes.
- Nothing built remains unwoven; Phase 1 of the course plan is complete.

## Verification
- Library: **154 tests pass** (up from 104), `yarn typecheck` clean, `yarn build` clean.
- Site: `yarn typecheck` + `yarn build` clean; each new chapter is its own lazy-loaded chunk.

Merging deploys the site automatically via `deploy-site.yml`. npm publish (`0.7.0`) is a separate manual step.