### PR TITLE
Release 0.12.0: Contextual Bandits (Chapter 25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Below are some simple code usage examples.
 * [Recommender](#recommender)
 * [Exponential Smoothing (time series)](#exponential-smoothing-time-series)
 * [Multi-Armed Bandit (reinforcement learning)](#multi-armed-bandit-reinforcement-learning)
+* [Contextual Bandit (LinUCB)](#contextual-bandit-linucb)
 
 ### Feedforward Neural Network
 ```TypeScript
@@ -567,6 +568,34 @@ console.log(bandit.getValues().map(v => Number(v.toFixed(2))));
 // [ 0.30, 0.55, 0.80 ]  <- learned sell-rates converge to the hidden truth
 console.log(bandit.getCounts());
 // [ 80, 246, 1674 ]  <- and it played the winner (special 2) far the most, sampling the rest to be sure
+
+```
+
+### Contextual Bandit (LinUCB)
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// Contextual bandit: the best offer depends on WHO is at the counter. Before each choice the world
+// hands you a context (here [isMorningRegular, isEveningTourist]); LinUCB fits a little ridge-regression
+// model per arm and picks by predicted reward + an uncertainty bonus where it has seen little data.
+const types = [[1, 0], [0, 1]];            // morning regular / evening tourist
+const rate = [[0.8, 0.2], [0.2, 0.8]];     // hidden: cinnamon roll wins mornings, espresso tonic evenings
+
+const bandit = new ml.ContextualBandit();
+bandit.setNumberOfArms(2).setContextDimensions(2).setStrategy('linucb'); // or 'epsilon-greedy'
+
+let lcg = 1;
+const rng = () => (lcg = (lcg * 48271) % 2147483647) / 2147483647;
+for (let t = 0; t < 3000; t++) {
+    const context = types[rng() < 0.5 ? 0 : 1];
+    const arm = bandit.selectArm(context);                       // pick an offer for this customer
+    const took = rng() < rate[arm][context[1] === 1 ? 1 : 0] ? 1 : 0;
+    bandit.update(arm, context, took);                           // learn from the outcome
+}
+
+console.log('morning →', bandit.selectArm([1, 0]), ' evening →', bandit.selectArm([0, 1]));
+// morning → 0  evening → 1  <- a per-customer policy: roll for regulars, tonic for tourists
 
 ```
 

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -26,17 +26,18 @@ generative). The built algorithms become the spine; everything else is roadmap.
 
 **Goal:** engaging, fun, genuinely educational, and very cool.
 
-**Status (this release).** Woven through **Ch 0–24** with no built-but-unwoven gaps: all of Part 1,
+**Status (this release).** Woven through **Ch 0–25** with no built-but-unwoven gaps: all of Part 1,
 the whole of Part 2 (k‑NN, Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support
 Vector Machines), all of Part 3 (k‑Means, Hierarchical Clustering, DBSCAN, PCA, Anomaly Detection,
 Association Rules, Recommender Systems), all of Part 4 — Time Series, the Perceptron interlude, Neural
-Networks, Convolutional Networks, Recurrent Networks, Transformers & Attention — and now **Ch 24
-Multi-Armed Bandits**, which opens **Part 5 (reinforcement learning)**: the first model that *acts*
-rather than predicts, learning online via select → reward → update with ε-greedy and UCB strategies.
-**All three deep-learning frontier chapters (CNN, RNN, Transformer) became full trainable builds**,
-each gradient-checked, rather than the planned "adopts" explainers. Still roadmap: the rest of the
-reinforcement-learning arc (Ch 25–27), generative (Ch 28–29), and Bayesian (Ch 30). See the status
-column below.
+Networks, Convolutional Networks, Recurrent Networks, Transformers & Attention — and **Part 5
+(reinforcement learning)** now under way with **Ch 24 Multi-Armed Bandits** (the first model that
+*acts* rather than predicts — online select → reward → update, ε-greedy + UCB) and **Ch 25 Contextual
+Bandits** (LinUCB: a per-arm ridge-regression model over the context, so the best offer depends on
+who's at the counter). **All three deep-learning frontier chapters (CNN, RNN, Transformer) became full
+trainable builds**, each gradient-checked, rather than the planned "adopts" explainers. Still roadmap:
+the rest of the reinforcement-learning arc (Ch 26–27), generative (Ch 28–29), and Bayesian (Ch 30).
+See the status column below.
 
 ---
 
@@ -186,7 +187,7 @@ Every row's "Wall" is the previous tool failing.
 | # | Chapter | Café problem | The Wall → The Idea | Status |
 |---|---|---|---|---|
 | 24 | **Multi-Armed Bandits** | Which daily special sells best? | Static prediction never *acts* or learns from outcomes → **explore vs. exploit**; regret; ε-greedy/UCB (the gentle RL entry) | ✅ `MultiArmedBandit` (first reinforcement-learning chapter — online select/reward/update; ε-greedy + UCB) |
-| 25 | **Contextual Bandits** | Personalized offers per customer context | One best arm for everyone is too coarse → condition the choice on context | ○ |
+| 25 | **Contextual Bandits** | Personalized offers per customer context | One best arm for everyone is too coarse → condition the choice on context | ✅ `ContextualBandit` (LinUCB + ε-greedy — per-arm ridge regression over the context, online) |
 | 26 | **MDPs & Q-Learning** | A restocking / pricing **policy** over time | Actions have *delayed* consequences → states, actions, rewards, value, Bellman, Q-learning | ○ |
 | 27 | **Deep RL (DQN / Policy Gradients)** | **Chain-scale** optimization where the state space explodes (many stores × SKUs × conditions) | *Tabular Q-learning's table is now impossibly large* → neural nets approximate value/policy. **NB: this is the weakest café hook** — keep it tied to chain-scale optimization, not a gimmicky "robot barista" | ○ (adopts) |
 

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -293,6 +293,26 @@ import * as ml from '../src/lib';
 }
 
 {
+    // Contextual bandit (LinUCB): the best offer now depends on WHO is at the counter.
+    // Context = [isMorningRegular, isEveningTourist]. Two arms: a cinnamon roll vs an espresso tonic.
+    const types = [[1, 0], [0, 1]];                  // morning regular / evening tourist
+    const rate = [[0.8, 0.2], [0.2, 0.8]];           // hidden: roll wins mornings, tonic wins evenings
+
+    const bandit = new ml.ContextualBandit().setNumberOfArms(2).setContextDimensions(2).setStrategy('linucb').setSeed(0);
+
+    let lcg = 1;
+    const rng = () => (lcg = (lcg * 48271) % 2147483647) / 2147483647; // tiny seeded generator
+    for (let t = 0; t < 3000; t++) {
+        const context = types[rng() < 0.5 ? 0 : 1];                  // who walked in
+        const arm = bandit.selectArm(context);                       // pick an offer for them
+        const took = rng() < rate[arm][context[1] === 1 ? 1 : 0] ? 1 : 0;
+        bandit.update(arm, context, took);                           // learn from the outcome
+    }
+    console.log('morning →', bandit.selectArm([1, 0]), ' evening →', bandit.selectArm([0, 1]));
+    // morning → 0  evening → 1  ← it learned a per-customer policy: roll for regulars, tonic for tourists
+}
+
+{
     // Naive Bayes (multinomial): classify messages by word counts.
     // Vocabulary [free, money, table, tonight]; one-hot classes [spam, ham].
     const inputs = new ml.Matrix([[2, 1, 0, 0], [1, 2, 0, 0], [0, 0, 2, 1], [0, 0, 1, 2]]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-learning",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "TypeScript & JavaScript machine learning library",
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,9 @@
     "bandit",
     "explore exploit",
     "epsilon-greedy",
-    "ucb"
+    "ucb",
+    "contextual bandit",
+    "linucb"
   ],
   "author": "Erik Gerrits <gerrits.erik@gmail.com>",
   "license": "MIT",

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -34,6 +34,7 @@ const CNNTutorial = lazy(() => import('./content/cnn.mdx'));
 const RNNTutorial = lazy(() => import('./content/rnn.mdx'));
 const TransformerTutorial = lazy(() => import('./content/transformer.mdx'));
 const BanditsTutorial = lazy(() => import('./content/bandits.mdx'));
+const ContextualBanditsTutorial = lazy(() => import('./content/contextual-bandits.mdx'));
 
 export function App() {
     return (
@@ -245,6 +246,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <BanditsTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="contextual-bandits"
+                    element={
+                        <TutorialPage>
+                            <ContextualBanditsTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -257,4 +257,13 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         chapter: 24,
         part: PART_5,
     },
+    {
+        id: 'contextual-bandits',
+        path: '/contextual-bandits',
+        title: 'Contextual Bandits',
+        tagline: 'The best offer depends on who walks in — learn a policy per customer.',
+        status: 'live',
+        chapter: 25,
+        part: PART_5,
+    },
 ];

--- a/site/src/components/ContextualBanditPlayground.module.css
+++ b/site/src/components/ContextualBanditPlayground.module.css
@@ -1,0 +1,72 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 520px) minmax(240px, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.chartWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 3 / 2;
+    background: #0b1120;
+}
+
+.chart {
+    width: 100%;
+    height: 100%;
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 14px;
+    font-size: 12px;
+    color: var(--muted);
+}
+
+.legend span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.legend i {
+    width: 12px;
+    height: 12px;
+    border-radius: 3px;
+    display: inline-block;
+}
+
+.note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/ContextualBanditPlayground.tsx
+++ b/site/src/components/ContextualBanditPlayground.tsx
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ContextualBandit } from 'machine-learning';
+import type { ContextualStrategy } from 'machine-learning';
+import { CONTEXTUAL_SCENARIOS, contextOf, bestRateForType, type ContextualScenario } from '../ml/contextualBanditDatasets';
+import { mulberry32 } from '../ml/rng';
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+import { drawContextualBandit } from '../viz/contextualBandit';
+import { CLUSTER_HEX } from '../viz/clusters';
+import { Card, Checkbox, ControlPanel, Hint, Metric, MetricsRow, NumberField, RunControls, Select, Slider } from './controls/Controls';
+import styles from './ContextualBanditPlayground.module.css';
+
+const STEPS_PER_FRAME = 4;
+
+export function ContextualBanditPlayground() {
+    const [scenarioId, setScenarioId] = useState(CONTEXTUAL_SCENARIOS[0].id);
+    const [strategy, setStrategy] = useState<ContextualStrategy>('linucb');
+    const [alphaSlider, setAlphaSlider] = useState(10); // alpha = slider / 10
+    const [epsilonSlider, setEpsilonSlider] = useState(10); // epsilon = slider / 100
+    const [seed, setSeed] = useState(0);
+    const [reveal, setReveal] = useState(true);
+    const [running, setRunning] = useState(false);
+    const [metrics, setMetrics] = useState({ days: 0, sales: 0, regret: 0, serving: '—' });
+
+    const alpha = alphaSlider / 10;
+    const epsilon = epsilonSlider / 100;
+
+    const banditRef = useRef<ContextualBandit | null>(null);
+    const envRef = useRef<() => number>(() => 0);
+    const scenarioRef = useRef<ContextualScenario>(CONTEXTUAL_SCENARIOS[0]);
+    const servingRef = useRef(-1);
+    const salesRef = useRef(0);
+    const optimalRef = useRef(0);
+    const frameRef = useRef(0);
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const draw = useCallback(() => {
+        const bandit = banditRef.current;
+        const canvas = canvasRef.current;
+        const scenario = scenarioRef.current;
+        if (!bandit || !canvas) return;
+
+        const predicted = scenario.types.map((_, t) => {
+            const ctx = contextOf(scenario, t);
+            return scenario.arms.map((_, a) => bandit.predict(a, ctx));
+        });
+        const rates = scenario.types.map((_, t) => scenario.arms.map((_, a) => scenario.rates[a][t]));
+
+        drawContextualBandit(canvas, {
+            arms: scenario.arms,
+            types: scenario.types,
+            predicted,
+            rates,
+            serving: servingRef.current,
+            revealRates: reveal,
+        });
+    }, [reveal]);
+
+    const rebuild = useCallback(() => {
+        const scenario = CONTEXTUAL_SCENARIOS.find(s => s.id === scenarioId) ?? CONTEXTUAL_SCENARIOS[0];
+        const bandit = new ContextualBandit()
+            .setNumberOfArms(scenario.arms.length)
+            .setContextDimensions(scenario.types.length)
+            .setStrategy(strategy)
+            .setAlpha(alpha)
+            .setEpsilon(epsilon)
+            .setSeed(seed);
+
+        banditRef.current = bandit;
+        scenarioRef.current = scenario;
+        envRef.current = mulberry32(seed + 101);
+        servingRef.current = -1;
+        salesRef.current = 0;
+        optimalRef.current = 0;
+        frameRef.current = 0;
+
+        setMetrics({ days: 0, sales: 0, regret: 0, serving: '—' });
+        setRunning(false);
+        draw();
+    }, [scenarioId, strategy, alpha, epsilon, seed, draw]);
+
+    useEffect(() => {
+        rebuild();
+    }, [rebuild]);
+
+    const step = useCallback(() => {
+        const bandit = banditRef.current;
+        const scenario = scenarioRef.current;
+        if (!bandit) return;
+
+        for (let s = 0; s < STEPS_PER_FRAME; s++) {
+            const type = Math.floor(envRef.current() * scenario.types.length); // who walks in
+            const context = contextOf(scenario, type);
+            const arm = bandit.selectArm(context);                              // pick an offer for them
+            const sold = envRef.current() < scenario.rates[arm][type] ? 1 : 0;  // did they take it?
+            bandit.update(arm, context, sold);                                  // learn from the outcome
+            servingRef.current = type;
+            salesRef.current += sold;
+            optimalRef.current += bestRateForType(scenario, type);              // a perfect chooser's take
+        }
+
+        draw();
+        frameRef.current += 1;
+        if (frameRef.current % 2 === 0) {
+            setMetrics({
+                days: bandit.getTotalSteps(),
+                sales: salesRef.current,
+                regret: Math.round(optimalRef.current - salesRef.current),
+                serving: scenario.types[servingRef.current] ?? '—',
+            });
+        }
+    }, [draw]);
+
+    useAnimationFrame(step, running);
+
+    const handleStep = () => {
+        if (!running) step();
+    };
+    const handleReset = () => {
+        setRunning(false);
+        rebuild();
+    };
+
+    const scenario = CONTEXTUAL_SCENARIOS.find(s => s.id === scenarioId);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <RunControls
+                    running={running}
+                    onToggle={() => setRunning(r => !r)}
+                    onStep={handleStep}
+                    onReset={handleReset}
+                />
+                <Select
+                    label="Scenario"
+                    value={scenarioId}
+                    options={CONTEXTUAL_SCENARIOS.map(s => ({ value: s.id, label: s.label }))}
+                    onChange={setScenarioId}
+                />
+                {scenario && <Hint>{scenario.blurb}</Hint>}
+                <Select
+                    label="Strategy"
+                    value={strategy}
+                    options={[
+                        { value: 'linucb', label: 'LinUCB' },
+                        { value: 'epsilon-greedy', label: 'ε-greedy' },
+                    ]}
+                    onChange={v => setStrategy(v as ContextualStrategy)}
+                />
+                {strategy === 'linucb' ? (
+                    <Slider label="Optimism α" value={alphaSlider} display={alpha.toFixed(1)} min={0} max={30} onChange={setAlphaSlider} />
+                ) : (
+                    <Slider label="Explore rate ε" value={epsilonSlider} display={epsilon.toFixed(2)} min={0} max={50} onChange={setEpsilonSlider} />
+                )}
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+                <Checkbox label="Show true rates" checked={reveal} onChange={setReveal} />
+                <Hint>Each panel is one kind of customer. Hit Train and watch a different ★ rise in each — one policy, tailored per context.</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.chartWrap}>
+                    <canvas ref={canvasRef} className={styles.chart} />
+                </div>
+
+                <div className={styles.side}>
+                    {scenario && (
+                        <div className={styles.legend}>
+                            {scenario.arms.map((arm, a) => (
+                                <span key={arm}>
+                                    <i style={{ background: CLUSTER_HEX[a % CLUSTER_HEX.length] }} />
+                                    {arm}
+                                </span>
+                            ))}
+                        </div>
+                    )}
+
+                    <MetricsRow>
+                        <Metric label="Days" value={String(metrics.days)} />
+                        <Metric label="Sales" value={String(metrics.sales)} />
+                        <Metric label="Regret" value={String(metrics.regret)} />
+                    </MetricsRow>
+
+                    <Card title="Serving now" subtitle="the lit-up panel">
+                        <p className={styles.note}>
+                            <strong>{metrics.serving}</strong> — the customer at the counter this turn. The
+                            bandit reads the context, picks that panel&apos;s ★ offer, and folds the result
+                            into <em>that offer&apos;s</em> model. <em>Regret</em> is the sales lost versus a
+                            chooser who already knew every customer&apos;s favourite.
+                        </p>
+                    </Card>
+
+                    <Card title="One model per offer" subtitle="LinUCB">
+                        <p className={styles.note}>
+                            Each offer learns a little linear model: how much each customer feature lifts its
+                            sell-rate. <strong>LinUCB</strong> picks the offer with the best predicted rate
+                            <em> plus</em> an optimism bonus where it has little data on that kind of customer —
+                            <strong> α</strong> sets how boldly it probes. On <em>One size fits all</em> the ★
+                            lands on the same offer in every panel: context turned out not to matter.
+                        </p>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/content/contextual-bandits.mdx
+++ b/site/src/content/contextual-bandits.mdx
@@ -1,0 +1,106 @@
+import { ContextualBanditPlayground } from '../components/ContextualBanditPlayground';
+
+# Chapter 25 — It depends who's asking
+
+> *Contextual bandits.* Last chapter's bandit found the one special that sells best. But the morning
+> regular and the evening tourist don't want the same thing — so "the best special" is the wrong
+> question. The right one is **best for *whom*** — and that's a policy the café can learn.
+
+The plain bandit from Chapter 24 settled Nadia's chalkboard: feature the season's best seller, sample
+the rest now and then. But standing at the counter she notices something it can't see. The 7am
+regulars reliably grab a cinnamon roll; the same roll sits untouched when the after-dinner crowd
+drifts in for something sharp and cold. One number per special — its overall sell-rate — is blurring
+two different worlds together.
+
+## The wall: one best arm for everyone is too coarse
+
+A multi-armed bandit keeps a single running average per arm, so it can only ever crown **one** winner.
+When the cinnamon roll sells to half the room and flops with the other half, that average lands
+somewhere in the lukewarm middle — and the bandit either over-features it on the evening crowd or
+under-features it in the morning. It has no handle for *"it depends."* The information Nadia needs —
+who's at the counter — is sitting right there, and the model has no slot to put it in.
+
+## The idea: a model per arm, conditioned on context
+
+So before each choice, let the world hand the bandit a **context**: a little feature vector describing
+the customer (morning regular? evening tourist? sweet tooth? in a hurry?). Now give **each offer its
+own small model** that predicts *its* reward from that context, rather than a lone average. Learn those
+models online from what you observe, and at decision time, score every offer **for this specific
+customer** and pick the best.
+
+The classic recipe is **LinUCB**. Each arm fits a ridge regression — reward ≈ `θ_a · context` — and,
+just like UCB last chapter, it doesn't trust the prediction blindly. It adds an **optimism bonus**
+that's large where the arm has seen little data *for customers like this one*:
+
+$$
+\text{score}_a(x) = \underbrace{\theta_a \cdot x}_{\text{predicted reward}} + \;\alpha \underbrace{\sqrt{x^{\top} A_a^{-1}\, x}}_{\text{how unsure, for this } x}
+$$
+
+Each panel below is one kind of customer. Press **Train** and watch a **different ★ rise in each** —
+a single bandit learning a tailored policy per context:
+
+<div className="breakout">
+  <ContextualBanditPlayground />
+</div>
+
+## How it works: ridge regression you can update one row at a time
+
+Each arm keeps two running tallies: a matrix `A_a` (it starts as the identity, for ridge
+regularisation, and accumulates the outer product of every context it's been chosen for) and a vector
+`b_a` (the contexts weighted by the rewards they earned). Its weights are `θ_a = A_a⁻¹ b_a` — ordinary
+ridge regression, but maintained **incrementally**, straight from the
+[`ContextualBandit`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/reinforcement/ContextualBandit.ts)
+source:
+
+```ts
+// update(arm, context, reward): fold one outcome into that arm's model
+this.A[arm] = Matrix.add(this.A[arm], Matrix.multiply(x, Matrix.transpose(x))); // A += x·xᵀ
+this.b[arm] = Matrix.add(this.b[arm], Matrix.multiply(x, reward));              // b += reward·x
+```
+
+Selection inverts each arm's `A_a`, reads off its prediction, and — for LinUCB — adds the optimism
+bonus before taking the best:
+
+```ts
+const inverse = this.A[arm].getInverse();
+const theta = Matrix.multiply(inverse, this.b[arm]);  // ridge weights θ_a = A_a⁻¹ b_a
+let score = dot(theta, x);                            // predicted reward θ_a · x
+if (this.strategy === "linucb") {
+    score += this.alpha * Math.sqrt(dot(Matrix.multiply(inverse, x), x)); // wider where data is thin
+}
+```
+
+That `xᵀ A_a⁻¹ x` term is exactly the variance of the prediction for *this* context: tiny once an arm
+has served many similar customers, large for a customer type it's barely tried — so the bonus pushes
+the bandit to go gather precisely the data it's missing.
+
+## Try it yourself
+
+- **Rush hours.** Three customer types, a different winner in each. Watch the three ★s land on three
+  *different* offers — one bandit, three policies. A plain Chapter-24 bandit could never split these.
+- **One size fits all.** Context is a decoy here — the cookie wins for everyone. The bandit discovers
+  the customer type doesn't move the needle and crowns the cookie in *both* panels, quietly behaving
+  like a plain bandit. Conditioning on context never hurts; it just stops helping.
+- **Optimism α.** Turn it up and LinUCB probes harder — it'll keep trying the unproven offers on a rare
+  customer type longer before committing. Turn it to 0 and it can prematurely lock a column onto a
+  lucky early guess. Compare against plain **ε-greedy**, which explores blindly across all contexts.
+- **Two crowds.** Note the oat flat white never earns a ★ — it's nobody's favourite, and the bandit
+  learns to skip it for both crowds.
+
+> **Field note — this is still a *one-shot* world.** Each customer's reward depends only on the offer
+> you make *them*, right now. Featuring the roll for the morning regular doesn't change who walks in
+> next, or what they'll want. The context is given, never *caused* by your past actions. That
+> independence is what keeps the math a tidy per-arm regression.
+
+## What broke — nothing; but the world is about to start remembering
+
+Nothing broke. The café now personalises: read the customer, make the offer most likely to land,
+and get sharper with every interaction. Bandits — plain and contextual — are the workhorses behind
+real recommendation, ad, and pricing systems for exactly this reason.
+
+But notice the quiet assumption in that field note: every turn is independent. Real decisions aren't
+always so kind. Set a price today and you change which customers come back next month; seat a party
+here and you shape the room for the next hour. When **an action moves you to a new situation** and the
+rewards ripple *forward in time*, a per-turn model isn't enough — you need to reason about **states**
+and a future you partly create. That's the leap to full reinforcement learning, and the next stop on
+the map (`docs/course-plan.md`).

--- a/site/src/ml/contextualBanditDatasets.ts
+++ b/site/src/ml/contextualBanditDatasets.ts
@@ -1,0 +1,63 @@
+// Scenarios for the contextual-bandit playground. The twist over Chapter 24: there's no single best
+// offer — the winner depends on WHO is at the counter. Each scenario lists the offers (arms), the
+// customer types (the context), and a hidden table of sell-rates: rates[arm][type] = how often that
+// offer sells to that type. The bandit never sees this table; it must learn a per-customer policy by
+// trying offers and watching. We encode each customer type as a one-hot context vector, so an arm's
+// learned weight for a type lines up directly with its true rate for that type.
+
+export interface ContextualScenario {
+    id: string;
+    label: string;
+    blurb: string;
+    arms: string[];      // the offers to choose between
+    types: string[];     // the customer contexts that walk in
+    rates: number[][];   // hidden rates[armIndex][typeIndex] — P(offer sells | this customer)
+}
+
+export const CONTEXTUAL_SCENARIOS: ContextualScenario[] = [
+    {
+        id: 'rush-hours',
+        label: 'Rush hours',
+        blurb: 'A different crowd each part of the day, and a different offer wins each one. The bandit has to learn three policies at once — one per column.',
+        arms: ['Cinnamon roll', 'Iced latte', 'Espresso tonic'],
+        types: ['Morning regular', 'Midday office', 'Evening tourist'],
+        rates: [
+            [0.80, 0.40, 0.30], // cinnamon roll — a morning thing
+            [0.35, 0.75, 0.45], // iced latte — midday favourite
+            [0.25, 0.40, 0.78], // espresso tonic — an evening treat
+        ],
+    },
+    {
+        id: 'two-crowds',
+        label: 'Two crowds',
+        blurb: 'Students want cheap, the office crowd wants fancy — and the oat flat white never quite wins anyone, a distractor the bandit must learn to skip.',
+        arms: ['Budget drip', 'Oat flat white', 'Pour-over'],
+        types: ['Students', 'Office crowd'],
+        rates: [
+            [0.70, 0.30], // budget drip — students
+            [0.45, 0.55], // oat flat white — never the best
+            [0.25, 0.72], // pour-over — office crowd
+        ],
+    },
+    {
+        id: 'one-size',
+        label: 'One size fits all',
+        blurb: 'Here context is a red herring: the cookie wins for everyone. A contextual bandit should discover that the customer type doesn’t matter and behave like a plain bandit.',
+        arms: ['Cookie', 'Brownie'],
+        types: ['Regulars', 'Newcomers'],
+        rates: [
+            [0.70, 0.68], // cookie — wins for both
+            [0.40, 0.42], // brownie — loses to both
+        ],
+    },
+];
+
+/** One-hot context vector for customer type `typeIndex` in a scenario with `types.length` types. */
+export function contextOf(scenario: ContextualScenario, typeIndex: number): number[] {
+    return scenario.types.map((_, i) => (i === typeIndex ? 1 : 0));
+}
+
+/** The best achievable sell-rate for a given customer type — what a perfect, all-knowing chooser earns. */
+export function bestRateForType(scenario: ContextualScenario, typeIndex: number): number {
+    return Math.max(...scenario.arms.map((_, arm) => scenario.rates[arm][typeIndex]));
+}

--- a/site/src/viz/contextualBandit.ts
+++ b/site/src/viz/contextualBandit.ts
@@ -1,0 +1,102 @@
+import { fitCanvas } from './canvas';
+import { CLUSTER_HEX } from './clusters';
+
+// One panel per customer type, side by side. Within a panel, one vertical bar per offer (arm), its
+// height the bandit's *predicted* sell-rate for that offer to that customer. A white tick marks the
+// offer's true hidden rate, and a ★ crowns the offer the bandit would currently pick for that type —
+// so you can watch a genuinely *different* winner emerge in each column. The customer being served on
+// the latest turn has their panel lit up.
+
+export interface ContextualView {
+    arms: string[];           // offer names (shared across panels; coloured consistently)
+    types: string[];          // customer type names (one panel each)
+    predicted: number[][];    // predicted[type][arm] — bandit's estimated sell-rate, clamped to [0, 1]
+    rates: number[][];        // true rates[type][arm]
+    serving: number;          // index of the customer type served this turn (-1 before the first)
+    revealRates: boolean;
+}
+
+export function drawContextualBandit(canvas: HTMLCanvasElement, view: ContextualView): void {
+    const { ctx, width, height } = fitCanvas(canvas);
+    ctx.fillStyle = '#0b1120';
+    ctx.fillRect(0, 0, width, height);
+
+    const nTypes = view.types.length;
+    const nArms = view.arms.length;
+    const outerPad = 12;
+    const panelGap = 10;
+    const panelW = (width - outerPad * 2 - panelGap * (nTypes - 1)) / nTypes;
+
+    const titleH = 26;
+    const plotTop = outerPad + titleH;
+    const plotBottom = height - outerPad - 4;
+    const plotH = plotBottom - plotTop;
+
+    ctx.textBaseline = 'middle';
+
+    for (let t = 0; t < nTypes; t++) {
+        const panelX = outerPad + t * (panelW + panelGap);
+
+        // Light the panel for the customer currently being served.
+        if (t === view.serving) {
+            ctx.fillStyle = 'rgba(250, 204, 21, 0.08)';
+            ctx.fillRect(panelX - 4, outerPad - 2, panelW + 8, height - outerPad * 2 + 4);
+            ctx.strokeStyle = 'rgba(250, 204, 21, 0.5)';
+            ctx.lineWidth = 1.5;
+            ctx.strokeRect(panelX - 4, outerPad - 2, panelW + 8, height - outerPad * 2 + 4);
+        }
+
+        // Panel title (customer type).
+        ctx.fillStyle = t === view.serving ? '#facc15' : '#e2e8f0';
+        ctx.font = '600 12px system-ui, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText(view.types[t], panelX + panelW / 2, outerPad + titleH / 2);
+
+        const chosen = argmax(view.predicted[t]);
+        const barSlot = panelW / nArms;
+        const barW = Math.min(38, barSlot * 0.6);
+
+        for (let a = 0; a < nArms; a++) {
+            const cx = panelX + barSlot * (a + 0.5);
+            const color = CLUSTER_HEX[a % CLUSTER_HEX.length];
+
+            // Track.
+            ctx.fillStyle = 'rgba(148, 163, 184, 0.10)';
+            ctx.fillRect(cx - barW / 2, plotTop, barW, plotH);
+
+            // Predicted-reward bar.
+            const h = clamp01(view.predicted[t][a]) * plotH;
+            ctx.fillStyle = color;
+            ctx.fillRect(cx - barW / 2, plotBottom - h, barW, h);
+
+            // True-rate tick.
+            if (view.revealRates) {
+                const ty = plotBottom - clamp01(view.rates[t][a]) * plotH;
+                ctx.strokeStyle = '#f8fafc';
+                ctx.lineWidth = 2;
+                ctx.beginPath();
+                ctx.moveTo(cx - barW / 2 - 3, ty);
+                ctx.lineTo(cx + barW / 2 + 3, ty);
+                ctx.stroke();
+            }
+
+            // ★ over the offer the bandit would pick for this customer.
+            if (a === chosen) {
+                ctx.fillStyle = '#facc15';
+                ctx.font = '13px system-ui, sans-serif';
+                ctx.textAlign = 'center';
+                ctx.fillText('★', cx, plotBottom - h - 10);
+            }
+        }
+    }
+}
+
+function argmax(values: number[]): number {
+    let best = 0;
+    for (let i = 1; i < values.length; i++) if (values[i] > values[best]) best = i;
+    return best;
+}
+
+function clamp01(v: number): number {
+    return Math.max(0, Math.min(1, v));
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,6 +1,8 @@
 export { default as AnomalyDetector } from "./machine-learning/unsupervised/AnomalyDetector";
 export { default as AssociationRules } from "./machine-learning/unsupervised/AssociationRules";
 export type { AssociationRule, FrequentItemset } from "./machine-learning/unsupervised/AssociationRules";
+export { default as ContextualBandit } from "./machine-learning/reinforcement/ContextualBandit";
+export type { ContextualStrategy } from "./machine-learning/reinforcement/ContextualBandit";
 export { default as ConvolutionalNeuralNetwork } from "./machine-learning/supervised/ConvolutionalNeuralNetwork";
 export { default as DBSCAN } from "./machine-learning/unsupervised/DBSCAN";
 export { default as DecisionTree } from "./machine-learning/supervised/DecisionTree";

--- a/src/lib/machine-learning/reinforcement/ContextualBandit.ts
+++ b/src/lib/machine-learning/reinforcement/ContextualBandit.ts
@@ -1,0 +1,184 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+import mulberry32 from "../../math/random/mulberry32";
+
+/** How the contextual bandit trades off acting on its current model (exploit) against gathering
+ *  information where it's least certain (explore). */
+export type ContextualStrategy = "linucb" | "epsilon-greedy";
+
+/**
+ * A **contextual bandit** — the step up from the plain {@link MultiArmedBandit}. There, one arm was
+ * best for everyone; here the best arm *depends on the situation*. Before each choice the world hands
+ * you a **context** — a feature vector describing who's at the counter (regular or tourist, morning or
+ * evening, sweet tooth or not) — and the reward an arm pays now depends on that context. So a single
+ * running average per arm is too coarse: the cinnamon roll might delight the morning crowd and bore
+ * the evening one.
+ *
+ * The fix is to give **each arm its own little linear model** that predicts its reward from the
+ * context, and to learn those models online from the outcomes you observe. This is the classic
+ * **LinUCB** algorithm: each arm keeps a ridge-regression fit `θ_a` (reward ≈ `θ_a · context`), and
+ * picks are guided by both the prediction *and* how uncertain it is:
+ *
+ * - **linucb** — choose the arm with the highest `θ_a · x + α · √(xᵀ A_a⁻¹ x)`: its predicted reward
+ *   plus an **optimism bonus** that's large where the arm has seen little data *like this context*.
+ *   It explores deliberately, aiming curiosity at the gaps in what it knows.
+ * - **epsilon-greedy** — use the same per-arm prediction `θ_a · x`, but explore by picking a random
+ *   arm with probability `epsilon` instead. Simpler, blind exploration.
+ *
+ * Like the multi-armed bandit, it learns **online** — there is no `train(inputs, targets)`. You loop
+ * {@link selectArm}(context) → observe a reward → {@link update}(arm, context, reward). Seeded for
+ * reproducibility.
+ *
+ * @example
+ * const bandit = new ContextualBandit().setNumberOfArms(3).setContextDimensions(2).setStrategy('linucb');
+ * for (let t = 0; t < 2000; t++) {
+ *   const context = describeCustomer();   // e.g. [isMorning, sweetTooth]
+ *   const arm = bandit.selectArm(context);
+ *   const reward = offer(arm, context);    // 1 = they took it, 0 = they passed
+ *   bandit.update(arm, context, reward);
+ * }
+ */
+export default class ContextualBandit {
+
+    private numberOfArms = 3;
+    private contextDimensions = 2;
+    private strategy: ContextualStrategy = "linucb";
+    private alpha = 1;            // LinUCB exploration weight (how much the uncertainty bonus counts)
+    private epsilon = 0.1;        // ε-greedy exploration rate
+    private regularization = 1;   // ridge λ — each arm's A starts as λ·I, keeping it invertible
+    private seed = 0;
+
+    private A: Matrix[];          // per arm: λ·I + Σ x·xᵀ  (d×d)
+    private b: Matrix[];          // per arm: Σ reward·x      (d×1)
+    private counts: number[];
+    private totalSteps = 0;
+    private random: () => number;
+
+    public constructor () {}
+
+    /** Choose an arm for this context, according to the strategy. */
+    public selectArm (context: number[]) {
+        this.ensureInitialized();
+        const x = Matrix.columnVector(context);
+
+        if (this.strategy === "epsilon-greedy" && this.random() < this.epsilon) {
+            return Math.floor(this.random() * this.numberOfArms); // explore: a random arm
+        }
+
+        let best = 0;
+        let bestScore = -Infinity;
+        for (let arm = 0; arm < this.numberOfArms; arm++) {
+            const inverse = this.A[arm].getInverse();
+            const theta = Matrix.multiply(inverse, this.b[arm]); // ridge weights θ_a = A_a⁻¹ b_a
+            let score = dot(theta, x);                           // predicted reward θ_a · x
+            if (this.strategy === "linucb") {
+                // Optimism bonus: α·√(xᵀ A_a⁻¹ x) — wide where this arm has little data like x.
+                score += this.alpha * Math.sqrt(Math.max(0, dot(Matrix.multiply(inverse, x), x)));
+            }
+            if (score > bestScore) {
+                bestScore = score;
+                best = arm;
+            }
+        }
+        return best;
+    }
+
+    /** Fold one observed (context, reward) outcome into the chosen arm's model. */
+    public update (arm: number, context: number[], reward: number) {
+        this.ensureInitialized();
+        const x = Matrix.columnVector(context);
+        this.A[arm] = Matrix.add(this.A[arm], Matrix.multiply(x, Matrix.transpose(x))); // A += x·xᵀ
+        this.b[arm] = Matrix.add(this.b[arm], Matrix.multiply(x, reward));              // b += reward·x
+        this.counts[arm]++;
+        this.totalSteps++;
+        return this;
+    }
+
+    public reset () {
+        this.A = undefined;
+        this.b = undefined;
+        this.counts = undefined;
+        this.totalSteps = 0;
+        this.random = undefined;
+        return this;
+    }
+
+    /* Parameter setters */
+
+    public setNumberOfArms (numberOfArms: number) { this.numberOfArms = numberOfArms; return this; }
+    public setContextDimensions (contextDimensions: number) { this.contextDimensions = contextDimensions; return this; }
+    public setStrategy (strategy: ContextualStrategy) { this.strategy = strategy; return this; }
+    public setAlpha (alpha: number) { this.alpha = alpha; return this; }
+    public setEpsilon (epsilon: number) { this.epsilon = epsilon; return this; }
+    public setRegularization (regularization: number) { this.regularization = regularization; return this; }
+    public setSeed (seed: number) { this.seed = seed; return this; }
+
+    /* Parameter getters */
+
+    public getNumberOfArms () { return this.numberOfArms; }
+    public getContextDimensions () { return this.contextDimensions; }
+    public getStrategy () { return this.strategy; }
+    public getAlpha () { return this.alpha; }
+    public getEpsilon () { return this.epsilon; }
+    public getRegularization () { return this.regularization; }
+    public getSeed () { return this.seed; }
+
+    /** An arm's learned weight vector θ_a — how strongly it expects each context feature to lift its reward. */
+    public getWeights (arm: number) {
+        this.ensureInitialized();
+        return columnToArray(Matrix.multiply(this.A[arm].getInverse(), this.b[arm]));
+    }
+
+    /** An arm's predicted reward θ_a · context for a given context. */
+    public predict (arm: number, context: number[]) {
+        this.ensureInitialized();
+        const theta = Matrix.multiply(this.A[arm].getInverse(), this.b[arm]);
+        return dot(theta, Matrix.columnVector(context));
+    }
+
+    /** An arm's LinUCB uncertainty width α·√(xᵀ A_a⁻¹ x) for a context — the optimism bonus driving exploration. */
+    public getConfidence (arm: number, context: number[]) {
+        this.ensureInitialized();
+        const x = Matrix.columnVector(context);
+        const inverse = this.A[arm].getInverse();
+        return this.alpha * Math.sqrt(Math.max(0, dot(Matrix.multiply(inverse, x), x)));
+    }
+
+    /** How many times each arm has been played. */
+    public getCounts () { this.ensureInitialized(); return this.counts.slice(); }
+    /** Total interactions so far. */
+    public getTotalSteps () { return this.totalSteps; }
+
+    /* Private methods */
+
+    private ensureInitialized () {
+        const d = this.contextDimensions;
+        if (this.A === undefined || this.A.length !== this.numberOfArms || this.A[0].getRowCount() !== d) {
+            this.A = [];
+            this.b = [];
+            for (let arm = 0; arm < this.numberOfArms; arm++) {
+                this.A.push(Matrix.multiply(Matrix.identity(d), this.regularization)); // λ·I, always invertible
+                this.b.push(Matrix.zeros(d, 1));
+            }
+            this.counts = new Array<number>(this.numberOfArms).fill(0);
+            this.totalSteps = 0;
+            this.random = mulberry32(this.seed);
+        }
+    }
+}
+
+/** Dot product of two column vectors (d×1 matrices). */
+function dot (a: Matrix, b: Matrix): number {
+    let sum = 0;
+    for (let i = 0; i < a.getRowCount(); i++) {
+        sum += a.getElement(i, 0) * b.getElement(i, 0);
+    }
+    return sum;
+}
+
+function columnToArray (column: Matrix): number[] {
+    const values: number[] = [];
+    for (let i = 0; i < column.getRowCount(); i++) {
+        values.push(column.getElement(i, 0));
+    }
+    return values;
+}

--- a/src/test/ContextualBandit.test.ts
+++ b/src/test/ContextualBandit.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import ContextualBandit from '../lib/machine-learning/reinforcement/ContextualBandit';
+import mulberry32 from '../lib/math/random/mulberry32';
+
+// A world where the best arm DEPENDS on the customer. Two customer types, encoded as a context:
+//   morning regular = [1, 0]   →   arm 0 (cinnamon roll) sells at 0.8, the rest at 0.2
+//   evening tourist = [0, 1]   →   arm 1 (espresso tonic) sells at 0.8, the rest at 0.2
+// No single arm is best for everyone, so a context-blind bandit can't do better than guessing which
+// type showed up. A contextual bandit should learn to read the context and switch its pick.
+const TYPES = [[1, 0], [0, 1]];
+const TRUE_RATE = [
+    [0.8, 0.2], // arm 0: great for type A, poor for type B
+    [0.2, 0.8], // arm 1: poor for type A, great for type B
+    [0.3, 0.3], // arm 2: a mediocre all-rounder
+];
+
+const rateOf = (arm: number, context: number[]) => TRUE_RATE[arm][context[1] === 1 ? 1 : 0];
+
+/** Run the bandit against the seeded world for `steps` turns; returns the back-half hit rate (sells). */
+function play(bandit: ContextualBandit, steps: number, seed = 7) {
+    const rand = mulberry32(seed);
+    let recentSales = 0;
+    for (let t = 0; t < steps; t++) {
+        const context = TYPES[Math.floor(rand() * TYPES.length)];
+        const arm = bandit.selectArm(context);
+        const sold = rand() < rateOf(arm, context) ? 1 : 0;
+        bandit.update(arm, context, sold);
+        if (t >= steps / 2) recentSales += sold; // measure once it has had time to learn
+    }
+    return recentSales / (steps / 2);
+}
+
+describe('ContextualBandit', () => {
+
+    it('learns a per-context policy with LinUCB', () => {
+        const bandit = new ContextualBandit().setNumberOfArms(3).setContextDimensions(2).setStrategy('linucb').setAlpha(1).setSeed(0);
+        play(bandit, 3000);
+
+        // The whole point: a DIFFERENT arm is chosen depending on who's at the counter.
+        expect(bandit.selectArm([1, 0])).toBe(0);
+        expect(bandit.selectArm([0, 1])).toBe(1);
+    });
+
+    it('recovers each arm\'s context-to-reward weights', () => {
+        const bandit = new ContextualBandit().setNumberOfArms(3).setContextDimensions(2).setStrategy('linucb').setSeed(0);
+        play(bandit, 4000);
+
+        // θ_a · type ≈ that arm's true sell-rate for the type, so the weights track TRUE_RATE.
+        expect(bandit.getWeights(0)[0]).toBeCloseTo(0.8, 1); // arm 0, feature for type A
+        expect(bandit.getWeights(1)[1]).toBeCloseTo(0.8, 1); // arm 1, feature for type B
+        expect(bandit.predict(0, [1, 0])).toBeCloseTo(0.8, 1);
+        // Arm 0 strongly prefers type A. (It can't pin down its type-B reward — a good policy almost
+        // never features arm 0 for type B, so that weight just stays near the ridge prior.)
+        expect(bandit.predict(0, [1, 0])).toBeGreaterThan(bandit.predict(0, [0, 1]) + 0.4);
+    });
+
+    it('beats a context-blind bandit when the best arm flips with context', () => {
+        const contextual = new ContextualBandit().setNumberOfArms(3).setContextDimensions(2).setStrategy('linucb').setSeed(1);
+        const contextualScore = play(contextual, 3000);
+
+        // A bandit fed a constant context can't tell the types apart — it can only chase one average
+        // arm, capped near (0.8 + 0.2) / 2 = 0.5 because the winner keeps flipping under it.
+        const blind = new ContextualBandit().setNumberOfArms(3).setContextDimensions(2).setStrategy('linucb').setSeed(1);
+        const rand = mulberry32(7);
+        let blindSales = 0;
+        for (let t = 0; t < 3000; t++) {
+            const context = TYPES[Math.floor(rand() * TYPES.length)];
+            const arm = blind.selectArm([1, 1]);          // always the SAME context → context-blind
+            const sold = rand() < rateOf(arm, context) ? 1 : 0;
+            blind.update(arm, [1, 1], sold);
+            if (t >= 1500) blindSales += sold;
+        }
+
+        expect(contextualScore).toBeGreaterThan(0.65);     // close to the 0.8 optimum
+        expect(contextualScore).toBeGreaterThan(blindSales / 1500 + 0.1);
+    });
+
+    it('also learns a policy with epsilon-greedy', () => {
+        const bandit = new ContextualBandit().setNumberOfArms(3).setContextDimensions(2).setStrategy('epsilon-greedy').setEpsilon(0.1).setSeed(0);
+        play(bandit, 3000);
+
+        expect(bandit.selectArm([1, 0])).toBe(0);
+        expect(bandit.selectArm([0, 1])).toBe(1);
+    });
+
+    it('reports a shrinking uncertainty bonus as an arm gathers data', () => {
+        const bandit = new ContextualBandit().setNumberOfArms(2).setContextDimensions(2).setStrategy('linucb').setSeed(0);
+        const before = bandit.getConfidence(0, [1, 0]);
+        for (let t = 0; t < 50; t++) bandit.update(0, [1, 0], 1);
+        const after = bandit.getConfidence(0, [1, 0]);
+        expect(after).toBeLessThan(before); // more evidence → narrower confidence
+    });
+
+    it('is deterministic for a fixed seed', () => {
+        const run = () => {
+            const b = new ContextualBandit().setNumberOfArms(3).setContextDimensions(2).setStrategy('epsilon-greedy').setEpsilon(0.2).setSeed(3);
+            play(b, 500);
+            return [b.predict(0, [1, 0]), b.predict(1, [0, 1]), b.getCounts()];
+        };
+        expect(run()).toEqual(run());
+    });
+
+    it('round-trips its hyperparameters and chains setters', () => {
+        const bandit = new ContextualBandit();
+        expect(bandit.getStrategy()).toBe('linucb');
+
+        const returned = bandit.setNumberOfArms(5).setContextDimensions(4).setStrategy('epsilon-greedy').setAlpha(0.5).setEpsilon(0.05).setRegularization(2).setSeed(9);
+        expect(returned).toBe(bandit);
+        expect(bandit.getNumberOfArms()).toBe(5);
+        expect(bandit.getContextDimensions()).toBe(4);
+        expect(bandit.getStrategy()).toBe('epsilon-greedy');
+        expect(bandit.getAlpha()).toBe(0.5);
+        expect(bandit.getEpsilon()).toBe(0.05);
+        expect(bandit.getRegularization()).toBe(2);
+        expect(bandit.getSeed()).toBe(9);
+    });
+});


### PR DESCRIPTION
Chapter 25 — **Contextual Bandits**, continuing **Part 5 · Learning by doing**. The step up from Ch 24's plain bandit: the best offer now depends on *who's at the counter*.

## Library
- `ContextualBandit` (in `src/lib/machine-learning/reinforcement/`): **LinUCB** + ε-greedy, a per-arm online ridge-regression model over the context (`θ_a = A_a⁻¹ b_a`) with an uncertainty bonus. `selectArm(context)` → `update(arm, context, reward)`; plus `predict`, `getWeights`, `getConfidence`. Built on the existing `Matrix`. Seeded, chainable.
- 7 tests: per-context policy (both strategies), weight recovery, beats a context-blind bandit when the winner flips, shrinking confidence, determinism, setter round-trip. (184 total pass.)
- Demo block, README section + keywords.
- **Bug fix:** the instance `Matrix.multiply` mutates its receiver — the four hot call sites now use the non-mutating static `Matrix.multiply`.

## Site
- `ml/contextualBanditDatasets.ts` — three scenarios (Rush hours / Two crowds / One size fits all).
- `viz/contextualBandit.ts` — a panel per customer type; bars = predicted sell-rate per offer, true-rate ticks, ★ on the chosen offer, lit panel = current customer.
- `ContextualBanditPlayground.tsx` + MDX tutorial (`content/contextual-bandits.mdx`), registered as Ch 25.
- `docs/course-plan.md` flipped Ch 25 ✅.

## Release
- Version bumped 0.11.0 → **0.12.0** (minor bump per new-algorithm batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)