### PR TITLE
Release 0.10.0: Transformers & Attention (Chapter 23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Below are some simple code usage examples.
 * [Support Vector Machine](#support-vector-machine)
 * [Convolutional Neural Network](#convolutional-neural-network)
 * [Recurrent Neural Network](#recurrent-neural-network)
+* [Transformer](#transformer)
 * [k-Means Clustering](#k-means-clustering)
 * [Hierarchical Clustering](#hierarchical-clustering)
 * [DBSCAN](#dbscan)
@@ -321,6 +322,33 @@ console.log(rnn.predict(reviews).getMaximumRowIndeces().toArray());
 
 console.log('gradients verified:', rnn.checkGradients());
 // gradients verified: true  <- finite-difference check of backprop-through-time
+
+```
+
+### Transformer
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// Transformer (single self-attention block): find the salient word anywhere in the sequence.
+// Vocab: 0=<cls> 1=filler 2=good 3=bad. Class = which keyword appears, at any position.
+const make = (pos: number, key: number) => { const s = [0, 1, 1, 1, 1]; s[pos] = key; return s; };
+const sequences = new ml.Matrix([make(1, 2), make(3, 2), make(2, 3), make(4, 3), make(4, 2), make(1, 3)]);
+const targets = new ml.Matrix([[1, 0], [1, 0], [0, 1], [0, 1], [1, 0], [0, 1]]);
+
+const transformer = new ml.Transformer();
+transformer.setVocabSize(4).setModelDim(8).setMaxLength(5).setLearningRate(0.05).setNumberOfEpochs(500).setSeed(0);
+
+transformer.train(sequences, targets);
+
+console.log(transformer.predict(sequences).getMaximumRowIndeces().toArray());
+// [ [ 0 ], [ 0 ], [ 1 ], [ 1 ], [ 0 ], [ 1 ] ]  <- "good" -> 0, "bad" -> 1, wherever it appears
+
+console.log(transformer.getAttention(make(3, 2))[0].map(a => Number(a.toFixed(2))));
+// [ 0.08, 0.13, 0.1, 0.55, 0.14 ]  <- the [CLS] token attends mostly to index 3, where the keyword sits
+
+console.log('gradients verified:', transformer.checkGradients());
+// gradients verified: true  <- finite-difference check of the attention backprop
 
 ```
 

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -30,11 +30,13 @@ generative). The built algorithms become the spine; everything else is roadmap.
 the whole of Part 2 (k‑NN, Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support
 Vector Machines), all of Part 3 (k‑Means, Hierarchical Clustering, DBSCAN, PCA, Anomaly Detection,
 Association Rules, Recommender Systems), and Part 4 — Time Series, the Perceptron interlude, Neural
-Networks, Convolutional Networks, and now **Ch 22 Recurrent Networks** (the newest chapter: a
-from-scratch trainable RNN with a learned embedding layer + backprop-through-time + gradient
-checking — again built fully rather than the planned "adopts" explainer). The two deep-learning
-frontier chapters (CNN, RNN) both became full trainable builds. Still roadmap: Transformers (Ch 23),
-the reinforcement-learning arc (Ch 24–27), generative, and Bayesian. See the status column below.
+Networks, Convolutional Networks, Recurrent Networks, and now **Ch 23 Transformers & Attention**
+(the newest chapter: a from-scratch trainable single self-attention block — Q/K/V, scaled
+dot-product attention, a CLS head, learned token + positional embeddings — with full backprop and
+gradient checking). **All three deep-learning frontier chapters (CNN, RNN, Transformer) became full
+trainable builds**, each gradient-checked, rather than the planned "adopts" explainers. That closes
+the built deep-learning arc (Ch 0–23). Still roadmap: the reinforcement-learning arc (Ch 24–27),
+generative (Ch 28–29), and Bayesian (Ch 30). See the status column below.
 
 ---
 
@@ -178,7 +180,7 @@ Every row's "Wall" is the previous tool failing.
 | 20 | **Neural Networks & Backprop** | Danger/delight hides in *combinations* of cues (XNOR-like) | k-NN is slow, memoryless, and dumb in high dimensions; linear can't combine → **stack layers that learn features**; backprop ("blame flows backward"); dropout; SGD/Adam | ✅ `FeedforwardNeuralNetwork` |
 | 21 | **Convolutional Nets (CNNs)** | Grade latte-art photos / spot pastry defects / scan receipts | Dense nets ignore spatial structure → **convolutions**, filters, pooling (computer vision) | ✅ `ConvolutionalNeuralNetwork` (built from scratch — exceeded the "adopts" plan) |
 | 22 | **Recurrent Nets / LSTMs** | Learn *sequence & text representations* (reviews, chat logs) — **not** forecasting (that's Ch 19) | Feedforward has no memory of order; this is the bridge to language → recurrence, memory, vanishing gradients. *Embeddings are introduced here as connective tissue* — learned word/item **vectors** where "similar sits close" (also reused by recsys, Ch 18) | ✅ `RecurrentNeuralNetwork` (built from scratch — RNN + embeddings + BPTT; exceeded the "adopts" plan) |
-| 23 | **Transformers & Attention** | The café's AI assistant / chatbot | RNNs forget long context & don't parallelize → **attention**; the modern backbone (and a nod to the model writing this) | ○ (adopts) |
+| 23 | **Transformers & Attention** | The café's AI assistant / chatbot | RNNs forget long context & don't parallelize → **attention**; the modern backbone (and a nod to the model writing this) | ✅ `Transformer` (built from scratch — single self-attention block + BPTT; exceeded the "adopts" plan) |
 
 ### Part 5 — Learning by doing: reinforcement learning (Season 4)
 | # | Chapter | Café problem | The Wall → The Idea | Status |

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -254,6 +254,26 @@ import * as ml from '../src/lib';
 }
 
 {
+    // Transformer (self-attention): find the salient word anywhere in the sequence.
+    // Vocab: 0=<cls> 1=filler 2=good 3=bad. Class = which keyword appears, at any position.
+    const make = (pos: number, key: number) => { const s = [0, 1, 1, 1, 1]; s[pos] = key; return s; };
+    const sequences = new ml.Matrix([make(1, 2), make(3, 2), make(2, 3), make(4, 3), make(4, 2), make(1, 3)]);
+    const targets = new ml.Matrix([[1, 0], [1, 0], [0, 1], [0, 1], [1, 0], [0, 1]]);
+
+    const transformer = new ml.Transformer();
+    transformer.setVocabSize(4).setModelDim(8).setMaxLength(5).setLearningRate(0.05).setNumberOfEpochs(500).setSeed(0);
+
+    transformer.train(sequences, targets);
+    console.log(transformer.predict(sequences).getMaximumRowIndeces().toArray());
+    // [ [ 0 ], [ 0 ], [ 1 ], [ 1 ], [ 0 ], [ 1 ] ]  ← "good" → 0, "bad" → 1, wherever it appears
+    // The [CLS] token's attention row concentrates on the keyword's position (here index 3):
+    console.log(transformer.getAttention(make(3, 2))[0].map(a => Number(a.toFixed(2))));
+    // [ 0.08, 0.13, 0.1, 0.55, 0.14 ]  ← CLS attends mostly to index 3, where the keyword sits
+    console.log('Transformer gradients verified:', transformer.checkGradients());
+    // Transformer gradients verified: true  ← finite-difference check of the attention backprop
+}
+
+{
     // Naive Bayes (multinomial): classify messages by word counts.
     // Vocabulary [free, money, table, tonight]; one-hot classes [spam, ham].
     const inputs = new ml.Matrix([[2, 1, 0, 0], [1, 2, 0, 0], [0, 0, 2, 1], [0, 0, 1, 2]]);

--- a/package.json
+++ b/package.json
@@ -71,7 +71,10 @@
     "recurrent neural network",
     "rnn",
     "embeddings",
-    "nlp"
+    "nlp",
+    "transformer",
+    "attention",
+    "self-attention"
   ],
   "author": "Erik Gerrits <gerrits.erik@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-learning",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "TypeScript & JavaScript machine learning library",
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index",

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -32,6 +32,7 @@ const TimeSeriesTutorial = lazy(() => import('./content/time-series.mdx'));
 const PerceptronTutorial = lazy(() => import('./content/perceptron.mdx'));
 const CNNTutorial = lazy(() => import('./content/cnn.mdx'));
 const RNNTutorial = lazy(() => import('./content/rnn.mdx'));
+const TransformerTutorial = lazy(() => import('./content/transformer.mdx'));
 
 export function App() {
     return (
@@ -227,6 +228,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <RNNTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="transformer"
+                    element={
+                        <TutorialPage>
+                            <TransformerTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -238,4 +238,13 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         chapter: 22,
         part: PART_4,
     },
+    {
+        id: 'transformer',
+        path: '/transformer',
+        title: 'Transformers & Attention',
+        tagline: 'Let every word look at every other and decide what matters — the modern backbone.',
+        status: 'live',
+        chapter: 23,
+        part: PART_4,
+    },
 ];

--- a/site/src/components/TransformerPlayground.module.css
+++ b/site/src/components/TransformerPlayground.module.css
@@ -1,0 +1,56 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(220px, 280px);
+    gap: 20px;
+    align-items: start;
+}
+
+.attnWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 16 / 9;
+}
+
+.attn {
+    width: 100%;
+    height: 100%;
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+.lossCanvas {
+    display: block;
+    width: 100%;
+    height: 130px;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/TransformerPlayground.tsx
+++ b/site/src/components/TransformerPlayground.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Transformer, Matrix } from 'machine-learning';
+import { TRANSFORMER_DATASETS } from '../ml/transformerDatasets';
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+import { fitCanvas } from '../viz/canvas';
+import { drawAttention } from '../viz/transformer';
+import { drawLossCurve } from '../viz/lossCurve';
+import { Badge, Card, ControlPanel, Hint, Metric, MetricsRow, NumberField, RunControls, Select, Slider } from './controls/Controls';
+import styles from './TransformerPlayground.module.css';
+
+const POINTS = 60;
+const MODEL_DIM = 16;
+
+interface TrainingData {
+    inputs: number[][];
+    targets: number[][];
+    inputMatrix: Matrix;
+    targetMatrix: Matrix;
+    vocab: string[];
+    classNames: string[];
+    positive: Set<number>;
+    negative: Set<number>;
+}
+
+export function TransformerPlayground() {
+    const [datasetId, setDatasetId] = useState(TRANSFORMER_DATASETS[0].id);
+    const [rateSlider, setRateSlider] = useState(20); // lr = rateSlider / 100
+    const [stepsPerFrame, setStepsPerFrame] = useState(8);
+    const [example, setExample] = useState(0);
+    const [seed, setSeed] = useState(0);
+    const [running, setRunning] = useState(false);
+    const [gradOk, setGradOk] = useState<boolean | null>(null);
+    const [metrics, setMetrics] = useState({ epoch: 0, loss: 0, acc: 0 });
+
+    const learningRate = rateSlider / 100;
+    const lrRef = useRef(learningRate);
+    const stepsRef = useRef(stepsPerFrame);
+    const exampleRef = useRef(example);
+    lrRef.current = learningRate;
+    stepsRef.current = stepsPerFrame;
+    exampleRef.current = example;
+
+    const modelRef = useRef<Transformer | null>(null);
+    const dataRef = useRef<TrainingData | null>(null);
+    const lossRef = useRef<number[]>([]);
+    const epochRef = useRef(0);
+    const frameRef = useRef(0);
+
+    const attnCanvasRef = useRef<HTMLCanvasElement | null>(null);
+    const lossCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const polarityOf = (data: TrainingData, token: number): 'pos' | 'neg' | 'filler' =>
+        data.positive.has(token) ? 'pos' : data.negative.has(token) ? 'neg' : 'filler';
+
+    const drawAll = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        if (!model || !data) return;
+
+        const canvas = attnCanvasRef.current;
+        if (canvas) {
+            const { ctx, width, height } = fitCanvas(canvas);
+            ctx.fillStyle = '#0b1120';
+            ctx.fillRect(0, 0, width, height);
+            const idx = Math.min(exampleRef.current, data.inputs.length - 1);
+            const seq = data.inputs[idx];
+            const words = seq.map(t => data.vocab[Math.round(t)]);
+            const polarity = seq.map(t => polarityOf(data, Math.round(t)));
+            drawAttention(ctx, width, height, words, model.getAttention(seq)[0], polarity);
+        }
+        const lossCanvas = lossCanvasRef.current;
+        if (lossCanvas) {
+            const { ctx, width, height } = fitCanvas(lossCanvas);
+            drawLossCurve(ctx, width, height, lossRef.current);
+        }
+    }, []);
+
+    const accuracy = useCallback((model: Transformer, data: TrainingData) => {
+        const preds = model.predict(data.inputMatrix).getMaximumRowIndeces().toArray().map(r => r[0]);
+        const truth = data.targets.map(t => t.indexOf(1));
+        return preds.filter((p, i) => p === truth[i]).length / preds.length;
+    }, []);
+
+    const rebuild = useCallback(() => {
+        const dataset = TRANSFORMER_DATASETS.find(d => d.id === datasetId) ?? TRANSFORMER_DATASETS[0];
+        const { inputs, targets } = dataset.generate(seed, POINTS);
+        const inputMatrix = new Matrix(inputs);
+        const targetMatrix = new Matrix(targets);
+
+        const model = new Transformer()
+            .setVocabSize(dataset.vocab.length)
+            .setModelDim(MODEL_DIM)
+            .setMaxLength(dataset.sequenceLength)
+            .setLearningRate(lrRef.current)
+            .setNumberOfEpochs(1)
+            .setSeed(seed);
+        model.train(inputMatrix, targetMatrix); // one pass to initialise
+
+        modelRef.current = model;
+        dataRef.current = {
+            inputs, targets, inputMatrix, targetMatrix,
+            vocab: dataset.vocab, classNames: dataset.classNames,
+            positive: new Set(dataset.positiveTokens), negative: new Set(dataset.negativeTokens),
+        };
+        lossRef.current = [model.computeLoss(inputMatrix, targetMatrix)];
+        epochRef.current = 1;
+        frameRef.current = 0;
+
+        setGradOk(model.checkGradients());
+        setMetrics({ epoch: 1, loss: lossRef.current[0], acc: accuracy(model, dataRef.current) });
+        drawAll();
+    }, [datasetId, seed, drawAll, accuracy]);
+
+    useEffect(() => { rebuild(); }, [rebuild]);
+    useEffect(() => { if (modelRef.current) modelRef.current.setLearningRate(learningRate); }, [learningRate]);
+    useEffect(() => { drawAll(); }, [example, drawAll]);
+
+    const step = useCallback(() => {
+        const model = modelRef.current;
+        const data = dataRef.current;
+        if (!model || !data) return;
+
+        for (let i = 0; i < stepsRef.current; i++) model.train(data.inputMatrix, data.targetMatrix);
+        epochRef.current += stepsRef.current;
+
+        lossRef.current.push(model.computeLoss(data.inputMatrix, data.targetMatrix));
+        if (lossRef.current.length > 1200) lossRef.current.shift();
+
+        drawAll();
+        frameRef.current += 1;
+        if (frameRef.current % 3 === 0) {
+            setMetrics({ epoch: epochRef.current, loss: lossRef.current[lossRef.current.length - 1], acc: accuracy(model, data) });
+        }
+    }, [drawAll, accuracy]);
+
+    useAnimationFrame(step, running);
+
+    const handleStep = () => { if (!running) step(); };
+    const handleReset = () => { setRunning(false); rebuild(); };
+    const handleDataset = (id: string) => { setDatasetId(id); setExample(0); };
+
+    const dataset = TRANSFORMER_DATASETS.find(d => d.id === datasetId);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <RunControls running={running} onToggle={() => setRunning(r => !r)} onStep={handleStep} onReset={handleReset} />
+                <Select
+                    label="Reviews"
+                    value={datasetId}
+                    options={TRANSFORMER_DATASETS.map(d => ({ value: d.id, label: d.label }))}
+                    onChange={handleDataset}
+                />
+                {dataset && <Hint>{dataset.blurb}</Hint>}
+                <Slider label="Learning rate" value={rateSlider} display={learningRate.toFixed(2)} min={5} max={40} onChange={setRateSlider} />
+                <Slider label="Speed" value={stepsPerFrame} display={`${stepsPerFrame} epochs / frame`} min={1} max={16} onChange={setStepsPerFrame} />
+                <Slider label="Show review" value={example} display={`#${example}`} min={0} max={POINTS - 1} onChange={setExample} />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+                <Hint>One sentiment word hides among fillers. Watch its attention bar grow tallest.</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.attnWrap}>
+                    <canvas ref={attnCanvasRef} className={styles.attn} />
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Epoch" value={String(metrics.epoch)} />
+                        <Metric label="Loss" value={metrics.loss.toFixed(3)} />
+                        <Metric label="Accuracy" value={`${(metrics.acc * 100).toFixed(0)}%`} />
+                    </MetricsRow>
+
+                    {gradOk && <Badge>✓ Gradients verified</Badge>}
+
+                    <Card title="Loss" subtitle="cross-entropy per epoch">
+                        <canvas ref={lossCanvasRef} className={styles.lossCanvas} />
+                    </Card>
+
+                    <Card title="What to watch" subtitle="attention finds the word">
+                        <p className={styles.note}>
+                            Every position can look at every other at once. Early on the attention is
+                            spread evenly; as it learns, the [CLS] slot's bar over the one sentiment word
+                            grows tallest — the model deciding *that's* the word that settles the verdict,
+                            wherever it sits.
+                        </p>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/content/transformer.mdx
+++ b/site/src/content/transformer.mdx
@@ -1,0 +1,92 @@
+import { TransformerPlayground } from '../components/TransformerPlayground';
+
+# Chapter 23 — Looking everywhere at once
+
+> *Transformers & attention.* The RNN read a review word by word through one little memory. What if
+> every word could look **directly** at every other, all at once, and decide for itself what matters?
+> That idea is the engine behind the café's new assistant — and the model that wrote this library.
+
+Nadia wants an assistant in the app: read a customer's message and route it, summarise the reviews,
+draft a reply. The RNN from last chapter can read, but two things hold it back, and a long message
+makes both bite.
+
+## The wall: a single memory, read in order
+
+The RNN reads strictly left to right and funnels everything through one hidden state. So it's
+**slow** — each step waits for the one before, no way to parallelise over the mountain of text an app
+collects — and it's **forgetful**: a verdict that depends on a word many steps back ("the coffee,
+*despite the twenty-minute wait*, was wonderful") has to survive being squeezed through that one
+state, step after step, fading as it goes. The relay is the bottleneck.
+
+## The idea: attention
+
+So drop the relay. Let **every position look at every other position directly**. Each word forms a
+**query** ("what am I looking for?") and every word offers a **key** ("here's what I am"); their dot
+product scores how relevant each other word is. Softmax those scores into weights that sum to one,
+and the word's new representation is a **weighted blend of everyone's values** — a custom summary of
+the whole sequence, built in one step. A special **[CLS]** slot does the same and its blend becomes
+the verdict. Every pair compared at once: fully parallel, and any word can reach any other directly.
+
+$$
+\mathrm{Attention}(Q, K, V) = \mathrm{softmax}\!\left(\frac{QK^{\top}}{\sqrt{d}}\right) V
+$$
+
+Below, one sentiment word hides among fillers at a random spot. Press **Train** and watch the [CLS]
+attention bar grow tallest over *that* word — the model learning where to look:
+
+<div className="breakout">
+  <TransformerPlayground />
+</div>
+
+## How it works: query, key, value
+
+Each position projects its embedding into a query, a key, and a value (`Q = X·Wq`, etc.). Then every
+query is scored against every key, softmaxed, and used to blend the values — straight from the
+[`Transformer`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/supervised/Transformer.ts)
+source:
+
+```ts
+for (let j = 0; j < L; j++) {
+    let dot = 0;
+    for (let d = 0; d < D; d++) dot += q[i][d] * k[j][d]; // query i · key j
+    scores[j] = dot * scaling;                            // ÷ √d keeps the softmax from saturating
+}
+const a = softmax(scores);                                // how much i attends to each j
+for (let j = 0; j < L; j++) for (let d = 0; d < D; d++) ctx[d] += a[j] * v[j][d]; // blend the values
+```
+
+The [CLS] position's blended context feeds a softmax classifier. One subtlety: attention has **no
+built-in sense of order** — shuffle the words and the scores are identical. So position is added in
+at the start, as a learned **positional embedding** (`X = tokenEmbedding + positionEmbedding`). The
+whole block trains by backpropagation — including the gnarly path back through the softmax-attention,
+which a shipped `checkGradients()` finite-difference-verifies (the ✓ badge).
+
+## Try it yourself
+
+- Watch the bars. Early on attention is spread roughly evenly; as the loss falls, the [CLS] bar over
+  the sentiment word climbs well above the fillers — the model decided *that's* the word that settles
+  the verdict, wherever it sits. Scrub **Show review** to see it find the word at different positions.
+- **Longer reviews** add more filler to look past; attention still picks the word out — the payoff of
+  looking everywhere at once rather than remembering through a narrow state.
+- Nudge the **learning rate** and **speed** to watch the focus sharpen faster or wobble.
+
+> **Field note — this is one head, one layer.** A real transformer stacks *many* blocks, each with
+> *multiple* attention heads (different heads learn different relationships — one tracks the
+> sentiment word, another the subject, another long-range agreement), plus feed-forward layers,
+> residual connections, and normalisation. Scale that to billions of parameters and oceans of text,
+> train it to predict the next token, and the same mechanism you just watched becomes a language model.
+
+## What broke — or rather, where it leads
+
+Nothing broke this time. Attention is the modern backbone: the very mechanism in this playground,
+multiplied up and trained on the open internet, is what powers the assistant Nadia ships in her app —
+and, not to be coy about it, the model writing this very page. From a shoebox of receipts in Chapter
+0 to a network that reads and writes language: that's the whole arc of the ledger.
+
+What's left isn't a new way of *seeing* the data so much as new things to *do* with it. So far every
+model has **predicted** — a number, a class, a cluster. The frontier the café hasn't reached yet is
+to **generate** (invent new recipes, draft the marketing), to **act and learn from outcomes** —
+which daily special to run, what to charge — where a choice today changes the rewards tomorrow
+(reinforcement learning), and to **reason under uncertainty** before a big bet. The shoebox is a
+long way behind. The map ahead — `docs/course-plan.md` — still has open chapters, and Nadia's café
+keeps growing into them.

--- a/site/src/ml/transformerDatasets.ts
+++ b/site/src/ml/transformerDatasets.ts
@@ -1,0 +1,72 @@
+import { mulberry32 } from './rng';
+
+// Fixed-length café reviews for the transformer playground (Chapter 23). Position 0 is a [CLS] slot;
+// the rest are filler words with exactly one sentiment word dropped in at a random spot. The class
+// is that word's polarity — so the model has to find the one word that matters, wherever it sits,
+// and the [CLS] attention row shows it doing exactly that.
+export interface TransformerDataset {
+    id: string;
+    label: string;
+    blurb: string;
+    vocab: string[];
+    classNames: string[];
+    positiveTokens: number[];
+    negativeTokens: number[];
+    sequenceLength: number;
+    generate: (seed: number, n: number) => { inputs: number[][]; targets: number[][] };
+}
+
+const VOCAB = [
+    '[CLS]', 'the', 'was', 'place', 'coffee', 'service', 'staff', // 0–6: CLS + fillers
+    'great', 'lovely', 'perfect', // 7–9 positive
+    'terrible', 'slow', 'rude', // 10–12 negative
+];
+const FILLERS = [1, 2, 3, 4, 5, 6];
+const POSITIVE = [7, 8, 9];
+const NEGATIVE = [10, 11, 12];
+
+function generator(length: number) {
+    return (seed: number, n: number) => {
+        const rand = mulberry32(seed);
+        const pick = (arr: number[]) => arr[Math.floor(rand() * arr.length)];
+        const inputs: number[][] = [];
+        const targets: number[][] = [];
+
+        for (let i = 0; i < n; i++) {
+            const positive = i % 2 === 0;
+            const seq = [0]; // [CLS]
+            for (let p = 1; p < length; p++) seq.push(pick(FILLERS));
+            const slot = 1 + Math.floor(rand() * (length - 1));
+            seq[slot] = positive ? pick(POSITIVE) : pick(NEGATIVE);
+
+            inputs.push(seq);
+            targets.push(positive ? [1, 0] : [0, 1]);
+        }
+        return { inputs, targets };
+    };
+}
+
+export const TRANSFORMER_DATASETS: TransformerDataset[] = [
+    {
+        id: 'reviews',
+        label: 'Café reviews',
+        blurb: 'One sentiment word ("lovely", "rude") hidden among fillers, at a random spot. The model must find it — watch the [CLS] attention bar lock onto it.',
+        vocab: VOCAB,
+        classNames: ['positive', 'negative'],
+        positiveTokens: POSITIVE,
+        negativeTokens: NEGATIVE,
+        sequenceLength: 6,
+        generate: generator(6),
+    },
+    {
+        id: 'long',
+        label: 'Longer reviews',
+        blurb: 'More filler to look past before finding the one word that decides the sentiment. Attention still picks it out — that\'s the point of looking everywhere at once.',
+        vocab: VOCAB,
+        classNames: ['positive', 'negative'],
+        positiveTokens: POSITIVE,
+        negativeTokens: NEGATIVE,
+        sequenceLength: 9,
+        generate: generator(9),
+    },
+];

--- a/site/src/viz/transformer.ts
+++ b/site/src/viz/transformer.ts
@@ -1,0 +1,55 @@
+// Attention viz for the transformer playground: the [CLS] token's attention over the sequence, as a
+// bar per word. As training proceeds the bar over the one sentiment word grows tallest — the model
+// learning to look at the word that decides the class.
+
+const POS = '#fb923c';   // positive word
+const NEG = '#38bdf8';   // negative word
+const FILLER = '#64748b'; // filler / [CLS]
+const BAR = 'rgba(251, 191, 36, 0.9)'; // attention bar (amber)
+
+export function drawAttention(
+    ctx: CanvasRenderingContext2D,
+    width: number,
+    height: number,
+    words: string[],
+    attentionRow: number[],
+    polarity: ('pos' | 'neg' | 'filler')[],
+): void {
+    const n = words.length;
+    if (n === 0) return;
+
+    const padX = 10;
+    const cellW = (width - 2 * padX) / n;
+    const baseY = height - 30;        // words sit here
+    const barTop = 24;                // bars grow down to baseY from here
+    const barAreaH = baseY - barTop;
+
+    const maxAttn = Math.max(1e-6, ...attentionRow);
+
+    ctx.fillStyle = 'rgba(226, 232, 240, 0.7)';
+    ctx.font = '11px ui-sans-serif, system-ui, sans-serif';
+    ctx.textAlign = 'left';
+    ctx.fillText('[CLS] attention — which word the model looks at', padX, 14);
+
+    ctx.textAlign = 'center';
+    for (let i = 0; i < n; i++) {
+        const cx = padX + (i + 0.5) * cellW;
+        const barH = (attentionRow[i] / maxAttn) * barAreaH;
+
+        // Attention bar.
+        ctx.fillStyle = BAR;
+        const barW = Math.min(cellW * 0.6, 26);
+        ctx.fillRect(cx - barW / 2, baseY - barH, barW, barH);
+
+        // Weight label above the bar.
+        ctx.fillStyle = 'rgba(148, 163, 184, 0.8)';
+        ctx.font = '9px ui-sans-serif, system-ui, sans-serif';
+        ctx.fillText(attentionRow[i].toFixed(2), cx, baseY - barH - 4);
+
+        // Word, coloured by polarity.
+        ctx.fillStyle = polarity[i] === 'pos' ? POS : polarity[i] === 'neg' ? NEG : FILLER;
+        ctx.font = '11px ui-sans-serif, system-ui, sans-serif';
+        ctx.fillText(words[i], cx, baseY + 16);
+    }
+    ctx.textAlign = 'left';
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -24,3 +24,4 @@ export { default as RecurrentNeuralNetwork } from "./machine-learning/supervised
 export { default as Recommender } from "./machine-learning/unsupervised/Recommender";
 export { default as SupportVectorMachine } from "./machine-learning/supervised/SupportVectorMachine";
 export type { Kernel } from "./machine-learning/supervised/SupportVectorMachine";
+export { default as Transformer } from "./machine-learning/supervised/Transformer";

--- a/src/lib/machine-learning/supervised/Transformer.ts
+++ b/src/lib/machine-learning/supervised/Transformer.ts
@@ -1,0 +1,361 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+import mulberry32 from "../../math/random/mulberry32";
+
+/**
+ * A minimal **transformer** — a single self-attention block with a classification head, the core of
+ * the architecture behind modern language models (including the one that wrote this library). Where
+ * an RNN ferries the whole past through one hidden state read left-to-right, **attention** lets every
+ * position look **directly at every other position** at once and decide, per pair, how much to care.
+ *
+ * The block, trained end-to-end by backprop through the attention:
+ *
+ *   tokens → token + positional **embeddings** (X)
+ *          → **Q, K, V** = X·Wq, X·Wk, X·Wv
+ *          → scores = QKᵀ/√d → **softmax** per row → attention weights A
+ *          → context = A·V
+ *          → classify from the first position's context (a "[CLS]" slot) → softmax
+ *
+ * The first token of every sequence is treated as a classification slot: its context vector — a
+ * learned, attention-weighted blend of the whole sequence — feeds the output layer. Reading off that
+ * slot's attention row shows *which words the model decided mattered*.
+ *
+ * Sequences are fixed-length token-id rows (no padding/masking — keep them all the same length, with
+ * the CLS token at position 0). This is one head and one layer — the essential mechanism; real
+ * transformers stack many multi-head blocks with feed-forward layers, residuals, and normalisation.
+ * {@link checkGradients} finite-difference-verifies the attention gradients.
+ *
+ * @example
+ * const t = new Transformer().setVocabSize(20).setModelDim(8).setMaxLength(6).setSeed(0);
+ * t.setLearningRate(0.05).setNumberOfEpochs(300).train(sequences, oneHot);
+ * t.getAttention(sequences.toArray()[0]); // L×L attention; row 0 = what [CLS] looked at
+ */
+export default class Transformer {
+
+    private vocabSize = 16;
+    private modelDim = 8;
+    private maxLength = 8;
+    private learningRate = 0.05;
+    private numberOfEpochs = 1;
+    private seed = 0;
+
+    // Learned parameters.
+    private tokenEmbeddings: number[][];    // [token][dim]
+    private positionEmbeddings: number[][]; // [position][dim]
+    private wq: number[][]; private wk: number[][]; private wv: number[][]; // [dim][dim]
+    private wOut: number[][];               // [dim][class]
+    private outBias: number[];              // [class]
+    private classCount = 0;
+
+    public constructor () {}
+
+    public train (inputs: Matrix, targets: Matrix) {
+        const sequences = inputs.toArray();
+        const labels = targets.toArray();
+        if (sequences.length === 0) {
+            return this;
+        }
+        if (this.tokenEmbeddings === undefined) {
+            this.initialize(labels[0].length);
+        }
+
+        for (let epoch = 0; epoch < this.numberOfEpochs; epoch++) {
+            const gradients = this.zeroGradients();
+            for (let n = 0; n < sequences.length; n++) {
+                const tokens = sequences[n].map(v => Math.round(v));
+                this.accumulateGradients(tokens, this.forward(tokens), labels[n], gradients);
+            }
+            this.applyGradients(gradients, sequences.length);
+        }
+        return this;
+    }
+
+    /** Class probabilities for each input sequence. */
+    public predict (inputs: Matrix) {
+        return new Matrix(inputs.toArray().map(row => this.forward(row.map(v => Math.round(v))).probabilities));
+    }
+
+    /** Average cross-entropy over the given sequences. */
+    public computeLoss (inputs: Matrix, targets: Matrix) {
+        const sequences = inputs.toArray();
+        const labels = targets.toArray();
+        if (sequences.length === 0) return 0;
+        let loss = 0;
+        for (let n = 0; n < sequences.length; n++) {
+            const { probabilities } = this.forward(sequences[n].map(v => Math.round(v)));
+            for (let c = 0; c < this.classCount; c++) loss -= labels[n][c] * Math.log(Math.max(1e-12, probabilities[c]));
+        }
+        return loss / sequences.length;
+    }
+
+    /** The attention matrix for one sequence: `A[i][j]` = how much position i attends to position j. */
+    public getAttention (sequence: number[]) {
+        return this.forward(sequence.map(v => Math.round(v))).attention.map(row => row.slice());
+    }
+
+    /**
+     * Finite-difference check of backprop through the self-attention (the trickiest gradient here —
+     * softmax-of-dot-products feeding a weighted sum). Reports whether analytic and numeric agree.
+     */
+    public checkGradients () {
+        const random = mulberry32(this.seed + 4242);
+        if (this.tokenEmbeddings === undefined) this.initialize(2);
+
+        const length = Math.min(4, this.maxLength);
+        const tokens = Array.from({ length }, () => Math.floor(random() * this.vocabSize));
+        const label = new Array<number>(this.classCount).fill(0);
+        label[Math.floor(random() * this.classCount)] = 1;
+
+        const analytic = this.zeroGradients();
+        this.accumulateGradients(tokens, this.forward(tokens), label, analytic);
+
+        const epsilon = 1e-4;
+        const tolerance = 1e-3;
+        const lossAt = () => {
+            const { probabilities } = this.forward(tokens);
+            let loss = 0;
+            for (let c = 0; c < this.classCount; c++) loss -= label[c] * Math.log(Math.max(1e-12, probabilities[c]));
+            return loss;
+        };
+        const ok = (g: number, get: () => number, set: (v: number) => void) => {
+            const o = get();
+            set(o + epsilon); const plus = lossAt();
+            set(o - epsilon); const minus = lossAt();
+            set(o);
+            const numeric = (plus - minus) / (2 * epsilon);
+            return Math.abs(g - numeric) / Math.max(1, Math.abs(g) + Math.abs(numeric)) < tolerance;
+        };
+        const checkMatrix = (g: number[][], p: number[][]) => {
+            for (let i = 0; i < p.length; i++) for (let j = 0; j < p[i].length; j++) {
+                if (!ok(g[i][j], () => p[i][j], v => { p[i][j] = v; })) return false;
+            }
+            return true;
+        };
+
+        if (!checkMatrix(analytic.wq, this.wq)) return false;
+        if (!checkMatrix(analytic.wk, this.wk)) return false;
+        if (!checkMatrix(analytic.wv, this.wv)) return false;
+        if (!checkMatrix(analytic.wOut, this.wOut)) return false;
+        for (let c = 0; c < this.classCount; c++) if (!ok(analytic.outBias[c], () => this.outBias[c], v => { this.outBias[c] = v; })) return false;
+        for (const t of new Set(tokens)) {
+            for (let d = 0; d < this.modelDim; d++) if (!ok(analytic.tokenEmbeddings[t][d], () => this.tokenEmbeddings[t][d], v => { this.tokenEmbeddings[t][d] = v; })) return false;
+        }
+        for (let p = 0; p < length; p++) {
+            for (let d = 0; d < this.modelDim; d++) if (!ok(analytic.positionEmbeddings[p][d], () => this.positionEmbeddings[p][d], v => { this.positionEmbeddings[p][d] = v; })) return false;
+        }
+        return true;
+    }
+
+    /* Setters */
+    public setVocabSize (v: number) { this.vocabSize = v; return this; }
+    public setModelDim (d: number) { this.modelDim = d; return this; }
+    public setMaxLength (l: number) { this.maxLength = l; return this; }
+    public setLearningRate (lr: number) { this.learningRate = lr; return this; }
+    public setNumberOfEpochs (e: number) { this.numberOfEpochs = e; return this; }
+    public setSeed (s: number) { this.seed = s; return this; }
+    public reset () { this.tokenEmbeddings = undefined; return this; }
+
+    /* Getters */
+    public getVocabSize () { return this.vocabSize; }
+    public getModelDim () { return this.modelDim; }
+    public getMaxLength () { return this.maxLength; }
+    public getLearningRate () { return this.learningRate; }
+    public getNumberOfEpochs () { return this.numberOfEpochs; }
+    public getSeed () { return this.seed; }
+
+    /* Private */
+
+    private initialize (classCount: number) {
+        const random = mulberry32(this.seed);
+        const D = this.modelDim;
+        const rand = (scale: number) => (random() * 2 - 1) * scale;
+        const square = () => Array.from({ length: D }, () => Array.from({ length: D }, () => rand(1 / Math.sqrt(D))));
+
+        this.classCount = classCount;
+        this.tokenEmbeddings = Array.from({ length: this.vocabSize }, () => Array.from({ length: D }, () => rand(0.4)));
+        this.positionEmbeddings = Array.from({ length: this.maxLength }, () => Array.from({ length: D }, () => rand(0.4)));
+        this.wq = square(); this.wk = square(); this.wv = square();
+        this.wOut = Array.from({ length: D }, () => Array.from({ length: classCount }, () => rand(Math.sqrt(6 / (D + classCount)))));
+        this.outBias = new Array<number>(classCount).fill(0);
+    }
+
+    private forward (tokens: number[]) {
+        const D = this.modelDim;
+        const L = tokens.length;
+        const scaling = 1 / Math.sqrt(D);
+
+        // Embedded input X = token + positional.
+        const x: number[][] = [];
+        for (let t = 0; t < L; t++) {
+            const row = new Array<number>(D);
+            for (let d = 0; d < D; d++) row[d] = this.tokenEmbeddings[tokens[t]][d] + this.positionEmbeddings[t][d];
+            x.push(row);
+        }
+
+        const q = matMul(x, this.wq);
+        const k = matMul(x, this.wk);
+        const v = matMul(x, this.wv);
+
+        // Attention scores → row softmax → context.
+        const attention: number[][] = [];
+        const context: number[][] = [];
+        for (let i = 0; i < L; i++) {
+            const scores = new Array<number>(L);
+            for (let j = 0; j < L; j++) {
+                let dot = 0;
+                for (let d = 0; d < D; d++) dot += q[i][d] * k[j][d];
+                scores[j] = dot * scaling;
+            }
+            const a = softmax(scores);
+            attention.push(a);
+            const ctx = new Array<number>(D).fill(0);
+            for (let j = 0; j < L; j++) for (let d = 0; d < D; d++) ctx[d] += a[j] * v[j][d];
+            context.push(ctx);
+        }
+
+        // Classify from the [CLS] position (index 0).
+        const cls = context[0];
+        const logits = new Array<number>(this.classCount);
+        for (let c = 0; c < this.classCount; c++) {
+            let sum = this.outBias[c];
+            for (let d = 0; d < D; d++) sum += cls[d] * this.wOut[d][c];
+            logits[c] = sum;
+        }
+
+        return { x, q, k, v, attention, context, probabilities: softmax(logits) };
+    }
+
+    private accumulateGradients (tokens: number[], cache: ReturnType<Transformer['forward']>, label: number[], g: Gradients) {
+        const D = this.modelDim;
+        const L = tokens.length;
+        const scaling = 1 / Math.sqrt(D);
+        const { x, q, k, v, attention, context, probabilities } = cache;
+
+        // Output layer (from CLS context).
+        const dLogits = new Array<number>(this.classCount);
+        for (let c = 0; c < this.classCount; c++) dLogits[c] = probabilities[c] - label[c];
+
+        const dContext = Array.from({ length: L }, () => new Array<number>(D).fill(0));
+        for (let c = 0; c < this.classCount; c++) {
+            g.outBias[c] += dLogits[c];
+            for (let d = 0; d < D; d++) {
+                g.wOut[d][c] += context[0][d] * dLogits[c];
+                dContext[0][d] += this.wOut[d][c] * dLogits[c]; // only CLS feeds the head
+            }
+        }
+
+        const dq = Array.from({ length: L }, () => new Array<number>(D).fill(0));
+        const dk = Array.from({ length: L }, () => new Array<number>(D).fill(0));
+        const dv = Array.from({ length: L }, () => new Array<number>(D).fill(0));
+
+        // Back through context = A·V and the row-softmax, per query row i.
+        for (let i = 0; i < L; i++) {
+            const a = attention[i];
+            const dA = new Array<number>(L).fill(0);
+            for (let j = 0; j < L; j++) {
+                let s = 0;
+                for (let d = 0; d < D; d++) {
+                    s += dContext[i][d] * v[j][d];        // dA[i][j]
+                    dv[j][d] += a[j] * dContext[i][d];    // dV[j]
+                }
+                dA[j] = s;
+            }
+            // Softmax Jacobian for row i.
+            let weighted = 0;
+            for (let j = 0; j < L; j++) weighted += a[j] * dA[j];
+            const dScores = new Array<number>(L);
+            for (let j = 0; j < L; j++) dScores[j] = a[j] * (dA[j] - weighted) * scaling;
+            // scores[i][j] = q[i]·k[j].
+            for (let j = 0; j < L; j++) {
+                for (let d = 0; d < D; d++) {
+                    dq[i][d] += dScores[j] * k[j][d];
+                    dk[j][d] += dScores[j] * q[i][d];
+                }
+            }
+        }
+
+        // Back through Q,K,V = X·W, accumulating dX.
+        const dx = Array.from({ length: L }, () => new Array<number>(D).fill(0));
+        accumulateLinear(x, dq, this.wq, g.wq, dx);
+        accumulateLinear(x, dk, this.wk, g.wk, dx);
+        accumulateLinear(x, dv, this.wv, g.wv, dx);
+
+        // Back into the embeddings.
+        for (let t = 0; t < L; t++) {
+            for (let d = 0; d < D; d++) {
+                g.tokenEmbeddings[tokens[t]][d] += dx[t][d];
+                g.positionEmbeddings[t][d] += dx[t][d];
+            }
+        }
+    }
+
+    private applyGradients (g: Gradients, count: number) {
+        const step = this.learningRate / count;
+        const update = (p: number[][], grad: number[][]) => {
+            for (let i = 0; i < p.length; i++) for (let j = 0; j < p[i].length; j++) p[i][j] -= step * grad[i][j];
+        };
+        update(this.tokenEmbeddings, g.tokenEmbeddings);
+        update(this.positionEmbeddings, g.positionEmbeddings);
+        update(this.wq, g.wq); update(this.wk, g.wk); update(this.wv, g.wv);
+        update(this.wOut, g.wOut);
+        for (let c = 0; c < this.classCount; c++) this.outBias[c] -= step * g.outBias[c];
+    }
+
+    private zeroGradients (): Gradients {
+        const zeros = (r: number, c: number) => Array.from({ length: r }, () => new Array<number>(c).fill(0));
+        const D = this.modelDim;
+        return {
+            tokenEmbeddings: zeros(this.vocabSize, D),
+            positionEmbeddings: zeros(this.maxLength, D),
+            wq: zeros(D, D), wk: zeros(D, D), wv: zeros(D, D),
+            wOut: zeros(D, this.classCount),
+            outBias: new Array<number>(this.classCount).fill(0),
+        };
+    }
+}
+
+interface Gradients {
+    tokenEmbeddings: number[][];
+    positionEmbeddings: number[][];
+    wq: number[][]; wk: number[][]; wv: number[][];
+    wOut: number[][];
+    outBias: number[];
+}
+
+/** Y = X·W where X is L×D and W is D×D → L×D. */
+function matMul (x: number[][], w: number[][]) {
+    const L = x.length;
+    const D = w.length;
+    const out: number[][] = [];
+    for (let i = 0; i < L; i++) {
+        const row = new Array<number>(D).fill(0);
+        for (let d = 0; d < D; d++) {
+            for (let e = 0; e < D; e++) row[e] += x[i][d] * w[d][e];
+        }
+        out.push(row);
+    }
+    return out;
+}
+
+/** Given upstream gradient dY of Y = X·W: accumulate dW (Xᵀ·dY) and add dX (dY·Wᵀ) into `dx`. */
+function accumulateLinear (x: number[][], dY: number[][], w: number[][], dW: number[][], dx: number[][]) {
+    const L = x.length;
+    const D = w.length;
+    for (let i = 0; i < L; i++) {
+        for (let d = 0; d < D; d++) {
+            const xid = x[i][d];
+            let dxid = 0;
+            for (let e = 0; e < D; e++) {
+                dW[d][e] += xid * dY[i][e];
+                dxid += dY[i][e] * w[d][e];
+            }
+            dx[i][d] += dxid;
+        }
+    }
+}
+
+function softmax (values: number[]) {
+    const max = Math.max(...values);
+    const exps = values.map(v => Math.exp(v - max));
+    const sum = exps.reduce((a, b) => a + b, 0);
+    return exps.map(v => v / sum);
+}

--- a/src/test/Transformer.test.ts
+++ b/src/test/Transformer.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import Transformer from '../lib/machine-learning/supervised/Transformer';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+
+// A task that genuinely needs attention: each length-5 sequence is [CLS, w, w, w, w] where the four
+// words are fillers (1) except for exactly one keyword — A (2) or B (3) — at a random position. The
+// class is which keyword is present, so the model must find the salient word *wherever it sits* and
+// route it to the CLS slot. Vocab: 0=CLS, 1=filler, 2=keyA, 3=keyB.
+const SEQUENCES: number[][] = [];
+const LABELS: number[][] = [];
+for (let pos = 1; pos <= 4; pos++) {
+    for (const key of [2, 3]) {
+        const seq = [0, 1, 1, 1, 1];
+        seq[pos] = key;
+        SEQUENCES.push(seq);
+        LABELS.push(key === 2 ? [1, 0] : [0, 1]);
+    }
+}
+
+describe('Transformer', () => {
+
+    it('verifies its attention backprop against finite differences', () => {
+        const small = new Transformer().setVocabSize(4).setModelDim(4).setMaxLength(4).setSeed(1);
+        expect(small.checkGradients()).toBe(true);
+
+        const bigger = new Transformer().setVocabSize(6).setModelDim(8).setMaxLength(5).setSeed(5);
+        expect(bigger.checkGradients()).toBe(true);
+    });
+
+    it('learns to find the keyword wherever it sits', () => {
+        const model = new Transformer()
+            .setVocabSize(4).setModelDim(8).setMaxLength(5)
+            .setLearningRate(0.05).setNumberOfEpochs(600).setSeed(0);
+        model.train(new Matrix(SEQUENCES), new Matrix(LABELS));
+
+        const predicted = model.predict(new Matrix(SEQUENCES)).getMaximumRowIndeces().toArray().map(r => r[0]);
+        const truth = LABELS.map(row => (row[0] === 1 ? 0 : 1));
+        expect(predicted.filter((p, i) => p === truth[i]).length).toBe(SEQUENCES.length);
+    });
+
+    it('returns class probabilities that sum to 1', () => {
+        const model = new Transformer().setVocabSize(4).setModelDim(8).setMaxLength(5).setSeed(0);
+        model.train(new Matrix(SEQUENCES), new Matrix(LABELS));
+
+        const predictions = model.predict(new Matrix(SEQUENCES)).toArray();
+        expect(predictions[0].length).toBe(2);
+        for (const row of predictions) expect(row[0] + row[1]).toBeCloseTo(1, 6);
+    });
+
+    it('exposes an attention matrix whose rows are distributions', () => {
+        const model = new Transformer().setVocabSize(4).setModelDim(8).setMaxLength(5).setSeed(0);
+        model.train(new Matrix(SEQUENCES), new Matrix(LABELS));
+
+        const attention = model.getAttention(SEQUENCES[0]);
+        expect(attention.length).toBe(5);       // L × L
+        expect(attention[0].length).toBe(5);
+        for (const row of attention) {
+            expect(row.reduce((a, b) => a + b, 0)).toBeCloseTo(1, 6); // each row softmaxes to 1
+        }
+    });
+
+    it('is deterministic and the loss falls', () => {
+        const run = () => {
+            const model = new Transformer().setVocabSize(4).setModelDim(8).setMaxLength(5).setNumberOfEpochs(80).setSeed(2);
+            model.train(new Matrix(SEQUENCES), new Matrix(LABELS));
+            return model.predict(new Matrix(SEQUENCES)).toArray();
+        };
+        expect(run()).toEqual(run());
+
+        const fresh = new Transformer().setVocabSize(4).setModelDim(8).setMaxLength(5).setSeed(2);
+        const initial = fresh.setNumberOfEpochs(0).train(new Matrix(SEQUENCES), new Matrix(LABELS)).computeLoss(new Matrix(SEQUENCES), new Matrix(LABELS));
+        const after = fresh.setNumberOfEpochs(200).train(new Matrix(SEQUENCES), new Matrix(LABELS)).computeLoss(new Matrix(SEQUENCES), new Matrix(LABELS));
+        expect(after).toBeLessThan(initial);
+    });
+
+    it('round-trips its hyperparameters and chains setters', () => {
+        const model = new Transformer();
+        expect(model.getModelDim()).toBe(8);
+
+        const returned = model.setVocabSize(30).setModelDim(16).setMaxLength(12).setLearningRate(0.01).setNumberOfEpochs(50).setSeed(7);
+        expect(returned).toBe(model);
+        expect(model.getVocabSize()).toBe(30);
+        expect(model.getModelDim()).toBe(16);
+        expect(model.getMaxLength()).toBe(12);
+        expect(model.getLearningRate()).toBe(0.01);
+        expect(model.getNumberOfEpochs()).toBe(50);
+        expect(model.getSeed()).toBe(7);
+    });
+});


### PR DESCRIPTION
Takes the library **0.9.0 → 0.10.0**, adding **Chapter 23: Transformers & Attention** — a from-scratch trainable single self-attention block, the third deep-learning frontier chapter built fully (the plan flagged all three `(adopts)`), and the close of the deep-learning arc.

## Library — `Transformer`
- Single self-attention block: token + positional **embeddings** → **Q/K/V** → scaled dot-product **softmax attention** → context → classify from the **[CLS]** position → softmax. Trained end-to-end by backprop through the attention.
- `train` / `predict` / `computeLoss`, **`getAttention()`**, and **`checkGradients()`** — finite-difference verification of the attention gradients (the trickiest in the library).
- Exported; demo, README, keywords. **6 tests** incl. the attention gradient check (two configs) and a find-the-keyword-anywhere task. Suite: 165 → **171**, all green.

## Site
- `transformerDatasets.ts` (café reviews, one sentiment word hidden among fillers at a random slot), `viz/transformer.ts` (the **[CLS] attention bar chart**), `TransformerPlayground.tsx` — live training where the attention bar **grows tallest over the salient word**; ✓ gradients verified.
- Registered Ch 23; `content/transformer.mdx` ("Looking everywhere at once") — Q/K/V + attention, positional embeddings, the multi-head/scale field note, closing nod to the model writing the course.
- `course-plan.md`: Ch 23 ✅.

## Verification
- Library: `yarn typecheck` + `yarn test` (171) clean; gradient check passes; `modelDim=16` reaches 100% accuracy with ~40% [CLS] attention on the keyword (≈2.5× the uniform baseline).
- Site: `yarn typecheck` + `yarn build` clean (own lazy chunk).

Merging deploys the site; the `v0.10.0` tag (pushed after merge) triggers `publish.yml` → npm.