### PR TITLE
Release 0.8.0: Convolutional Networks (Chapter 21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Below are some simple code usage examples.
 * [Random Forest](#random-forest)
 * [Gradient Boosting](#gradient-boosting)
 * [Support Vector Machine](#support-vector-machine)
+* [Convolutional Neural Network](#convolutional-neural-network)
 * [k-Means Clustering](#k-means-clustering)
 * [Hierarchical Clustering](#hierarchical-clustering)
 * [DBSCAN](#dbscan)
@@ -262,6 +263,35 @@ console.log(predictions.transform(score => (score >= 0 ? 1 : 0)).toArray());
 
 console.log(supportVectorMachine.getSupportVectorIndices());
 // [ 0, 2, 3, 4, 6 ]  <- the boundary-hugging points the line balances on (the rest could be deleted)
+
+```
+
+### Convolutional Neural Network
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// CNN: conv -> ReLU -> max-pool -> dense -> softmax, trained from scratch by backprop.
+// 8x8 images, a horizontal line (class 0) or a vertical line (class 1) at various positions.
+const size = 8;
+const line = (orientation: 'h' | 'v', pos: number) => {
+    const image = new Array(size * size).fill(0);
+    for (let k = 0; k < size; k++) image[orientation === 'h' ? pos * size + k : k * size + pos] = 1;
+    return image;
+};
+const images = new ml.Matrix([line('h', 1), line('h', 4), line('h', 6), line('v', 1), line('v', 4), line('v', 6)]);
+const targets = new ml.Matrix([[1, 0], [1, 0], [1, 0], [0, 1], [0, 1], [0, 1]]);
+
+const cnn = new ml.ConvolutionalNeuralNetwork();
+cnn.setInputShape(8, 8).setFilterCount(4).setLearningRate(0.3).setNumberOfEpochs(300).setSeed(0);
+
+cnn.train(images, targets);
+
+console.log(cnn.predict(images).getMaximumRowIndeces().toArray());
+// [ [ 0 ], [ 0 ], [ 0 ], [ 1 ], [ 1 ], [ 1 ] ]  <- horizontals -> class 0, verticals -> class 1
+
+console.log('gradients verified:', cnn.checkGradients());
+// gradients verified: true  <- finite-difference check of the convolution backprop
 
 ```
 

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -26,15 +26,14 @@ generative). The built algorithms become the spine; everything else is roadmap.
 
 **Goal:** engaging, fun, genuinely educational, and very cool.
 
-**Status (this release).** Woven through **Ch 0–19**: all of Part 1, the whole of Part 2 (k‑NN,
-Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support Vector Machines), all of
-Part 3 (k‑Means, Hierarchical Clustering, DBSCAN, PCA, Anomaly Detection, Association Rules,
-Recommender Systems), and Part 4 so far — **Ch 19 Time Series** (Holt-Winters exponential
-smoothing), the **Perceptron interlude**, and now **Ch 20 Neural Networks** (the newest weave: the
-matching-dials XNOR problem → hidden layers + backprop). **Every built algorithm is now woven into
-the café story** — there is no longer a built-but-unwoven chapter. Everything past Ch 20 (CNNs,
-RNNs/transformers, reinforcement learning, generative, Bayesian) is roadmap: new builds the library
-grows into. See the status column below.
+**Status (this release).** Woven through **Ch 0–21** with no built-but-unwoven gaps: all of Part 1,
+the whole of Part 2 (k‑NN, Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support
+Vector Machines), all of Part 3 (k‑Means, Hierarchical Clustering, DBSCAN, PCA, Anomaly Detection,
+Association Rules, Recommender Systems), and Part 4 — Time Series, the Perceptron interlude, Neural
+Networks, and now **Ch 21 Convolutional Networks** (the newest chapter: a from-scratch trainable CNN
+with conv/pool/backprop and gradient checking — built fully rather than the planned "adopts"
+explainer). Still roadmap: RNNs/transformers (Ch 22–23), the reinforcement-learning arc (Ch 24–27),
+generative, and Bayesian — new builds the library grows into. See the status column below.
 
 ---
 
@@ -176,7 +175,7 @@ Every row's "Wall" is the previous tool failing.
 | 19 | **Time Series Forecasting** | *Forecasting numbers* across weeks & seasons | Plain regression ignores order & seasonality → moving averages, exponential smoothing, trend/seasonality (ARIMA-lite) | ✅ `ExponentialSmoothing` |
 | — | *Interlude: The Perceptron* | A single artificial "brain cell" | Built as a short history interlude (Priya shows Nadia where neural nets came from): weighted sum + activation; why one neuron can't do XOR | ✅ `Perceptron` (interlude) |
 | 20 | **Neural Networks & Backprop** | Danger/delight hides in *combinations* of cues (XNOR-like) | k-NN is slow, memoryless, and dumb in high dimensions; linear can't combine → **stack layers that learn features**; backprop ("blame flows backward"); dropout; SGD/Adam | ✅ `FeedforwardNeuralNetwork` |
-| 21 | **Convolutional Nets (CNNs)** | Grade latte-art photos / spot pastry defects / scan receipts | Dense nets ignore spatial structure → **convolutions**, filters, pooling (computer vision) | ○ (adopts) |
+| 21 | **Convolutional Nets (CNNs)** | Grade latte-art photos / spot pastry defects / scan receipts | Dense nets ignore spatial structure → **convolutions**, filters, pooling (computer vision) | ✅ `ConvolutionalNeuralNetwork` (built from scratch — exceeded the "adopts" plan) |
 | 22 | **Recurrent Nets / LSTMs** | Learn *sequence & text representations* (reviews, chat logs) — **not** forecasting (that's Ch 19) | Feedforward has no memory of order; this is the bridge to language → recurrence, memory, vanishing gradients. *Embeddings are introduced here as connective tissue* — learned word/item **vectors** where "similar sits close" (also reused by recsys, Ch 18) | ○ (adopts) |
 | 23 | **Transformers & Attention** | The café's AI assistant / chatbot | RNNs forget long context & don't parallelize → **attention**; the modern backbone (and a nod to the model writing this) | ○ (adopts) |
 

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -211,6 +211,28 @@ import * as ml from '../src/lib';
 }
 
 {
+    // Convolutional neural network: learns to spot a shape anywhere in a tiny image.
+    // 8×8 images — a horizontal line (class 0) or a vertical line (class 1), at various positions.
+    const size = 8;
+    const line = (orientation: 'h' | 'v', pos: number) => {
+        const image = new Array(size * size).fill(0);
+        for (let k = 0; k < size; k++) image[orientation === 'h' ? pos * size + k : k * size + pos] = 1;
+        return image;
+    };
+    const images = new ml.Matrix([line('h', 1), line('h', 4), line('h', 6), line('v', 1), line('v', 4), line('v', 6)]);
+    const targets = new ml.Matrix([[1, 0], [1, 0], [1, 0], [0, 1], [0, 1], [0, 1]]);
+
+    const cnn = new ml.ConvolutionalNeuralNetwork();
+    cnn.setInputShape(8, 8).setFilterCount(4).setLearningRate(0.3).setNumberOfEpochs(300).setSeed(0);
+
+    cnn.train(images, targets);
+    console.log(cnn.predict(images).getMaximumRowIndeces().toArray());
+    // [ [ 0 ], [ 0 ], [ 0 ], [ 1 ], [ 1 ], [ 1 ] ]  ← horizontals → class 0, verticals → class 1
+    console.log('CNN gradients verified:', cnn.checkGradients());
+    // CNN gradients verified: true  ← finite-difference check of the convolution backprop
+}
+
+{
     // Naive Bayes (multinomial): classify messages by word counts.
     // Vocabulary [free, money, table, tonight]; one-hot classes [spam, ham].
     const inputs = new ml.Matrix([[2, 1, 0, 0], [1, 2, 0, 0], [0, 0, 2, 1], [0, 0, 1, 2]]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-learning",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "TypeScript & JavaScript machine learning library",
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,11 @@
     "time series",
     "forecasting",
     "exponential smoothing",
-    "perceptron"
+    "perceptron",
+    "convolutional neural network",
+    "cnn",
+    "deep learning",
+    "computer vision"
   ],
   "author": "Erik Gerrits <gerrits.erik@gmail.com>",
   "license": "MIT",

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -30,6 +30,7 @@ const AssociationRulesTutorial = lazy(() => import('./content/association-rules.
 const RecommenderSystemsTutorial = lazy(() => import('./content/recommender-systems.mdx'));
 const TimeSeriesTutorial = lazy(() => import('./content/time-series.mdx'));
 const PerceptronTutorial = lazy(() => import('./content/perceptron.mdx'));
+const CNNTutorial = lazy(() => import('./content/cnn.mdx'));
 
 export function App() {
     return (
@@ -209,6 +210,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <PerceptronTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="cnn"
+                    element={
+                        <TutorialPage>
+                            <CNNTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -220,4 +220,13 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         chapter: 20,
         part: PART_4,
     },
+    {
+        id: 'cnn',
+        path: '/cnn',
+        title: 'Convolutional Networks',
+        tagline: 'Slide little filters over an image to spot a shape anywhere it appears.',
+        status: 'live',
+        chapter: 21,
+        part: PART_4,
+    },
 ];

--- a/site/src/components/CNNPlayground.module.css
+++ b/site/src/components/CNNPlayground.module.css
@@ -1,0 +1,56 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(220px, 280px);
+    gap: 20px;
+    align-items: start;
+}
+
+.vizWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 16 / 9;
+}
+
+.viz {
+    width: 100%;
+    height: 100%;
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+.lossCanvas {
+    display: block;
+    width: 100%;
+    height: 130px;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/CNNPlayground.tsx
+++ b/site/src/components/CNNPlayground.tsx
@@ -1,0 +1,243 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ConvolutionalNeuralNetwork, Matrix } from 'machine-learning';
+import { CNN_DATASETS } from '../ml/cnnDatasets';
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+import { fitCanvas } from '../viz/canvas';
+import { drawGrid, label } from '../viz/cnn';
+import { drawLossCurve } from '../viz/lossCurve';
+import { Badge, Card, ControlPanel, Hint, Metric, MetricsRow, NumberField, RunControls, Select, Slider } from './controls/Controls';
+import styles from './CNNPlayground.module.css';
+
+const POINTS = 90;
+const FILTER_PRESETS = [4, 6, 8];
+
+interface TrainingData {
+    inputs: number[][];
+    targets: number[][];
+    inputMatrix: Matrix;
+    targetMatrix: Matrix;
+    size: number;
+    classNames: string[];
+}
+
+export function CNNPlayground() {
+    const [datasetId, setDatasetId] = useState(CNN_DATASETS[0].id);
+    const [filters, setFilters] = useState(CNN_DATASETS[0].recommendedFilters);
+    const [rateSlider, setRateSlider] = useState(Math.round(CNN_DATASETS[0].recommendedLr * 100));
+    const [stepsPerFrame, setStepsPerFrame] = useState(3);
+    const [example, setExample] = useState(0);
+    const [seed, setSeed] = useState(0);
+    const [running, setRunning] = useState(false);
+    const [gradOk, setGradOk] = useState<boolean | null>(null);
+    const [metrics, setMetrics] = useState({ epoch: 0, loss: 0, acc: 0 });
+
+    const learningRate = rateSlider / 100;
+
+    const lrRef = useRef(learningRate);
+    const stepsRef = useRef(stepsPerFrame);
+    const exampleRef = useRef(example);
+    lrRef.current = learningRate;
+    stepsRef.current = stepsPerFrame;
+    exampleRef.current = example;
+
+    const modelRef = useRef<ConvolutionalNeuralNetwork | null>(null);
+    const dataRef = useRef<TrainingData | null>(null);
+    const lossRef = useRef<number[]>([]);
+    const epochRef = useRef(0);
+    const frameRef = useRef(0);
+
+    const vizCanvasRef = useRef<HTMLCanvasElement | null>(null);
+    const lossCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const reshape = (row: number[], size: number) => {
+        const g: number[][] = [];
+        for (let i = 0; i < size; i++) g.push(row.slice(i * size, (i + 1) * size));
+        return g;
+    };
+
+    const drawViz = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        const canvas = vizCanvasRef.current;
+        if (!model || !data || !canvas) return;
+
+        const { ctx, width, height } = fitCanvas(canvas);
+        ctx.fillStyle = '#0b1120';
+        ctx.fillRect(0, 0, width, height);
+
+        const idx = Math.min(exampleRef.current, data.inputs.length - 1);
+        const image = data.inputs[idx];
+        const learnedFilters = model.getFilters();
+        const maps = model.getConvMaps(image);
+
+        // Input image (top-left) + its predicted class.
+        label(ctx, 'Input image', 8, 16);
+        drawGrid(ctx, 8, 22, 96, reshape(image, data.size));
+        const probs = model.predict(new Matrix([image])).toArray()[0];
+        const predicted = probs.indexOf(Math.max(...probs));
+        const trueClass = data.targets[idx].indexOf(1);
+        ctx.fillStyle = predicted === trueClass ? '#34d399' : '#f87171';
+        ctx.font = '12px ui-sans-serif, system-ui, sans-serif';
+        ctx.fillText(`pred: ${data.classNames[predicted]}`, 8, 140);
+        ctx.fillStyle = 'rgba(148,163,184,0.8)';
+        ctx.fillText(`true: ${data.classNames[trueClass]}`, 8, 156);
+
+        // Learned filters (a row).
+        const fx = 130;
+        label(ctx, `Learned filters (${learnedFilters.length})`, fx, 16);
+        const fbox = 34;
+        learnedFilters.forEach((f, k) => drawGrid(ctx, fx + k * (fbox + 8), 22, fbox, f, true));
+
+        // Feature maps for this image (a row), aligned under the filters.
+        label(ctx, 'Feature maps (what each filter sees here)', fx, 86);
+        const mbox = 44;
+        maps.forEach((m, k) => drawGrid(ctx, fx + k * (mbox + 8), 92, mbox, m));
+    }, []);
+
+    const drawLoss = useCallback(() => {
+        const canvas = lossCanvasRef.current;
+        if (!canvas) return;
+        const { ctx, width, height } = fitCanvas(canvas);
+        drawLossCurve(ctx, width, height, lossRef.current);
+    }, []);
+
+    const rebuild = useCallback(() => {
+        const dataset = CNN_DATASETS.find(d => d.id === datasetId) ?? CNN_DATASETS[0];
+        const { inputs, targets } = dataset.generate(seed, POINTS);
+        const inputMatrix = new Matrix(inputs);
+        const targetMatrix = new Matrix(targets);
+
+        const model = new ConvolutionalNeuralNetwork()
+            .setInputShape(dataset.size, dataset.size)
+            .setFilterCount(filters)
+            .setLearningRate(lrRef.current)
+            .setNumberOfEpochs(1)
+            .setSeed(seed);
+        model.train(inputMatrix, targetMatrix); // one pass to initialise the weights + shapes
+
+        modelRef.current = model;
+        dataRef.current = { inputs, targets, inputMatrix, targetMatrix, size: dataset.size, classNames: dataset.classNames };
+        lossRef.current = [model.computeLoss(inputMatrix, targetMatrix)];
+        epochRef.current = 1;
+        frameRef.current = 0;
+
+        setGradOk(model.checkGradients());
+        setMetrics({ epoch: 1, loss: lossRef.current[0], acc: accuracy(model, inputMatrix, targets) });
+        drawViz();
+        drawLoss();
+    }, [datasetId, filters, seed, drawViz, drawLoss]);
+
+    useEffect(() => {
+        rebuild();
+    }, [rebuild]);
+
+    useEffect(() => {
+        // Live LR changes shouldn't reset training.
+        if (modelRef.current) modelRef.current.setLearningRate(learningRate);
+    }, [learningRate]);
+
+    const step = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        if (!model || !data) return;
+
+        for (let i = 0; i < stepsRef.current; i++) model.train(data.inputMatrix, data.targetMatrix);
+        epochRef.current += stepsRef.current;
+
+        const loss = model.computeLoss(data.inputMatrix, data.targetMatrix);
+        lossRef.current.push(loss);
+        if (lossRef.current.length > 1200) lossRef.current.shift();
+
+        drawViz();
+        drawLoss();
+
+        frameRef.current += 1;
+        if (frameRef.current % 3 === 0) {
+            setMetrics({ epoch: epochRef.current, loss, acc: accuracy(model, data.inputMatrix, data.targets) });
+        }
+    }, [drawViz, drawLoss]);
+
+    useAnimationFrame(step, running);
+
+    const handleStep = () => {
+        if (!running) step();
+    };
+    const handleReset = () => {
+        setRunning(false);
+        rebuild();
+    };
+    const handleDataset = (id: string) => {
+        const next = CNN_DATASETS.find(d => d.id === id);
+        if (!next) return;
+        setDatasetId(next.id);
+        setFilters(next.recommendedFilters);
+        setRateSlider(Math.round(next.recommendedLr * 100));
+    };
+    // Re-draw the viz when the selected example changes (no retrain).
+    useEffect(() => { drawViz(); }, [example, drawViz]);
+
+    const dataset = CNN_DATASETS.find(d => d.id === datasetId);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <RunControls running={running} onToggle={() => setRunning(r => !r)} onStep={handleStep} onReset={handleReset} />
+                <Select
+                    label="Images"
+                    value={datasetId}
+                    options={CNN_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={handleDataset}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Select
+                    label="Filters"
+                    value={String(filters)}
+                    options={FILTER_PRESETS.map(f => ({ value: String(f), label: `${f} filters` }))}
+                    onChange={v => setFilters(Number(v))}
+                />
+                <Slider label="Learning rate" value={rateSlider} display={learningRate.toFixed(2)} min={2} max={60} onChange={setRateSlider} />
+                <Slider label="Speed" value={stepsPerFrame} display={`${stepsPerFrame} epochs / frame`} min={1} max={8} onChange={setStepsPerFrame} />
+                <Slider label="Show example" value={example} display={`#${example}`} min={0} max={POINTS - 1} onChange={setExample} />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.vizWrap}>
+                    <canvas ref={vizCanvasRef} className={styles.viz} />
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Epoch" value={String(metrics.epoch)} />
+                        <Metric label="Loss" value={metrics.loss.toFixed(3)} />
+                        <Metric label="Accuracy" value={`${(metrics.acc * 100).toFixed(0)}%`} />
+                    </MetricsRow>
+
+                    {gradOk && <Badge>✓ Gradients verified</Badge>}
+
+                    <Card title="Loss" subtitle="cross-entropy per epoch">
+                        <canvas ref={lossCanvasRef} className={styles.lossCanvas} />
+                    </Card>
+
+                    <Card title="What to watch" subtitle="filters become detectors">
+                        <p className={styles.note}>
+                            Each filter starts as random noise and sharpens into a little edge detector —
+                            one for horizontal strokes, one for vertical, and so on. The feature maps light
+                            up wherever a filter's pattern appears, so the same stroke is found no matter
+                            where it sits.
+                        </p>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function accuracy(model: ConvolutionalNeuralNetwork, inputMatrix: Matrix, targets: number[][]): number {
+    const predicted = model.predict(inputMatrix).getMaximumRowIndeces().toArray().map(row => row[0]);
+    let correct = 0;
+    for (let i = 0; i < predicted.length; i++) {
+        if (predicted[i] === targets[i].indexOf(1)) correct++;
+    }
+    return predicted.length > 0 ? correct / predicted.length : 0;
+}

--- a/site/src/content/cnn.mdx
+++ b/site/src/content/cnn.mdx
@@ -1,0 +1,92 @@
+import { CNNPlayground } from '../components/CNNPlayground';
+
+# Chapter 21 — Seeing the pour
+
+> *Convolutional networks.* The app is full of photos now. A plain network reads a picture as a bag
+> of pixels — so the same stroke, an inch to the left, looks like something it has never seen.
+
+The loyalty app lets regulars snap their latte art, and Nadia wants it to auto-tag the **pour
+direction** — a horizontal sweep, a vertical line, a diagonal rosetta. Easy by eye. But the cup is
+never in the same spot in the frame, so the stroke lands anywhere in the image. That single fact
+breaks the tool she just built.
+
+## The wall: flattening throws away "next to"
+
+Feed a photo to the dense network from Chapter 20 and you first have to **flatten** it — unroll the
+grid of pixels into one long row. Do that and a stroke in the top-left and the *same* stroke in the
+bottom-right share almost no active pixels; to the network they're unrelated inputs. It can memorise
+the exact photos it trained on, but nudge the stroke a few pixels and every input value changes and
+it's lost. Flattening discards the one thing that matters in an image: **which pixels are next to
+which**. And wiring every pixel to every neuron is a parameter explosion that overfits fast.
+
+## The idea: slide a small filter everywhere
+
+So the network stops looking at the whole image at once. It takes a tiny **filter** — a few pixels
+square — and slides it across every position, computing a little weighted sum at each spot. The
+**same filter weights** are reused everywhere, so a filter that learns to detect a horizontal edge
+fires on a horizontal stroke *wherever it sits*. Each filter produces a **feature map**: a picture of
+where its pattern occurs. **Pooling** then shrinks each map (keep the strongest response in each
+little block), buying tolerance to small shifts, and a final dense layer reads off "which patterns
+showed up" to call the class. Shared weights mean far fewer parameters and built-in position
+tolerance. Press **Train** and watch the filters turn from noise into edge detectors:
+
+<div className="breakout">
+  <CNNPlayground />
+</div>
+
+## How it works: convolve, pool, classify
+
+The convolution is just that sliding weighted sum (technically cross-correlation), squashed through
+**ReLU** — straight from the
+[`ConvolutionalNeuralNetwork`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/supervised/ConvolutionalNeuralNetwork.ts)
+source:
+
+```ts
+let sum = this.filterBiases[k];
+for (let di = 0; di < f; di++)
+    for (let dj = 0; dj < f; dj++)
+        sum += image[i + di][j + dj] * this.filters[k][di][dj]; // the same filter, at every (i, j)
+actRow.push(sum > 0 ? sum : 0);                                  // ReLU
+```
+
+**Max-pooling** keeps only the strongest response in each 2×2 block (and remembers which cell won, so
+the gradient can flow back to it) — that's where the shift-tolerance comes from:
+
+```ts
+const value = convActivated[k][pi * 2 + di][pj * 2 + dj];
+if (value > best) { best = value; bestDi = di; bestDj = dj; } // winner takes the block
+```
+
+Then the pooled maps are flattened, a dense layer maps them to the classes, and **softmax** turns
+that into probabilities. The whole stack — conv → ReLU → pool → dense → softmax — trains by the same
+backpropagation as Chapter 20; the only new gradients are routing through the pool's winners and back
+into the shared filters. Because that convolution backprop is so easy to get subtly wrong, the model
+ships a `checkGradients()` that finite-difference-verifies it — the green **✓ Gradients verified**
+badge.
+
+## Try it yourself
+
+- Watch the **learned filters**: they start as random static and sharpen into little oriented edge
+  detectors — one tuned to horizontal strokes, one to vertical, and so on.
+- Scrub **Show example** through the dataset. The same filter's **feature map** lights up along
+  whatever stroke is present, wherever it is — that's a shared filter earning its keep.
+- Switch to **Messy pours** (grainier) and it still gets there, just slower. Drop the filter count to
+  4 and it has fewer patterns to work with; raise it and it learns faster.
+
+> **Field note — tolerance, not magic invariance.** One conv + one pool buys *some* shift tolerance,
+> not perfect position-invariance — real vision models stack many conv/pool layers (and use padding
+> and strides) to build it up, and they're hungry for data. What's exact here is the principle:
+> **shared filters that look for local patterns anywhere**, which is the whole idea of seeing.
+
+## What broke
+
+A CNN reads images by leaning on the thing dense nets threw away — that nearby pixels belong
+together — and it does it with a handful of reused filters instead of a wall of weights. That's how
+the app can tag a pour no matter where the cup sits.
+
+But notice the assumption baked in: the input is a **fixed-size grid where neighbours relate in
+space**. Perfect for a photo. Useless for the other data flooding in — a customer's *run of visits*
+over months, the *words* of a written review. Those are **sequences**: variable length, and what
+matters is the order and what came before, not which pixel sits next to which. A filter sliding over
+space has no notion of "earlier" or "memory." To read a sentence or a history, Nadia needs a network
+wired for *time* — one that carries something forward as it reads. That's the next turn of the story.

--- a/site/src/ml/cnnDatasets.ts
+++ b/site/src/ml/cnnDatasets.ts
@@ -1,0 +1,81 @@
+import { gaussian, mulberry32 } from './rng';
+
+// Tiny grayscale "latte-art stroke" images for the CNN playground (Chapter 21). Each image is a
+// flattened `size × size` intensity grid (row-major, 0–1) holding one stroke — horizontal, vertical,
+// or diagonal — drawn at a random position with a little noise. Because the stroke can sit anywhere,
+// a flat dense net would see every position as a different input; a CNN's shared filters spot the
+// orientation wherever it lands. Targets are one-hot over the three directions.
+export interface CnnDataset {
+    id: string;
+    label: string;
+    blurb: string;
+    size: number;
+    classNames: string[];
+    recommendedFilters: number;
+    recommendedLr: number;
+    generate: (seed: number, n: number) => { inputs: number[][]; targets: number[][] };
+}
+
+const CLASS_NAMES = ['— horizontal', '| vertical', '/ diagonal'];
+
+function strokeImage(rand: () => number, klass: number, size: number, noise: number): number[] {
+    const image = new Array<number>(size * size).fill(0);
+    const set = (i: number, j: number, v: number) => {
+        if (i >= 0 && i < size && j >= 0 && j < size) {
+            image[i * size + j] = Math.max(image[i * size + j], v);
+        }
+    };
+
+    if (klass === 0) {
+        const r = 2 + Math.floor(rand() * (size - 4));
+        for (let j = 0; j < size; j++) { set(r, j, 1); set(r - 1, j, 0.4); set(r + 1, j, 0.4); }
+    } else if (klass === 1) {
+        const c = 2 + Math.floor(rand() * (size - 4));
+        for (let i = 0; i < size; i++) { set(i, c, 1); set(i, c - 1, 0.4); set(i, c + 1, 0.4); }
+    } else {
+        const offset = -3 + Math.floor(rand() * 7);
+        for (let i = 0; i < size; i++) { const j = i + offset; set(i, j, 1); set(i, j - 1, 0.4); set(i, j + 1, 0.4); }
+    }
+
+    for (let p = 0; p < image.length; p++) {
+        image[p] = Math.min(1, Math.max(0, image[p] + gaussian(rand) * noise));
+    }
+    return image;
+}
+
+function strokes(size: number, noise: number) {
+    return (seed: number, n: number) => {
+        const rand = mulberry32(seed);
+        const inputs: number[][] = [];
+        const targets: number[][] = [];
+        for (let i = 0; i < n; i++) {
+            const klass = i % 3;
+            inputs.push(strokeImage(rand, klass, size, noise));
+            targets.push([klass === 0 ? 1 : 0, klass === 1 ? 1 : 0, klass === 2 ? 1 : 0]);
+        }
+        return { inputs, targets };
+    };
+}
+
+export const CNN_DATASETS: CnnDataset[] = [
+    {
+        id: 'strokes',
+        label: 'Latte-art strokes',
+        blurb: 'Classify the pour direction — horizontal, vertical, or diagonal — wherever the stroke lands. Watch the filters turn into little edge detectors.',
+        size: 12,
+        classNames: CLASS_NAMES,
+        recommendedFilters: 6,
+        recommendedLr: 0.25,
+        generate: strokes(12, 0.06),
+    },
+    {
+        id: 'messy',
+        label: 'Messy pours',
+        blurb: 'The same three directions, but grainier — more noise on every pixel. The CNN still finds the orientation; it just needs a few more passes.',
+        size: 12,
+        classNames: CLASS_NAMES,
+        recommendedFilters: 8,
+        recommendedLr: 0.2,
+        generate: strokes(12, 0.16),
+    },
+];

--- a/site/src/viz/cnn.ts
+++ b/site/src/viz/cnn.ts
@@ -1,0 +1,66 @@
+// Drawing helpers for the CNN playground: render small 2-D grids (images, feature maps, filters).
+
+const SKY: [number, number, number] = [56, 189, 248];
+const AMBER: [number, number, number] = [251, 146, 60];
+const DARK: [number, number, number] = [11, 17, 32];
+
+function lerp(a: [number, number, number], b: [number, number, number], t: number): string {
+    const r = Math.round(a[0] + (b[0] - a[0]) * t);
+    const g = Math.round(a[1] + (b[1] - a[1]) * t);
+    const bch = Math.round(a[2] + (b[2] - a[2]) * t);
+    return `rgb(${r}, ${g}, ${bch})`;
+}
+
+/**
+ * Draws a 2-D array into a `box`-pixel square at (x, y). Grayscale for images / feature maps (dark →
+ * bright with value); a diverging blue↔amber map for filters (negative weights blue, positive amber),
+ * so a learned edge detector reads at a glance.
+ */
+export function drawGrid(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    box: number,
+    grid: number[][],
+    diverging = false,
+): void {
+    const rows = grid.length;
+    const cols = grid[0]?.length ?? 0;
+    if (rows === 0 || cols === 0) return;
+
+    const cell = box / Math.max(rows, cols);
+
+    let scale = 1e-6;
+    for (const row of grid) {
+        for (const v of row) {
+            scale = Math.max(scale, diverging ? Math.abs(v) : v);
+        }
+    }
+
+    for (let i = 0; i < rows; i++) {
+        for (let j = 0; j < cols; j++) {
+            const v = grid[i][j];
+            let color: string;
+            if (diverging) {
+                const t = Math.max(-1, Math.min(1, v / scale));
+                color = t >= 0 ? lerp(DARK, AMBER, t) : lerp(DARK, SKY, -t);
+            } else {
+                color = lerp(DARK, [255, 255, 255], Math.max(0, Math.min(1, v / scale)));
+            }
+            ctx.fillStyle = color;
+            ctx.fillRect(x + j * cell, y + i * cell, Math.ceil(cell), Math.ceil(cell));
+        }
+    }
+
+    ctx.strokeStyle = 'rgba(148, 163, 184, 0.4)';
+    ctx.lineWidth = 1;
+    ctx.strokeRect(x + 0.5, y + 0.5, box, box);
+}
+
+/** Small caption above a grid. */
+export function label(ctx: CanvasRenderingContext2D, text: string, x: number, y: number): void {
+    ctx.fillStyle = 'rgba(226, 232, 240, 0.85)';
+    ctx.font = '11px ui-sans-serif, system-ui, sans-serif';
+    ctx.textBaseline = 'alphabetic';
+    ctx.fillText(text, x, y);
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,6 +1,7 @@
 export { default as AnomalyDetector } from "./machine-learning/unsupervised/AnomalyDetector";
 export { default as AssociationRules } from "./machine-learning/unsupervised/AssociationRules";
 export type { AssociationRule, FrequentItemset } from "./machine-learning/unsupervised/AssociationRules";
+export { default as ConvolutionalNeuralNetwork } from "./machine-learning/supervised/ConvolutionalNeuralNetwork";
 export { default as DBSCAN } from "./machine-learning/unsupervised/DBSCAN";
 export { default as DecisionTree } from "./machine-learning/supervised/DecisionTree";
 export type { DecisionTreeNode } from "./machine-learning/supervised/DecisionTree";

--- a/src/lib/machine-learning/supervised/ConvolutionalNeuralNetwork.ts
+++ b/src/lib/machine-learning/supervised/ConvolutionalNeuralNetwork.ts
@@ -1,0 +1,427 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+import mulberry32 from "../../math/random/mulberry32";
+
+/**
+ * A small **convolutional neural network** for tiny grayscale images — the architecture that learns
+ * to *see*. A plain {@link FeedforwardNeuralNetwork} treats an image as a flat list of pixels, so a
+ * shape in the top-left and the same shape in the bottom-right look like totally different inputs.
+ * A CNN instead slides a handful of small **filters** across the image, so each filter learns one
+ * little local pattern (an edge, a stroke) it can spot *anywhere* — that's what makes it
+ * translation-tolerant and far more data-efficient on images.
+ *
+ * The topology is the classic minimal stack, all trained from scratch by backpropagation:
+ *
+ *   image → **conv** (`filterCount` filters, `filterSize`², ReLU) → **2×2 max-pool** → flatten
+ *         → **dense** → softmax over the classes
+ *
+ * Inputs are a Matrix whose rows are flattened images (`inputHeight × inputWidth`, row-major);
+ * targets are one-hot rows; `predict` returns class probabilities. The filters and dense weights
+ * persist across `train()` calls, so calling it with `numberOfEpochs = 1` in a loop animates the
+ * learning. {@link checkGradients} finite-difference-verifies the (error-prone) convolution backprop.
+ *
+ * @example
+ * const cnn = new ConvolutionalNeuralNetwork().setInputShape(12, 12).setFilterCount(6).setSeed(0);
+ * cnn.setLearningRate(0.1).setNumberOfEpochs(200).train(images, oneHotLabels);
+ * cnn.predict(images); // N × C class probabilities
+ */
+export default class ConvolutionalNeuralNetwork {
+
+    private inputHeight = 12;
+    private inputWidth = 12;
+    private filterCount = 6;
+    private filterSize = 3;
+    private learningRate = 0.1;
+    private numberOfEpochs = 1;
+    private seed = 0;
+
+    // Learned parameters.
+    private filters: number[][][];   // [filter][row][col]
+    private filterBiases: number[];  // [filter]
+    private denseWeights: number[][]; // [flattenedIndex][class]
+    private denseBiases: number[];   // [class]
+
+    // Derived shapes (set on first train).
+    private classCount = 0;
+    private convHeight = 0;
+    private convWidth = 0;
+    private poolHeight = 0;
+    private poolWidth = 0;
+    private flattenedLength = 0;
+
+    public constructor () {}
+
+    public train (inputs: Matrix, targets: Matrix) {
+        const images = inputs.toArray();
+        const labels = targets.toArray();
+        const exampleCount = images.length;
+        if (exampleCount === 0) {
+            return this;
+        }
+
+        if (this.filters === undefined) {
+            this.initialize(labels[0].length);
+        }
+
+        for (let epoch = 0; epoch < this.numberOfEpochs; epoch++) {
+            const gradients = this.zeroGradients();
+
+            for (let n = 0; n < exampleCount; n++) {
+                const image = this.reshape(images[n]);
+                const cache = this.forward(image);
+                this.accumulateGradients(image, cache, labels[n], gradients);
+            }
+
+            this.applyGradients(gradients, exampleCount);
+        }
+
+        return this;
+    }
+
+    /** Class probabilities for each input row (softmax over the output layer). */
+    public predict (inputs: Matrix) {
+        return new Matrix(inputs.toArray().map(row => this.forward(this.reshape(row)).probabilities));
+    }
+
+    /** Average cross-entropy over the given examples — what training minimises. */
+    public computeLoss (inputs: Matrix, targets: Matrix) {
+        const images = inputs.toArray();
+        const labels = targets.toArray();
+        if (images.length === 0) {
+            return 0;
+        }
+
+        let loss = 0;
+        for (let n = 0; n < images.length; n++) {
+            const { probabilities } = this.forward(this.reshape(images[n]));
+            for (let c = 0; c < this.classCount; c++) {
+                loss -= labels[n][c] * Math.log(Math.max(1e-12, probabilities[c]));
+            }
+        }
+        return loss / images.length;
+    }
+
+    /**
+     * Finite-difference check of backprop: nudge every parameter by a hair, compare how the loss
+     * actually moves against the analytic gradient, and report whether they agree everywhere
+     * (relative error < 1e-4). A live proof the convolution gradients are right.
+     */
+    public checkGradients () {
+        const random = mulberry32(this.seed + 12345);
+        if (this.filters === undefined) {
+            this.initialize(2);
+        }
+
+        // One small random example to test against.
+        const image = Array.from({ length: this.inputHeight }, () =>
+            Array.from({ length: this.inputWidth }, () => random() * 2 - 1));
+        const label = new Array<number>(this.classCount).fill(0);
+        label[Math.floor(random() * this.classCount)] = 1;
+
+        const analytic = this.zeroGradients();
+        this.accumulateGradients(image, this.forward(image), label, analytic);
+
+        const epsilon = 1e-4;
+        const tolerance = 1e-3;
+        const lossAt = () => {
+            const { probabilities } = this.forward(image);
+            let loss = 0;
+            for (let c = 0; c < this.classCount; c++) {
+                loss -= label[c] * Math.log(Math.max(1e-12, probabilities[c]));
+            }
+            return loss;
+        };
+
+        const ok = (analyticGrad: number, get: () => number, set: (v: number) => void) => {
+            const original = get();
+            set(original + epsilon);
+            const lossPlus = lossAt();
+            set(original - epsilon);
+            const lossMinus = lossAt();
+            set(original);
+            const numeric = (lossPlus - lossMinus) / (2 * epsilon);
+            const denom = Math.max(1, Math.abs(analyticGrad) + Math.abs(numeric));
+            return Math.abs(analyticGrad - numeric) / denom < tolerance;
+        };
+
+        for (let k = 0; k < this.filterCount; k++) {
+            for (let i = 0; i < this.filterSize; i++) {
+                for (let j = 0; j < this.filterSize; j++) {
+                    if (!ok(analytic.filters[k][i][j], () => this.filters[k][i][j], v => { this.filters[k][i][j] = v; })) return false;
+                }
+            }
+            if (!ok(analytic.filterBiases[k], () => this.filterBiases[k], v => { this.filterBiases[k] = v; })) return false;
+        }
+        for (let v = 0; v < this.flattenedLength; v++) {
+            for (let c = 0; c < this.classCount; c++) {
+                if (!ok(analytic.denseWeights[v][c], () => this.denseWeights[v][c], val => { this.denseWeights[v][c] = val; })) return false;
+            }
+        }
+        for (let c = 0; c < this.classCount; c++) {
+            if (!ok(analytic.denseBiases[c], () => this.denseBiases[c], val => { this.denseBiases[c] = val; })) return false;
+        }
+        return true;
+    }
+
+    /* Parameter setters */
+
+    public setInputShape (height: number, width: number) {
+        this.inputHeight = height;
+        this.inputWidth = width;
+        return this;
+    }
+
+    public setFilterCount (filterCount: number) {
+        this.filterCount = filterCount;
+        return this;
+    }
+
+    public setFilterSize (filterSize: number) {
+        this.filterSize = filterSize;
+        return this;
+    }
+
+    public setLearningRate (learningRate: number) {
+        this.learningRate = learningRate;
+        return this;
+    }
+
+    public setNumberOfEpochs (numberOfEpochs: number) {
+        this.numberOfEpochs = numberOfEpochs;
+        return this;
+    }
+
+    public setSeed (seed: number) {
+        this.seed = seed;
+        return this;
+    }
+
+    public reset () {
+        this.filters = undefined;
+        return this;
+    }
+
+    /* Parameter getters */
+
+    public getFilterCount () {
+        return this.filterCount;
+    }
+
+    public getFilterSize () {
+        return this.filterSize;
+    }
+
+    public getLearningRate () {
+        return this.learningRate;
+    }
+
+    public getNumberOfEpochs () {
+        return this.numberOfEpochs;
+    }
+
+    public getSeed () {
+        return this.seed;
+    }
+
+    /** The learned filters (`filterCount × filterSize × filterSize`) — the patterns each one detects. */
+    public getFilters () {
+        return this.filters ? this.filters.map(filter => filter.map(row => row.slice())) : [];
+    }
+
+    /** The post-ReLU feature maps a single (flattened) image produces — one per filter. */
+    public getConvMaps (inputRow: number[]) {
+        return this.forward(this.reshape(inputRow)).convActivated.map(map => map.map(row => row.slice()));
+    }
+
+    /* Private methods */
+
+    private initialize (classCount: number) {
+        const random = mulberry32(this.seed);
+        const f = this.filterSize;
+
+        this.classCount = classCount;
+        this.convHeight = this.inputHeight - f + 1;
+        this.convWidth = this.inputWidth - f + 1;
+        this.poolHeight = Math.floor(this.convHeight / 2);
+        this.poolWidth = Math.floor(this.convWidth / 2);
+        this.flattenedLength = this.filterCount * this.poolHeight * this.poolWidth;
+
+        // Xavier-ish uniform init.
+        const convScale = Math.sqrt(6 / (f * f + f * f));
+        this.filters = Array.from({ length: this.filterCount }, () =>
+            Array.from({ length: f }, () => Array.from({ length: f }, () => (random() * 2 - 1) * convScale)));
+        this.filterBiases = new Array<number>(this.filterCount).fill(0);
+
+        const denseScale = Math.sqrt(6 / (this.flattenedLength + this.classCount));
+        this.denseWeights = Array.from({ length: this.flattenedLength }, () =>
+            Array.from({ length: this.classCount }, () => (random() * 2 - 1) * denseScale));
+        this.denseBiases = new Array<number>(this.classCount).fill(0);
+    }
+
+    private reshape (row: number[]) {
+        const image: number[][] = [];
+        for (let i = 0; i < this.inputHeight; i++) {
+            image.push(row.slice(i * this.inputWidth, (i + 1) * this.inputWidth));
+        }
+        return image;
+    }
+
+    private forward (image: number[][]) {
+        const f = this.filterSize;
+        const convPre: number[][][] = [];
+        const convActivated: number[][][] = [];
+
+        // Convolution (valid cross-correlation) + ReLU.
+        for (let k = 0; k < this.filterCount; k++) {
+            const pre: number[][] = [];
+            const act: number[][] = [];
+            for (let i = 0; i < this.convHeight; i++) {
+                const preRow: number[] = [];
+                const actRow: number[] = [];
+                for (let j = 0; j < this.convWidth; j++) {
+                    let sum = this.filterBiases[k];
+                    for (let di = 0; di < f; di++) {
+                        for (let dj = 0; dj < f; dj++) {
+                            sum += image[i + di][j + dj] * this.filters[k][di][dj];
+                        }
+                    }
+                    preRow.push(sum);
+                    actRow.push(sum > 0 ? sum : 0);
+                }
+                pre.push(preRow);
+                act.push(actRow);
+            }
+            convPre.push(pre);
+            convActivated.push(act);
+        }
+
+        // 2×2 max-pool (stride 2); remember which cell won, for backprop.
+        const poolArgs: [number, number][][][] = [];
+        const flattened: number[] = [];
+        for (let k = 0; k < this.filterCount; k++) {
+            const args: [number, number][][] = [];
+            for (let pi = 0; pi < this.poolHeight; pi++) {
+                const argRow: [number, number][] = [];
+                for (let pj = 0; pj < this.poolWidth; pj++) {
+                    let best = -Infinity;
+                    let bestDi = 0;
+                    let bestDj = 0;
+                    for (let di = 0; di < 2; di++) {
+                        for (let dj = 0; dj < 2; dj++) {
+                            const value = convActivated[k][pi * 2 + di][pj * 2 + dj];
+                            if (value > best) {
+                                best = value;
+                                bestDi = di;
+                                bestDj = dj;
+                            }
+                        }
+                    }
+                    argRow.push([bestDi, bestDj]);
+                    flattened.push(best);
+                }
+                args.push(argRow);
+            }
+            poolArgs.push(args);
+        }
+
+        // Dense → softmax.
+        const logits = new Array<number>(this.classCount);
+        for (let c = 0; c < this.classCount; c++) {
+            let sum = this.denseBiases[c];
+            for (let v = 0; v < this.flattenedLength; v++) {
+                sum += flattened[v] * this.denseWeights[v][c];
+            }
+            logits[c] = sum;
+        }
+        const probabilities = softmax(logits);
+
+        return { convPre, convActivated, poolArgs, flattened, probabilities };
+    }
+
+    private accumulateGradients (image: number[][], cache: ReturnType<ConvolutionalNeuralNetwork['forward']>, label: number[], gradients: Gradients) {
+        const f = this.filterSize;
+
+        // Softmax + cross-entropy: dLoss/dLogit = prediction − target.
+        const dLogits = new Array<number>(this.classCount);
+        for (let c = 0; c < this.classCount; c++) {
+            dLogits[c] = cache.probabilities[c] - label[c];
+        }
+
+        // Dense layer.
+        const dFlattened = new Array<number>(this.flattenedLength).fill(0);
+        for (let c = 0; c < this.classCount; c++) {
+            gradients.denseBiases[c] += dLogits[c];
+            for (let v = 0; v < this.flattenedLength; v++) {
+                gradients.denseWeights[v][c] += cache.flattened[v] * dLogits[c];
+                dFlattened[v] += this.denseWeights[v][c] * dLogits[c];
+            }
+        }
+
+        // Un-flatten, route through max-pool, then ReLU, into the conv pre-activations.
+        let v = 0;
+        for (let k = 0; k < this.filterCount; k++) {
+            for (let pi = 0; pi < this.poolHeight; pi++) {
+                for (let pj = 0; pj < this.poolWidth; pj++) {
+                    const grad = dFlattened[v++];
+                    const [di, dj] = cache.poolArgs[k][pi][pj];
+                    const ci = pi * 2 + di;
+                    const cj = pj * 2 + dj;
+                    // ReLU: gradient only flows where the pre-activation was positive.
+                    if (cache.convPre[k][ci][cj] <= 0 || grad === 0) {
+                        continue;
+                    }
+                    gradients.filterBiases[k] += grad;
+                    for (let fi = 0; fi < f; fi++) {
+                        for (let fj = 0; fj < f; fj++) {
+                            gradients.filters[k][fi][fj] += image[ci + fi][cj + fj] * grad;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private applyGradients (gradients: Gradients, exampleCount: number) {
+        const step = this.learningRate / exampleCount;
+
+        for (let k = 0; k < this.filterCount; k++) {
+            this.filterBiases[k] -= step * gradients.filterBiases[k];
+            for (let i = 0; i < this.filterSize; i++) {
+                for (let j = 0; j < this.filterSize; j++) {
+                    this.filters[k][i][j] -= step * gradients.filters[k][i][j];
+                }
+            }
+        }
+        for (let v = 0; v < this.flattenedLength; v++) {
+            for (let c = 0; c < this.classCount; c++) {
+                this.denseWeights[v][c] -= step * gradients.denseWeights[v][c];
+            }
+        }
+        for (let c = 0; c < this.classCount; c++) {
+            this.denseBiases[c] -= step * gradients.denseBiases[c];
+        }
+    }
+
+    private zeroGradients (): Gradients {
+        return {
+            filters: Array.from({ length: this.filterCount }, () =>
+                Array.from({ length: this.filterSize }, () => new Array<number>(this.filterSize).fill(0))),
+            filterBiases: new Array<number>(this.filterCount).fill(0),
+            denseWeights: Array.from({ length: this.flattenedLength }, () => new Array<number>(this.classCount).fill(0)),
+            denseBiases: new Array<number>(this.classCount).fill(0),
+        };
+    }
+}
+
+interface Gradients {
+    filters: number[][][];
+    filterBiases: number[];
+    denseWeights: number[][];
+    denseBiases: number[];
+}
+
+function softmax (logits: number[]) {
+    const max = Math.max(...logits);
+    const exps = logits.map(value => Math.exp(value - max));
+    const sum = exps.reduce((a, b) => a + b, 0);
+    return exps.map(value => value / sum);
+}

--- a/src/test/ConvolutionalNeuralNetwork.test.ts
+++ b/src/test/ConvolutionalNeuralNetwork.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import ConvolutionalNeuralNetwork from '../lib/machine-learning/supervised/ConvolutionalNeuralNetwork';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+
+// A tiny translation-invariant task: an 8×8 image with a single horizontal line (class 0) or a
+// single vertical line (class 1), at varying positions. A CNN should learn to spot the orientation
+// wherever it sits — exactly what a dense net struggles with.
+const SIZE = 8;
+function line(orientation: 'h' | 'v', position: number): number[] {
+    const image = new Array<number>(SIZE * SIZE).fill(0);
+    for (let k = 0; k < SIZE; k++) {
+        image[orientation === 'h' ? position * SIZE + k : k * SIZE + position] = 1;
+    }
+    return image;
+}
+const POSITIONS = [1, 2, 4, 5, 6];
+const IMAGES = [...POSITIONS.map(p => line('h', p)), ...POSITIONS.map(p => line('v', p))];
+const LABELS = [...POSITIONS.map(() => [1, 0]), ...POSITIONS.map(() => [0, 1])];
+
+describe('ConvolutionalNeuralNetwork', () => {
+
+    it('verifies its convolution backprop against finite differences', () => {
+        const small = new ConvolutionalNeuralNetwork().setInputShape(6, 6).setFilterCount(2).setSeed(1);
+        expect(small.checkGradients()).toBe(true);
+
+        // …and at the default (larger) configuration too.
+        const big = new ConvolutionalNeuralNetwork().setInputShape(8, 8).setFilterCount(4).setSeed(3);
+        expect(big.checkGradients()).toBe(true);
+    });
+
+    it('learns horizontal-vs-vertical regardless of position', () => {
+        const model = new ConvolutionalNeuralNetwork()
+            .setInputShape(SIZE, SIZE)
+            .setFilterCount(4)
+            .setLearningRate(0.3)
+            .setNumberOfEpochs(400)
+            .setSeed(0);
+        model.train(new Matrix(IMAGES), new Matrix(LABELS));
+
+        const predicted = model.predict(new Matrix(IMAGES)).getMaximumRowIndeces().toArray().map(row => row[0]);
+        const truth = LABELS.map(row => (row[0] === 1 ? 0 : 1));
+        const correct = predicted.filter((p, i) => p === truth[i]).length;
+        expect(correct).toBe(IMAGES.length); // all of them
+    });
+
+    it('returns class probabilities that sum to 1', () => {
+        const model = new ConvolutionalNeuralNetwork().setInputShape(SIZE, SIZE).setFilterCount(3).setSeed(0);
+        model.train(new Matrix(IMAGES), new Matrix(LABELS));
+
+        const predictions = model.predict(new Matrix(IMAGES)).toArray();
+        expect(predictions[0].length).toBe(2);
+        for (const row of predictions) {
+            expect(row[0] + row[1]).toBeCloseTo(1, 6);
+        }
+    });
+
+    it('is deterministic for a fixed seed, and the loss falls', () => {
+        const train = () => {
+            const model = new ConvolutionalNeuralNetwork().setInputShape(SIZE, SIZE).setFilterCount(4).setNumberOfEpochs(50).setSeed(2);
+            const before = model.train(new Matrix(IMAGES), new Matrix(LABELS)).computeLoss(new Matrix(IMAGES), new Matrix(LABELS));
+            return { predictions: model.predict(new Matrix(IMAGES)).toArray(), before };
+        };
+        const a = train();
+        const b = train();
+        expect(a.predictions).toEqual(b.predictions);
+
+        const fresh = new ConvolutionalNeuralNetwork().setInputShape(SIZE, SIZE).setFilterCount(4).setSeed(2);
+        const initialLoss = fresh.setNumberOfEpochs(0).train(new Matrix(IMAGES), new Matrix(LABELS)).computeLoss(new Matrix(IMAGES), new Matrix(LABELS));
+        expect(a.before).toBeLessThan(initialLoss);
+    });
+
+    it('round-trips its hyperparameters and chains setters', () => {
+        const model = new ConvolutionalNeuralNetwork();
+        expect(model.getFilterCount()).toBe(6);
+
+        const returned = model.setInputShape(10, 10).setFilterCount(8).setFilterSize(5).setLearningRate(0.05).setNumberOfEpochs(20).setSeed(9);
+        expect(returned).toBe(model);
+        expect(model.getFilterCount()).toBe(8);
+        expect(model.getFilterSize()).toBe(5);
+        expect(model.getLearningRate()).toBe(0.05);
+        expect(model.getNumberOfEpochs()).toBe(20);
+        expect(model.getSeed()).toBe(9);
+    });
+});


### PR DESCRIPTION
The course's first **Part 4 / Phase-2 frontier build** — a full trainable convolutional network, paying off Ch 20's "reading an image needs neighbouring pixels" tease. Built from scratch (conv + pool + backprop) rather than the course plan's `(adopts)` explainer.

## Library — `ConvolutionalNeuralNetwork`
- Architecture: **conv (K filters, ReLU) → 2×2 max-pool → flatten → dense → softmax**, trained by backprop (gradient routed through the pool's winners and back into the shared filters).
- `train(images, oneHot)` / `predict` / `computeLoss`; `getFilters()` + `getConvMaps()` for visualization; **`checkGradients()`** — finite-difference verification of the (error-prone) convolution backprop.
- Exported; added to demo, README, keywords. **5 tests**, including the gradient check at two configs (both pass) and "learns orientation regardless of position." Suite: 154 → **159**, all green.

## Site
- `cnnDatasets.ts` (tiny 12×12 latte-art stroke images: 3 pour directions, random positions + noise), `viz/cnn.ts` (grayscale image/feature-map grids + a diverging blue↔amber filter view), and `CNNPlayground.tsx` — live training where the filters **sharpen from noise into edge detectors**, feature maps light up along the stroke, accuracy/loss track, and a ✓ Gradients verified badge.
- Registered Ch 21 in `algorithms.ts` + `App.tsx`; `content/cnn.mdx` ("Seeing the pour"), honest about *partial* shift-tolerance and teasing sequences/RNNs.
- `course-plan.md`: Ch 21 ✅.

## Verification
- Library: `yarn typecheck` + `yarn test` (159) clean; gradient check passes; both datasets train to ~100% within ~50 epochs.
- Site: `yarn typecheck` + `yarn build` clean (own lazy chunk).

No version bump — accumulates on `master` for the next release. Merging redeploys the site via `deploy-site.yml`.