### PR TITLE
Release 0.9.0: Recurrent Networks (Chapter 22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Below are some simple code usage examples.
 * [Gradient Boosting](#gradient-boosting)
 * [Support Vector Machine](#support-vector-machine)
 * [Convolutional Neural Network](#convolutional-neural-network)
+* [Recurrent Neural Network](#recurrent-neural-network)
 * [k-Means Clustering](#k-means-clustering)
 * [Hierarchical Clustering](#hierarchical-clustering)
 * [DBSCAN](#dbscan)
@@ -292,6 +293,34 @@ console.log(cnn.predict(images).getMaximumRowIndeces().toArray());
 
 console.log('gradients verified:', cnn.checkGradients());
 // gradients verified: true  <- finite-difference check of the convolution backprop
+
+```
+
+### Recurrent Neural Network
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// RNN: embedding -> recurrent hidden state -> dense softmax, trained by backprop-through-time.
+// Read a tiny review and classify sentiment. Vocab: 0=<pad> 1=the 2=coffee 3=service 4=was 5=great 6=terrible
+const reviews = new ml.Matrix([
+    [1, 2, 4, 5, 0], // the coffee was great    -> positive
+    [1, 3, 4, 5, 0], // the service was great   -> positive
+    [1, 2, 4, 6, 0], // the coffee was terrible -> negative
+    [1, 3, 4, 6, 0], // the service was terrible -> negative
+]);
+const sentiment = new ml.Matrix([[1, 0], [1, 0], [0, 1], [0, 1]]); // [positive, negative]
+
+const rnn = new ml.RecurrentNeuralNetwork();
+rnn.setVocabSize(7).setEmbeddingDim(2).setHiddenSize(8).setLearningRate(0.1).setNumberOfEpochs(400).setSeed(0);
+
+rnn.train(reviews, sentiment);
+
+console.log(rnn.predict(reviews).getMaximumRowIndeces().toArray());
+// [ [ 0 ], [ 0 ], [ 1 ], [ 1 ] ]  <- "great" -> positive (0), "terrible" -> negative (1)
+
+console.log('gradients verified:', rnn.checkGradients());
+// gradients verified: true  <- finite-difference check of backprop-through-time
 
 ```
 

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -30,10 +30,11 @@ generative). The built algorithms become the spine; everything else is roadmap.
 the whole of Part 2 (k‑NN, Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support
 Vector Machines), all of Part 3 (k‑Means, Hierarchical Clustering, DBSCAN, PCA, Anomaly Detection,
 Association Rules, Recommender Systems), and Part 4 — Time Series, the Perceptron interlude, Neural
-Networks, and now **Ch 21 Convolutional Networks** (the newest chapter: a from-scratch trainable CNN
-with conv/pool/backprop and gradient checking — built fully rather than the planned "adopts"
-explainer). Still roadmap: RNNs/transformers (Ch 22–23), the reinforcement-learning arc (Ch 24–27),
-generative, and Bayesian — new builds the library grows into. See the status column below.
+Networks, Convolutional Networks, and now **Ch 22 Recurrent Networks** (the newest chapter: a
+from-scratch trainable RNN with a learned embedding layer + backprop-through-time + gradient
+checking — again built fully rather than the planned "adopts" explainer). The two deep-learning
+frontier chapters (CNN, RNN) both became full trainable builds. Still roadmap: Transformers (Ch 23),
+the reinforcement-learning arc (Ch 24–27), generative, and Bayesian. See the status column below.
 
 ---
 
@@ -176,7 +177,7 @@ Every row's "Wall" is the previous tool failing.
 | — | *Interlude: The Perceptron* | A single artificial "brain cell" | Built as a short history interlude (Priya shows Nadia where neural nets came from): weighted sum + activation; why one neuron can't do XOR | ✅ `Perceptron` (interlude) |
 | 20 | **Neural Networks & Backprop** | Danger/delight hides in *combinations* of cues (XNOR-like) | k-NN is slow, memoryless, and dumb in high dimensions; linear can't combine → **stack layers that learn features**; backprop ("blame flows backward"); dropout; SGD/Adam | ✅ `FeedforwardNeuralNetwork` |
 | 21 | **Convolutional Nets (CNNs)** | Grade latte-art photos / spot pastry defects / scan receipts | Dense nets ignore spatial structure → **convolutions**, filters, pooling (computer vision) | ✅ `ConvolutionalNeuralNetwork` (built from scratch — exceeded the "adopts" plan) |
-| 22 | **Recurrent Nets / LSTMs** | Learn *sequence & text representations* (reviews, chat logs) — **not** forecasting (that's Ch 19) | Feedforward has no memory of order; this is the bridge to language → recurrence, memory, vanishing gradients. *Embeddings are introduced here as connective tissue* — learned word/item **vectors** where "similar sits close" (also reused by recsys, Ch 18) | ○ (adopts) |
+| 22 | **Recurrent Nets / LSTMs** | Learn *sequence & text representations* (reviews, chat logs) — **not** forecasting (that's Ch 19) | Feedforward has no memory of order; this is the bridge to language → recurrence, memory, vanishing gradients. *Embeddings are introduced here as connective tissue* — learned word/item **vectors** where "similar sits close" (also reused by recsys, Ch 18) | ✅ `RecurrentNeuralNetwork` (built from scratch — RNN + embeddings + BPTT; exceeded the "adopts" plan) |
 | 23 | **Transformers & Attention** | The café's AI assistant / chatbot | RNNs forget long context & don't parallelize → **attention**; the modern backbone (and a nod to the model writing this) | ○ (adopts) |
 
 ### Part 5 — Learning by doing: reinforcement learning (Season 4)

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -233,6 +233,27 @@ import * as ml from '../src/lib';
 }
 
 {
+    // Recurrent neural network: read a sequence (a tiny review) and classify its sentiment.
+    // Vocabulary: 0=<pad> 1=the 2=coffee 3=service 4=was 5=great 6=terrible
+    const reviews = new ml.Matrix([
+        [1, 2, 4, 5, 0], // the coffee was great   → positive
+        [1, 3, 4, 5, 0], // the service was great  → positive
+        [1, 2, 4, 6, 0], // the coffee was terrible → negative
+        [1, 3, 4, 6, 0], // the service was terrible → negative
+    ]);
+    const sentiment = new ml.Matrix([[1, 0], [1, 0], [0, 1], [0, 1]]); // [positive, negative]
+
+    const rnn = new ml.RecurrentNeuralNetwork();
+    rnn.setVocabSize(7).setEmbeddingDim(2).setHiddenSize(8).setLearningRate(0.1).setNumberOfEpochs(400).setSeed(0);
+
+    rnn.train(reviews, sentiment);
+    console.log(rnn.predict(reviews).getMaximumRowIndeces().toArray());
+    // [ [ 0 ], [ 0 ], [ 1 ], [ 1 ] ]  ← "great" reviews → positive (0), "terrible" → negative (1)
+    console.log('RNN gradients verified:', rnn.checkGradients());
+    // RNN gradients verified: true  ← finite-difference check of backprop-through-time
+}
+
+{
     // Naive Bayes (multinomial): classify messages by word counts.
     // Vocabulary [free, money, table, tonight]; one-hot classes [spam, ham].
     const inputs = new ml.Matrix([[2, 1, 0, 0], [1, 2, 0, 0], [0, 0, 2, 1], [0, 0, 1, 2]]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-learning",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "TypeScript & JavaScript machine learning library",
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,11 @@
     "convolutional neural network",
     "cnn",
     "deep learning",
-    "computer vision"
+    "computer vision",
+    "recurrent neural network",
+    "rnn",
+    "embeddings",
+    "nlp"
   ],
   "author": "Erik Gerrits <gerrits.erik@gmail.com>",
   "license": "MIT",

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -31,6 +31,7 @@ const RecommenderSystemsTutorial = lazy(() => import('./content/recommender-syst
 const TimeSeriesTutorial = lazy(() => import('./content/time-series.mdx'));
 const PerceptronTutorial = lazy(() => import('./content/perceptron.mdx'));
 const CNNTutorial = lazy(() => import('./content/cnn.mdx'));
+const RNNTutorial = lazy(() => import('./content/rnn.mdx'));
 
 export function App() {
     return (
@@ -218,6 +219,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <CNNTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="rnn"
+                    element={
+                        <TutorialPage>
+                            <RNNTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -229,4 +229,13 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         chapter: 21,
         part: PART_4,
     },
+    {
+        id: 'rnn',
+        path: '/rnn',
+        title: 'Recurrent Networks',
+        tagline: 'Read a sequence word by word, carrying a memory of what came before.',
+        status: 'live',
+        chapter: 22,
+        part: PART_4,
+    },
 ];

--- a/site/src/components/RNNPlayground.module.css
+++ b/site/src/components/RNNPlayground.module.css
@@ -1,0 +1,83 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.boundaryWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 1 / 1;
+}
+
+.boundary {
+    width: 100%;
+    height: 100%;
+}
+
+.legend {
+    position: absolute;
+    bottom: 10px;
+    left: 12px;
+    display: flex;
+    gap: 14px;
+    font-size: 12px;
+    background: rgba(11, 17, 32, 0.6);
+    padding: 4px 10px;
+    border-radius: 999px;
+    backdrop-filter: blur(4px);
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.sampleList {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.sample {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    font-size: 12px;
+}
+
+.sampleText {
+    color: var(--muted);
+    font-style: italic;
+}
+
+.lossCanvas {
+    display: block;
+    width: 100%;
+    height: 130px;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/RNNPlayground.tsx
+++ b/site/src/components/RNNPlayground.tsx
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { RecurrentNeuralNetwork, Matrix } from 'machine-learning';
+import { RNN_DATASETS } from '../ml/rnnDatasets';
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+import { fitCanvas } from '../viz/canvas';
+import { drawEmbeddings } from '../viz/rnn';
+import { drawLossCurve } from '../viz/lossCurve';
+import { Badge, Card, ControlPanel, Hint, Metric, MetricsRow, NumberField, RunControls, Select, Slider } from './controls/Controls';
+import styles from './RNNPlayground.module.css';
+
+const POINTS = 80;
+const SAMPLE_COUNT = 4;
+
+interface TrainingData {
+    inputs: number[][];
+    targets: number[][];
+    inputMatrix: Matrix;
+    targetMatrix: Matrix;
+    vocab: string[];
+    classNames: string[];
+    positive: Set<number>;
+    negative: Set<number>;
+}
+
+export function RNNPlayground() {
+    const [datasetId, setDatasetId] = useState(RNN_DATASETS[0].id);
+    const [rateSlider, setRateSlider] = useState(10); // lr = rateSlider / 100
+    const [stepsPerFrame, setStepsPerFrame] = useState(4);
+    const [seed, setSeed] = useState(0);
+    const [running, setRunning] = useState(false);
+    const [gradOk, setGradOk] = useState<boolean | null>(null);
+    const [metrics, setMetrics] = useState({ epoch: 0, loss: 0, acc: 0 });
+    const [samples, setSamples] = useState<{ words: string; predicted: number; correct: boolean }[]>([]);
+
+    const learningRate = rateSlider / 100;
+    const lrRef = useRef(learningRate);
+    const stepsRef = useRef(stepsPerFrame);
+    lrRef.current = learningRate;
+    stepsRef.current = stepsPerFrame;
+
+    const modelRef = useRef<RecurrentNeuralNetwork | null>(null);
+    const dataRef = useRef<TrainingData | null>(null);
+    const lossRef = useRef<number[]>([]);
+    const epochRef = useRef(0);
+    const frameRef = useRef(0);
+
+    const embedCanvasRef = useRef<HTMLCanvasElement | null>(null);
+    const lossCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const refreshStats = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        if (!model || !data) return;
+
+        const preds = model.predict(data.inputMatrix).getMaximumRowIndeces().toArray().map(r => r[0]);
+        const truth = data.targets.map(t => t.indexOf(1));
+        const correct = preds.filter((p, i) => p === truth[i]).length;
+
+        const sample = [];
+        for (let i = 0; i < SAMPLE_COUNT; i++) {
+            const idx = Math.floor((i / SAMPLE_COUNT) * data.inputs.length);
+            const words = data.inputs[idx].filter(t => t > 0).map(t => data.vocab[Math.round(t)]).join(' ');
+            sample.push({ words, predicted: preds[idx], correct: preds[idx] === truth[idx] });
+        }
+        setSamples(sample);
+        setMetrics({ epoch: epochRef.current, loss: model.computeLoss(data.inputMatrix, data.targetMatrix), acc: correct / preds.length });
+    }, []);
+
+    const drawAll = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        if (!model || !data) return;
+
+        const canvas = embedCanvasRef.current;
+        if (canvas) {
+            const { ctx, width, height } = fitCanvas(canvas);
+            ctx.fillStyle = '#0b1120';
+            ctx.fillRect(0, 0, width, height);
+            drawEmbeddings(ctx, width, height, model.getEmbeddings(), data.vocab, data.positive, data.negative);
+        }
+        const lossCanvas = lossCanvasRef.current;
+        if (lossCanvas) {
+            const { ctx, width, height } = fitCanvas(lossCanvas);
+            drawLossCurve(ctx, width, height, lossRef.current);
+        }
+    }, []);
+
+    const rebuild = useCallback(() => {
+        const dataset = RNN_DATASETS.find(d => d.id === datasetId) ?? RNN_DATASETS[0];
+        const { inputs, targets } = dataset.generate(seed, POINTS);
+        const inputMatrix = new Matrix(inputs);
+        const targetMatrix = new Matrix(targets);
+
+        const model = new RecurrentNeuralNetwork()
+            .setVocabSize(dataset.vocab.length)
+            .setEmbeddingDim(2)
+            .setHiddenSize(12)
+            .setLearningRate(lrRef.current)
+            .setNumberOfEpochs(1)
+            .setSeed(seed);
+        model.train(inputMatrix, targetMatrix); // one pass to initialise weights/shapes
+
+        modelRef.current = model;
+        dataRef.current = {
+            inputs, targets, inputMatrix, targetMatrix,
+            vocab: dataset.vocab, classNames: dataset.classNames,
+            positive: new Set(dataset.positiveTokens), negative: new Set(dataset.negativeTokens),
+        };
+        lossRef.current = [model.computeLoss(inputMatrix, targetMatrix)];
+        epochRef.current = 1;
+        frameRef.current = 0;
+
+        setGradOk(model.checkGradients());
+        drawAll();
+        refreshStats();
+    }, [datasetId, seed, drawAll, refreshStats]);
+
+    useEffect(() => { rebuild(); }, [rebuild]);
+    useEffect(() => { if (modelRef.current) modelRef.current.setLearningRate(learningRate); }, [learningRate]);
+
+    const step = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        if (!model || !data) return;
+
+        for (let i = 0; i < stepsRef.current; i++) model.train(data.inputMatrix, data.targetMatrix);
+        epochRef.current += stepsRef.current;
+
+        lossRef.current.push(model.computeLoss(data.inputMatrix, data.targetMatrix));
+        if (lossRef.current.length > 1200) lossRef.current.shift();
+
+        drawAll();
+        frameRef.current += 1;
+        if (frameRef.current % 3 === 0) refreshStats();
+    }, [drawAll, refreshStats]);
+
+    useAnimationFrame(step, running);
+
+    const handleStep = () => { if (!running) step(); };
+    const handleReset = () => { setRunning(false); rebuild(); };
+    const handleDataset = (id: string) => { setDatasetId(id); };
+
+    const dataset = RNN_DATASETS.find(d => d.id === datasetId);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <RunControls running={running} onToggle={() => setRunning(r => !r)} onStep={handleStep} onReset={handleReset} />
+                <Select
+                    label="Reviews"
+                    value={datasetId}
+                    options={RNN_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={handleDataset}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Slider label="Learning rate" value={rateSlider} display={learningRate.toFixed(2)} min={2} max={40} onChange={setRateSlider} />
+                <Slider label="Speed" value={stepsPerFrame} display={`${stepsPerFrame} epochs / frame`} min={1} max={10} onChange={setStepsPerFrame} />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+                <Hint>The scatter is the learned word vectors. Watch positive and negative words drift apart.</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.boundaryWrap}>
+                    <canvas ref={embedCanvasRef} className={styles.boundary} />
+                    <div className={styles.legend}>
+                        <span style={{ color: '#fb923c' }}>● positive</span>
+                        <span style={{ color: '#38bdf8' }}>● negative</span>
+                        <span style={{ color: '#94a3b8' }}>● filler</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Epoch" value={String(metrics.epoch)} />
+                        <Metric label="Loss" value={metrics.loss.toFixed(3)} />
+                        <Metric label="Accuracy" value={`${(metrics.acc * 100).toFixed(0)}%`} />
+                    </MetricsRow>
+
+                    {gradOk && <Badge>✓ Gradients verified</Badge>}
+
+                    <Card title="Reading reviews" subtitle="prediction per sample">
+                        <ul className={styles.sampleList}>
+                            {samples.map((s, i) => (
+                                <li key={i} className={styles.sample}>
+                                    <span className={styles.sampleText}>"{s.words}"</span>
+                                    <span style={{ color: s.correct ? '#34d399' : '#f87171' }}>
+                                        {dataset?.classNames[s.predicted]}
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
+                    </Card>
+
+                    <Card title="Loss" subtitle="cross-entropy per epoch">
+                        <canvas ref={lossCanvasRef} className={styles.lossCanvas} />
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/content/rnn.mdx
+++ b/site/src/content/rnn.mdx
@@ -1,0 +1,103 @@
+import { RNNPlayground } from '../components/RNNPlayground';
+
+# Chapter 22 — Reading the reviews
+
+> *Recurrent networks.* A photo is a grid you can take in at a glance. A review is a *stream* — words
+> arriving one after another, where the order and what came before are the whole point.
+
+The app is filling up with written reviews now — "the latte was lovely", "rude staff, cold coffee" —
+and Nadia wants it to read them: tag each one's sentiment, and eventually understand them. But a
+review isn't a fixed grid of pixels. It's a variable-length run of *words*, and meaning lives in the
+sequence.
+
+## The wall: no order, and words aren't numbers
+
+Everything she's built takes a fixed-size input all at once. Two problems hit immediately. First,
+**order**: flatten a review into a bag of words and you throw away the sequence; pad it to a fixed
+length and feed it to a dense net, and "great" in the first slot looks like a totally different input
+from "great" in the fourth — the CNN's translation problem, now in *time*. Second, **words aren't
+numbers**: if you just hand the network token id 5 for "coffee" and 1 for "the", it'll assume coffee
+is somehow five-times-the, which is nonsense. She needs a way to *represent* words, and a way to
+*read in order while remembering*.
+
+## The idea: embeddings + a hidden state that carries
+
+Two pieces solve it. First, an **embedding**: give every word its own short learned vector instead of
+a bare id. Training is free to discover that "great" and "lovely" should point in similar directions
+— the same "similar sits close" trick the recommender used for items in Chapter 18. Second,
+**recurrence**: walk the review word by word, keeping a **hidden state** that updates at every step,
+so what was read earlier shapes how later words land:
+
+$$
+h_t = \tanh(W_{xh}\,x_t + W_{hh}\,h_{t-1} + b), \qquad \hat{y} = \mathrm{softmax}(W_{hy}\,h_T + b_y)
+$$
+
+Read to the last word, then turn the final state into the verdict. Below it's just two embedding
+dimensions so you can watch them move — press **Train** and the positive and negative words drift
+apart while the fillers stay in the muddle:
+
+<div className="breakout">
+  <RNNPlayground />
+</div>
+
+## How it works: walk the sequence, carrying state
+
+Each step looks up the word's embedding and mixes it with the running memory, straight from the
+[`RecurrentNeuralNetwork`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/supervised/RecurrentNeuralNetwork.ts)
+source:
+
+```ts
+const embedding = this.embeddings[token];                  // word → its learned vector
+for (let h = 0; h < H; h++) {
+    let sum = this.hiddenBias[h];
+    for (let d = 0; d < D; d++) sum += embedding[d] * Wxh[d][h]; // the new word…
+    for (let i = 0; i < H; i++) sum += previous[i] * Whh[i][h];  // …mixed with the memory so far
+    next[h] = Math.tanh(sum);
+}
+```
+
+The final hidden state goes through a dense layer + softmax for the class. Training is
+**backpropagation through time**: unroll the loop and let the blame flow *backward* through every
+step — each step's gradient feeds the step before it, and the same recurrent weights collect their
+share at every position:
+
+```ts
+for (let t = steps - 1; t >= 0; t--) {                 // walk backward through the sequence
+    const dRaw = dh[h] * (1 - current[h] * current[h]); // back through tanh
+    // …accumulate grads for Wxh, Whh, the embedding used, and dh_prev for the earlier step
+}
+```
+
+Because through-time gradients are notoriously easy to get wrong, the model ships a
+`checkGradients()` that finite-difference-verifies them — the ✓ badge in the playground.
+
+## Try it yourself
+
+- Watch the **embedding scatter**. The word vectors start as random dots; as the loss falls, the
+  positive words slide one way and the negative words the other, with fillers like "the" and "was"
+  marooned in between. Nobody told it which words are positive — it inferred it from which reviews
+  they appear in.
+- Read the **sample predictions** flip from wrong to right as training proceeds.
+- Switch to **Longer reviews**: two-clause reviews mean the hidden state must carry meaning further
+  before the verdict — it still gets there, just over more epochs.
+
+> **Field note — the embedding is the quiet star, and memory has a limit.** Those learned word
+> vectors are reusable far beyond this task (search, recommendations — Ch 18's latent factors are the
+> same idea). But notice the catch in backprop-through-time: the further back a signal has to flow,
+> the more it's multiplied down through `tanh` after `tanh` until it nearly **vanishes**. So a plain
+> RNN struggles to connect words far apart, and forgets the start of a long review. Gated variants
+> (**LSTM**, **GRU**) add a protected memory lane to carry signal across long gaps — the standard fix.
+
+## What broke
+
+The RNN can finally *read*: turn words into meaningful vectors and process a sequence in order,
+carrying memory forward. For tagging a short review, it's the right shape.
+
+But two limits are baked into its wiring. It reads **strictly one step at a time, left to right** —
+which can't be parallelised, so it's slow to train on the mountains of text a real app collects. And
+even with gates, it leans on a *single* hidden state to ferry everything forward, so connecting a
+verdict to a detail many words back ("the coffee, despite the *awful* twenty-minute wait, was
+actually wonderful") stays hard. What if, instead of squeezing the whole past through one narrow
+state, every word could look **directly at every other word** and decide for itself which ones
+matter? That's **attention** — the idea behind the **transformer**, the backbone of every modern
+language model, including the one writing this very page. It's where the story goes next.

--- a/site/src/ml/rnnDatasets.ts
+++ b/site/src/ml/rnnDatasets.ts
@@ -1,0 +1,89 @@
+import { mulberry32 } from './rng';
+
+// Tiny café-review data for the RNN playground (Chapter 22). Each review is a sequence of token ids
+// (0 = <pad>), right-padded to a common length; the label is its sentiment. Reviews are built from
+// templates so the sentiment rides on the adjectives — which is what makes the learned word
+// embeddings organise: positive words drift one way, negative the other, fillers stay in the middle.
+export interface RnnDataset {
+    id: string;
+    label: string;
+    blurb: string;
+    vocab: string[];
+    classNames: string[];
+    positiveTokens: number[];
+    negativeTokens: number[];
+    sequenceLength: number;
+    generate: (seed: number, n: number) => { inputs: number[][]; targets: number[][] };
+}
+
+// index 0 is reserved for <pad>.
+const VOCAB = [
+    '<pad>', 'the', 'was', 'and', 'really', // 0–4 fillers
+    'coffee', 'latte', 'service', 'place', 'staff', 'cake', // 5–10 nouns
+    'great', 'amazing', 'lovely', 'friendly', 'perfect', 'cozy', // 11–16 positive
+    'terrible', 'cold', 'slow', 'rude', 'stale', 'awful', // 17–22 negative
+];
+const NOUNS = [5, 6, 7, 8, 9, 10];
+const POSITIVE = [11, 12, 13, 14, 15, 16];
+const NEGATIVE = [17, 18, 19, 20, 21, 22];
+
+function pad(tokens: number[], length: number) {
+    const row = tokens.slice(0, length);
+    while (row.length < length) row.push(0);
+    return row;
+}
+
+function generator(length: number, withLongTemplates: boolean) {
+    return (seed: number, n: number) => {
+        const rand = mulberry32(seed);
+        const pick = (arr: number[]) => arr[Math.floor(rand() * arr.length)];
+        const inputs: number[][] = [];
+        const targets: number[][] = [];
+
+        for (let i = 0; i < n; i++) {
+            const positive = i % 2 === 0;
+            const adj = () => (positive ? pick(POSITIVE) : pick(NEGATIVE));
+            const noun = () => pick(NOUNS);
+
+            const templates: number[][] = [
+                [1, noun(), 2, adj()],              // the <noun> was <adj>
+                [adj(), noun()],                    // <adj> <noun>
+                [1, noun(), 2, 4, adj()],           // the <noun> was really <adj>
+            ];
+            if (withLongTemplates) {
+                templates.push([noun(), 2, adj(), 3, adj()]);          // <noun> was <adj> and <adj>
+                templates.push([1, noun(), 2, adj(), 3, 1, noun(), 2, adj()]); // two clauses
+            }
+            const tokens = templates[Math.floor(rand() * templates.length)];
+
+            inputs.push(pad(tokens, length));
+            targets.push(positive ? [1, 0] : [0, 1]);
+        }
+        return { inputs, targets };
+    };
+}
+
+export const RNN_DATASETS: RnnDataset[] = [
+    {
+        id: 'reviews',
+        label: 'Café reviews',
+        blurb: 'Short reviews — "the latte was lovely", "rude staff". The net reads each one word by word and learns which words swing the sentiment.',
+        vocab: VOCAB,
+        classNames: ['positive', 'negative'],
+        positiveTokens: POSITIVE,
+        negativeTokens: NEGATIVE,
+        sequenceLength: 6,
+        generate: generator(6, false),
+    },
+    {
+        id: 'long',
+        label: 'Longer reviews',
+        blurb: 'Two-clause reviews that run longer, so the hidden state has to carry meaning further before the verdict. Same vocabulary, more to remember.',
+        vocab: VOCAB,
+        classNames: ['positive', 'negative'],
+        positiveTokens: POSITIVE,
+        negativeTokens: NEGATIVE,
+        sequenceLength: 10,
+        generate: generator(10, true),
+    },
+];

--- a/site/src/viz/rnn.ts
+++ b/site/src/viz/rnn.ts
@@ -1,0 +1,47 @@
+// Scatter of the learned 2-D word embeddings — the heart of the RNN chapter. As training proceeds,
+// words that swing sentiment the same way drift together, so positive and negative words separate
+// while fillers stay in the muddle.
+
+const POS = '#fb923c';   // amber — positive words
+const NEG = '#38bdf8';   // sky — negative words
+const NEUTRAL = '#64748b'; // slate — fillers / nouns
+
+export function drawEmbeddings(
+    ctx: CanvasRenderingContext2D,
+    width: number,
+    height: number,
+    embeddings: number[][],
+    vocab: string[],
+    positive: Set<number>,
+    negative: Set<number>,
+): void {
+    const pad = 26;
+    // Bounds over real tokens (skip <pad> at index 0).
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+    for (let t = 1; t < embeddings.length; t++) {
+        minX = Math.min(minX, embeddings[t][0]);
+        maxX = Math.max(maxX, embeddings[t][0]);
+        minY = Math.min(minY, embeddings[t][1]);
+        maxY = Math.max(maxY, embeddings[t][1]);
+    }
+    const spanX = maxX - minX || 1;
+    const spanY = maxY - minY || 1;
+    const toX = (x: number) => pad + ((x - minX) / spanX) * (width - 2 * pad);
+    const toY = (y: number) => pad + (1 - (y - minY) / spanY) * (height - 2 * pad);
+
+    ctx.font = '10px ui-sans-serif, system-ui, sans-serif';
+    ctx.textBaseline = 'middle';
+    for (let t = 1; t < embeddings.length; t++) {
+        const px = toX(embeddings[t][0]);
+        const py = toY(embeddings[t][1]);
+        const color = positive.has(t) ? POS : negative.has(t) ? NEG : NEUTRAL;
+
+        ctx.beginPath();
+        ctx.arc(px, py, 3, 0, 2 * Math.PI);
+        ctx.fillStyle = color;
+        ctx.fill();
+
+        ctx.fillStyle = color === NEUTRAL ? 'rgba(148,163,184,0.85)' : color;
+        ctx.fillText(vocab[t], px + 5, py);
+    }
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -20,6 +20,7 @@ export { default as NearestNeighbors } from "./machine-learning/supervised/Neare
 export { default as PCA } from "./machine-learning/unsupervised/PCA";
 export { default as Perceptron } from "./machine-learning/supervised/Perceptron";
 export { default as RandomForest } from "./machine-learning/supervised/RandomForest";
+export { default as RecurrentNeuralNetwork } from "./machine-learning/supervised/RecurrentNeuralNetwork";
 export { default as Recommender } from "./machine-learning/unsupervised/Recommender";
 export { default as SupportVectorMachine } from "./machine-learning/supervised/SupportVectorMachine";
 export type { Kernel } from "./machine-learning/supervised/SupportVectorMachine";

--- a/src/lib/machine-learning/supervised/RecurrentNeuralNetwork.ts
+++ b/src/lib/machine-learning/supervised/RecurrentNeuralNetwork.ts
@@ -1,0 +1,335 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+import mulberry32 from "../../math/random/mulberry32";
+
+/**
+ * A small **recurrent neural network** (Elman RNN) with a learned **embedding** layer — the
+ * architecture that learns to *read*. A feedforward net (or a CNN) takes a fixed-size input all at
+ * once and has no notion of order; a sequence — the words of a review, a run of visits — arrives one
+ * step at a time and the meaning lives in the order. An RNN walks the sequence carrying a **hidden
+ * state** that it updates at each step, so what it read earlier colours how it reads what comes next.
+ *
+ * The pipeline, trained end-to-end by **backpropagation through time**:
+ *
+ *   token ids → **embedding** (each token → a learned vector) → **recurrent step**
+ *             `hₜ = tanh(Wxh·xₜ + Whh·hₜ₋₁ + b)` → **dense** on the final state → softmax over classes
+ *
+ * The embedding is the quiet star: training nudges tokens that play similar roles toward similar
+ * vectors, so "similar sits close" falls out for free (the same trick recommenders use for items).
+ *
+ * Inputs are a Matrix whose rows are token-id sequences (integers; **0 is reserved for padding** and
+ * skipped), right-padded to a common length; targets are one-hot rows; `predict` returns class
+ * probabilities. Weights persist across `train()` calls (animate by looping with `numberOfEpochs = 1`).
+ * {@link checkGradients} finite-difference-verifies the through-time gradients.
+ *
+ * @example
+ * const rnn = new RecurrentNeuralNetwork().setVocabSize(20).setEmbeddingDim(2).setHiddenSize(8).setSeed(0);
+ * rnn.setLearningRate(0.1).setNumberOfEpochs(300).train(reviews, sentimentOneHot);
+ * rnn.predict(reviews);     // N × C probabilities
+ * rnn.getEmbeddings();      // V × D — the learned word vectors
+ */
+export default class RecurrentNeuralNetwork {
+
+    private vocabSize = 16;
+    private embeddingDim = 8;
+    private hiddenSize = 12;
+    private learningRate = 0.1;
+    private numberOfEpochs = 1;
+    private seed = 0;
+
+    // Learned parameters.
+    private embeddings: number[][]; // [token][dim]
+    private weightsInputHidden: number[][];  // [dim][hidden]   (Wxh)
+    private weightsHiddenHidden: number[][]; // [hidden][hidden] (Whh)
+    private hiddenBias: number[];            // [hidden]
+    private weightsHiddenOutput: number[][]; // [hidden][class]  (Why)
+    private outputBias: number[];            // [class]
+    private classCount = 0;
+
+    public constructor () {}
+
+    public train (inputs: Matrix, targets: Matrix) {
+        const sequences = inputs.toArray();
+        const labels = targets.toArray();
+        if (sequences.length === 0) {
+            return this;
+        }
+
+        if (this.embeddings === undefined) {
+            this.initialize(labels[0].length);
+        }
+
+        for (let epoch = 0; epoch < this.numberOfEpochs; epoch++) {
+            const gradients = this.zeroGradients();
+            for (let n = 0; n < sequences.length; n++) {
+                const tokens = toTokens(sequences[n]);
+                const cache = this.forward(tokens);
+                this.accumulateGradients(cache, labels[n], gradients);
+            }
+            this.applyGradients(gradients, sequences.length);
+        }
+
+        return this;
+    }
+
+    /** Class probabilities for each input sequence (softmax over the output of the final state). */
+    public predict (inputs: Matrix) {
+        return new Matrix(inputs.toArray().map(row => this.forward(toTokens(row)).probabilities));
+    }
+
+    /** Average cross-entropy over the given sequences. */
+    public computeLoss (inputs: Matrix, targets: Matrix) {
+        const sequences = inputs.toArray();
+        const labels = targets.toArray();
+        if (sequences.length === 0) {
+            return 0;
+        }
+        let loss = 0;
+        for (let n = 0; n < sequences.length; n++) {
+            const { probabilities } = this.forward(toTokens(sequences[n]));
+            for (let c = 0; c < this.classCount; c++) {
+                loss -= labels[n][c] * Math.log(Math.max(1e-12, probabilities[c]));
+            }
+        }
+        return loss / sequences.length;
+    }
+
+    /**
+     * Finite-difference check of backprop-through-time: nudge every parameter, compare the actual
+     * loss change to the analytic gradient, report whether they agree everywhere (relative error
+     * < 1e-3). A live proof the through-time gradients are right — easy to get subtly wrong.
+     */
+    public checkGradients () {
+        const random = mulberry32(this.seed + 7919);
+        if (this.embeddings === undefined) {
+            this.initialize(2);
+        }
+
+        const length = 4;
+        const tokens: number[] = [];
+        for (let i = 0; i < length; i++) {
+            tokens.push(1 + Math.floor(random() * (this.vocabSize - 1))); // avoid the padding token 0
+        }
+        const label = new Array<number>(this.classCount).fill(0);
+        label[Math.floor(random() * this.classCount)] = 1;
+
+        const analytic = this.zeroGradients();
+        this.accumulateGradients(this.forward(tokens), label, analytic);
+
+        const epsilon = 1e-4;
+        const tolerance = 1e-3;
+        const lossAt = () => {
+            const { probabilities } = this.forward(tokens);
+            let loss = 0;
+            for (let c = 0; c < this.classCount; c++) {
+                loss -= label[c] * Math.log(Math.max(1e-12, probabilities[c]));
+            }
+            return loss;
+        };
+        const ok = (analyticGrad: number, get: () => number, set: (v: number) => void) => {
+            const original = get();
+            set(original + epsilon);
+            const plus = lossAt();
+            set(original - epsilon);
+            const minus = lossAt();
+            set(original);
+            const numeric = (plus - minus) / (2 * epsilon);
+            return Math.abs(analyticGrad - numeric) / Math.max(1, Math.abs(analyticGrad) + Math.abs(numeric)) < tolerance;
+        };
+
+        // Only the embeddings actually used by the test sequence get a gradient.
+        for (const t of new Set(tokens)) {
+            for (let d = 0; d < this.embeddingDim; d++) {
+                if (!ok(analytic.embeddings[t][d], () => this.embeddings[t][d], v => { this.embeddings[t][d] = v; })) return false;
+            }
+        }
+        for (let d = 0; d < this.embeddingDim; d++) {
+            for (let h = 0; h < this.hiddenSize; h++) {
+                if (!ok(analytic.weightsInputHidden[d][h], () => this.weightsInputHidden[d][h], v => { this.weightsInputHidden[d][h] = v; })) return false;
+            }
+        }
+        for (let i = 0; i < this.hiddenSize; i++) {
+            for (let h = 0; h < this.hiddenSize; h++) {
+                if (!ok(analytic.weightsHiddenHidden[i][h], () => this.weightsHiddenHidden[i][h], v => { this.weightsHiddenHidden[i][h] = v; })) return false;
+            }
+            if (!ok(analytic.hiddenBias[i], () => this.hiddenBias[i], v => { this.hiddenBias[i] = v; })) return false;
+        }
+        for (let h = 0; h < this.hiddenSize; h++) {
+            for (let c = 0; c < this.classCount; c++) {
+                if (!ok(analytic.weightsHiddenOutput[h][c], () => this.weightsHiddenOutput[h][c], v => { this.weightsHiddenOutput[h][c] = v; })) return false;
+            }
+        }
+        for (let c = 0; c < this.classCount; c++) {
+            if (!ok(analytic.outputBias[c], () => this.outputBias[c], v => { this.outputBias[c] = v; })) return false;
+        }
+        return true;
+    }
+
+    /* Parameter setters */
+
+    public setVocabSize (vocabSize: number) { this.vocabSize = vocabSize; return this; }
+    public setEmbeddingDim (embeddingDim: number) { this.embeddingDim = embeddingDim; return this; }
+    public setHiddenSize (hiddenSize: number) { this.hiddenSize = hiddenSize; return this; }
+    public setLearningRate (learningRate: number) { this.learningRate = learningRate; return this; }
+    public setNumberOfEpochs (numberOfEpochs: number) { this.numberOfEpochs = numberOfEpochs; return this; }
+    public setSeed (seed: number) { this.seed = seed; return this; }
+    public reset () { this.embeddings = undefined; return this; }
+
+    /* Parameter getters */
+
+    public getVocabSize () { return this.vocabSize; }
+    public getEmbeddingDim () { return this.embeddingDim; }
+    public getHiddenSize () { return this.hiddenSize; }
+    public getLearningRate () { return this.learningRate; }
+    public getNumberOfEpochs () { return this.numberOfEpochs; }
+    public getSeed () { return this.seed; }
+
+    /** The learned embedding vector for each token (`vocabSize × embeddingDim`). */
+    public getEmbeddings () {
+        return this.embeddings ? this.embeddings.map(row => row.slice()) : [];
+    }
+
+    /* Private methods */
+
+    private initialize (classCount: number) {
+        const random = mulberry32(this.seed);
+        const rand = (scale: number) => (random() * 2 - 1) * scale;
+        this.classCount = classCount;
+
+        const D = this.embeddingDim;
+        const H = this.hiddenSize;
+        this.embeddings = Array.from({ length: this.vocabSize }, () => Array.from({ length: D }, () => rand(0.5)));
+        this.weightsInputHidden = Array.from({ length: D }, () => Array.from({ length: H }, () => rand(Math.sqrt(6 / (D + H)))));
+        this.weightsHiddenHidden = Array.from({ length: H }, () => Array.from({ length: H }, () => rand(Math.sqrt(6 / (H + H)))));
+        this.hiddenBias = new Array<number>(H).fill(0);
+        this.weightsHiddenOutput = Array.from({ length: H }, () => Array.from({ length: classCount }, () => rand(Math.sqrt(6 / (H + classCount)))));
+        this.outputBias = new Array<number>(classCount).fill(0);
+    }
+
+    private forward (tokens: number[]) {
+        const H = this.hiddenSize;
+        const realTokens: number[] = [];
+        const hiddenStates: number[][] = [new Array<number>(H).fill(0)]; // h_0 = zeros
+
+        for (const token of tokens) {
+            if (token <= 0) {
+                continue; // padding: carry the hidden state unchanged
+            }
+            const previous = hiddenStates[hiddenStates.length - 1];
+            const embedding = this.embeddings[token];
+            const next = new Array<number>(H);
+            for (let h = 0; h < H; h++) {
+                let sum = this.hiddenBias[h];
+                for (let d = 0; d < this.embeddingDim; d++) sum += embedding[d] * this.weightsInputHidden[d][h];
+                for (let i = 0; i < H; i++) sum += previous[i] * this.weightsHiddenHidden[i][h];
+                next[h] = Math.tanh(sum);
+            }
+            realTokens.push(token);
+            hiddenStates.push(next);
+        }
+
+        const finalState = hiddenStates[hiddenStates.length - 1];
+        const logits = new Array<number>(this.classCount);
+        for (let c = 0; c < this.classCount; c++) {
+            let sum = this.outputBias[c];
+            for (let h = 0; h < H; h++) sum += finalState[h] * this.weightsHiddenOutput[h][c];
+            logits[c] = sum;
+        }
+
+        return { realTokens, hiddenStates, probabilities: softmax(logits) };
+    }
+
+    private accumulateGradients (cache: ReturnType<RecurrentNeuralNetwork['forward']>, label: number[], gradients: Gradients) {
+        const H = this.hiddenSize;
+        const { realTokens, hiddenStates, probabilities } = cache;
+        const steps = realTokens.length;
+        const finalState = hiddenStates[steps];
+
+        // Output layer: softmax + cross-entropy gives prediction − target.
+        const dLogits = new Array<number>(this.classCount);
+        for (let c = 0; c < this.classCount; c++) dLogits[c] = probabilities[c] - label[c];
+
+        let dh = new Array<number>(H).fill(0);
+        for (let c = 0; c < this.classCount; c++) {
+            gradients.outputBias[c] += dLogits[c];
+            for (let h = 0; h < H; h++) {
+                gradients.weightsHiddenOutput[h][c] += finalState[h] * dLogits[c];
+                dh[h] += this.weightsHiddenOutput[h][c] * dLogits[c];
+            }
+        }
+
+        // Backprop through time, latest step first.
+        for (let t = steps - 1; t >= 0; t--) {
+            const token = realTokens[t];
+            const embedding = this.embeddings[token];
+            const current = hiddenStates[t + 1];
+            const previous = hiddenStates[t];
+
+            const dRaw = new Array<number>(H);
+            for (let h = 0; h < H; h++) {
+                dRaw[h] = dh[h] * (1 - current[h] * current[h]); // tanh'
+            }
+
+            const dhPrev = new Array<number>(H).fill(0);
+            for (let h = 0; h < H; h++) {
+                const g = dRaw[h];
+                gradients.hiddenBias[h] += g;
+                for (let d = 0; d < this.embeddingDim; d++) {
+                    gradients.weightsInputHidden[d][h] += embedding[d] * g;
+                    gradients.embeddings[token][d] += this.weightsInputHidden[d][h] * g;
+                }
+                for (let i = 0; i < H; i++) {
+                    gradients.weightsHiddenHidden[i][h] += previous[i] * g;
+                    dhPrev[i] += this.weightsHiddenHidden[i][h] * g;
+                }
+            }
+            dh = dhPrev;
+        }
+    }
+
+    private applyGradients (g: Gradients, count: number) {
+        const step = this.learningRate / count;
+        const update = (param: number[][], grad: number[][]) => {
+            for (let i = 0; i < param.length; i++) {
+                for (let j = 0; j < param[i].length; j++) param[i][j] -= step * grad[i][j];
+            }
+        };
+        update(this.embeddings, g.embeddings);
+        update(this.weightsInputHidden, g.weightsInputHidden);
+        update(this.weightsHiddenHidden, g.weightsHiddenHidden);
+        update(this.weightsHiddenOutput, g.weightsHiddenOutput);
+        for (let h = 0; h < this.hiddenSize; h++) this.hiddenBias[h] -= step * g.hiddenBias[h];
+        for (let c = 0; c < this.classCount; c++) this.outputBias[c] -= step * g.outputBias[c];
+    }
+
+    private zeroGradients (): Gradients {
+        const zeros = (rows: number, cols: number) => Array.from({ length: rows }, () => new Array<number>(cols).fill(0));
+        return {
+            embeddings: zeros(this.vocabSize, this.embeddingDim),
+            weightsInputHidden: zeros(this.embeddingDim, this.hiddenSize),
+            weightsHiddenHidden: zeros(this.hiddenSize, this.hiddenSize),
+            hiddenBias: new Array<number>(this.hiddenSize).fill(0),
+            weightsHiddenOutput: zeros(this.hiddenSize, this.classCount),
+            outputBias: new Array<number>(this.classCount).fill(0),
+        };
+    }
+}
+
+interface Gradients {
+    embeddings: number[][];
+    weightsInputHidden: number[][];
+    weightsHiddenHidden: number[][];
+    hiddenBias: number[];
+    weightsHiddenOutput: number[][];
+    outputBias: number[];
+}
+
+function toTokens (row: number[]) {
+    return row.map(value => Math.round(value));
+}
+
+function softmax (logits: number[]) {
+    const max = Math.max(...logits);
+    const exps = logits.map(v => Math.exp(v - max));
+    const sum = exps.reduce((a, b) => a + b, 0);
+    return exps.map(v => v / sum);
+}

--- a/src/test/RecurrentNeuralNetwork.test.ts
+++ b/src/test/RecurrentNeuralNetwork.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import RecurrentNeuralNetwork from '../lib/machine-learning/supervised/RecurrentNeuralNetwork';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+
+// A small order-sensitive task over tokens {1,2,3} (0 = padding): class A if the sequence STARTS
+// with token 1, else class B. The label can't be read from any single position — the net has to
+// carry "what did I see first?" forward through the whole sequence.
+const SEQUENCES = [
+    [1, 2, 3, 0], [1, 3, 2, 0], [1, 2, 2, 0], [1, 3, 3, 0],
+    [2, 1, 3, 0], [3, 2, 1, 0], [2, 3, 3, 0], [3, 1, 1, 0],
+];
+const LABELS = SEQUENCES.map(s => (s[0] === 1 ? [1, 0] : [0, 1]));
+
+describe('RecurrentNeuralNetwork', () => {
+
+    it('verifies its backprop-through-time against finite differences', () => {
+        const small = new RecurrentNeuralNetwork().setVocabSize(4).setEmbeddingDim(3).setHiddenSize(4).setSeed(1);
+        expect(small.checkGradients()).toBe(true);
+
+        const bigger = new RecurrentNeuralNetwork().setVocabSize(6).setEmbeddingDim(2).setHiddenSize(8).setSeed(4);
+        expect(bigger.checkGradients()).toBe(true);
+    });
+
+    it('learns an order-sensitive sequence task', () => {
+        const model = new RecurrentNeuralNetwork()
+            .setVocabSize(4).setEmbeddingDim(4).setHiddenSize(10)
+            .setLearningRate(0.1).setNumberOfEpochs(800).setSeed(0);
+        model.train(new Matrix(SEQUENCES), new Matrix(LABELS));
+
+        const predicted = model.predict(new Matrix(SEQUENCES)).getMaximumRowIndeces().toArray().map(row => row[0]);
+        const truth = LABELS.map(row => (row[0] === 1 ? 0 : 1));
+        const correct = predicted.filter((p, i) => p === truth[i]).length;
+        expect(correct).toBe(SEQUENCES.length);
+    });
+
+    it('returns class probabilities that sum to 1', () => {
+        const model = new RecurrentNeuralNetwork().setVocabSize(4).setHiddenSize(6).setSeed(0);
+        model.train(new Matrix(SEQUENCES), new Matrix(LABELS));
+
+        const predictions = model.predict(new Matrix(SEQUENCES)).toArray();
+        expect(predictions[0].length).toBe(2);
+        for (const row of predictions) {
+            expect(row[0] + row[1]).toBeCloseTo(1, 6);
+        }
+    });
+
+    it('exposes learned embeddings of the right shape, and the loss falls', () => {
+        const model = new RecurrentNeuralNetwork().setVocabSize(4).setEmbeddingDim(2).setHiddenSize(8).setSeed(2);
+        const initial = model.setNumberOfEpochs(0).train(new Matrix(SEQUENCES), new Matrix(LABELS)).computeLoss(new Matrix(SEQUENCES), new Matrix(LABELS));
+        const after = model.setNumberOfEpochs(300).train(new Matrix(SEQUENCES), new Matrix(LABELS)).computeLoss(new Matrix(SEQUENCES), new Matrix(LABELS));
+
+        expect(after).toBeLessThan(initial);
+        const embeddings = model.getEmbeddings();
+        expect(embeddings.length).toBe(4);     // vocab size
+        expect(embeddings[0].length).toBe(2);  // embedding dim
+    });
+
+    it('is deterministic for a fixed seed', () => {
+        const run = () => {
+            const model = new RecurrentNeuralNetwork().setVocabSize(4).setHiddenSize(8).setNumberOfEpochs(100).setSeed(3);
+            model.train(new Matrix(SEQUENCES), new Matrix(LABELS));
+            return model.predict(new Matrix(SEQUENCES)).toArray();
+        };
+        expect(run()).toEqual(run());
+    });
+
+    it('round-trips its hyperparameters and chains setters', () => {
+        const model = new RecurrentNeuralNetwork();
+        expect(model.getHiddenSize()).toBe(12);
+
+        const returned = model.setVocabSize(30).setEmbeddingDim(4).setHiddenSize(16).setLearningRate(0.05).setNumberOfEpochs(40).setSeed(9);
+        expect(returned).toBe(model);
+        expect(model.getVocabSize()).toBe(30);
+        expect(model.getEmbeddingDim()).toBe(4);
+        expect(model.getHiddenSize()).toBe(16);
+        expect(model.getLearningRate()).toBe(0.05);
+        expect(model.getNumberOfEpochs()).toBe(40);
+        expect(model.getSeed()).toBe(9);
+    });
+});


### PR DESCRIPTION
Takes the library **0.8.0 → 0.9.0**, adding **Chapter 22: Recurrent Networks** — a from-scratch trainable RNN, the second deep-learning frontier chapter built fully (the plan flagged it `(adopts)`).

## Library — `RecurrentNeuralNetwork`
- Learned **embedding** layer + Elman RNN (`hₜ = tanh(Wxh·xₜ + Whh·hₜ₋₁ + b)`) + dense softmax over the final state, trained by **backprop-through-time** (token 0 = padding, skipped).
- `train` / `predict` / `computeLoss`, `getEmbeddings()`, and **`checkGradients()`** — finite-difference verification of the through-time gradients.
- Exported; added to demo, README, keywords. **6 tests** incl. the BPTT gradient check (two configs) and an order-sensitive learning task. Suite: 159 → **165**, all green.

## Site
- `rnnDatasets.ts` (café-review vocab + templated pos/neg sequences), `viz/rnn.ts` (2D word-embedding scatter), `RNNPlayground.tsx` — live training where the **word vectors organize by sentiment**, sample reviews get predicted, ✓ gradients verified.
- Registered Ch 22; `content/rnn.mdx` ("Reading the reviews") — embeddings + recurrence, the vanishing-gradients/LSTM field note, teasing attention/transformers.
- `course-plan.md`: Ch 22 ✅.

## Verification
- Library: `yarn typecheck` + `yarn test` (165) clean; gradient check passes; review datasets train to 100% within ~100–300 epochs.
- Site: `yarn typecheck` + `yarn build` clean (own lazy chunk).

Merging deploys the site; the `v0.9.0` tag (pushed after merge) triggers `publish.yml` → npm.