### PR TITLE
Add publish.yml: npm publish on version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish
+
+# Publish the library to npm when a version tag is pushed (e.g. `git tag v0.7.0 && git push --tags`).
+# Requires an `NPM_TOKEN` repository secret (an npm automation token for the package owner).
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: yarn
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: yarn install --frozen-lockfile
+
+      # Gate the publish on a green build, so a bad tag can never ship.
+      - name: Type-check and test
+        run: |
+          yarn typecheck
+          yarn test
+
+      # `npm publish` runs prepublishOnly (yarn build) and ships only dist/lib (see package.json).
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -486,3 +486,16 @@ yarn build              # production build (deployed to GitHub Pages by deploy-s
 
 > **Enabling the live site:** in the repo, go to **Settings → Pages → Build and deployment →
 > Source: "GitHub Actions"**. Pushes to `master` then deploy automatically.
+
+### Releasing
+
+The npm package is published by CI when a version tag is pushed:
+
+```bash
+# bump "version" in package.json, commit as "Release X.Y.Z", merge to master, then:
+git tag vX.Y.Z
+git push --tags        # publish.yml type-checks, tests, builds, and runs `npm publish`
+```
+
+> Requires an **`NPM_TOKEN`** repository secret (an npm *automation* token for the package owner):
+> **Settings → Secrets and variables → Actions → New repository secret**.


### PR DESCRIPTION
Follow-up to #9. The `publish.yml` workflow was committed to `new-chapters` *after* #9 had already been merged (at the Release 0.7.0 commit), so it never reached `master`. This lands it.

On a pushed **`v*` tag**, the workflow type-checks, tests, builds, and runs `npm publish` (gated on a green build; `prepublishOnly` compiles `dist/lib`). Requires the **`NPM_TOKEN`** repo secret (already added).

No effect on the already-published `0.7.0`; this wires up automation for `0.8.0` onward. Also documents the release flow in the README.