### PR TITLE
Release 0.13.0: MDPs & Q-Learning (Chapter 26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Below are some simple code usage examples.
 * [Exponential Smoothing (time series)](#exponential-smoothing-time-series)
 * [Multi-Armed Bandit (reinforcement learning)](#multi-armed-bandit-reinforcement-learning)
 * [Contextual Bandit (LinUCB)](#contextual-bandit-linucb)
+* [Q-Learning (reinforcement learning)](#q-learning-reinforcement-learning)
 
 ### Feedforward Neural Network
 ```TypeScript
@@ -596,6 +597,48 @@ for (let t = 0; t < 3000; t++) {
 
 console.log('morning →', bandit.selectArm([1, 0]), ' evening →', bandit.selectArm([0, 1]));
 // morning → 0  evening → 1  <- a per-customer policy: roll for regulars, tonic for tourists
+
+```
+
+### Q-Learning (reinforcement learning)
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// Q-learning: a café runner learns the quickest tray route across the floor — kitchen (S) to table (G),
+// dodging a spill (#). Unlike a bandit, actions have *delayed* consequences, so the agent learns a
+// value for every (state, action) and lets the goal's reward propagate backward through the floor.
+const COLS = 4, ROWS = 3, GOAL = 3, HAZARD = 5, START = 8; // state = row*COLS + col
+const step = (s: number, a: number) => {                   //   . . . G
+    let r = Math.floor(s / COLS), c = s % COLS;             //   . # . .
+    if (a === 0) r--; else if (a === 1) c++; else if (a === 2) r++; else c--; //  S . . .
+    if (r < 0 || r >= ROWS || c < 0 || c >= COLS) { r = Math.floor(s / COLS); c = s % COLS; }
+    const next = r * COLS + c;
+    if (next === GOAL) return { next, reward: 1, done: true };
+    if (next === HAZARD) return { next, reward: -1, done: true };
+    return { next, reward: -0.04, done: false };
+};
+
+const agent = new ml.QLearning();
+agent.setNumberOfStates(ROWS * COLS).setNumberOfActions(4).setDiscountFactor(0.95).setEpsilon(0.2).setSeed(0);
+
+for (let episode = 0; episode < 3000; episode++) {         // learn online, one transition at a time
+    let state = START;
+    for (let t = 0; t < 50; t++) {
+        const action = agent.selectAction(state);
+        const { next, reward, done } = step(state, action);
+        agent.update(state, action, reward, next, done);
+        if (done) break;
+        state = next;
+    }
+}
+
+const arrows = ['↑', '→', '↓', '←'];
+const policy = agent.getPolicy().map((a, s) => (s === GOAL ? 'G' : s === HAZARD ? '#' : arrows[a]));
+for (let r = 0; r < ROWS; r++) console.log(policy.slice(r * COLS, r * COLS + COLS).join(' '));
+// → → → G   the learned policy: every cell points along a quickest safe route to the table,
+// ↑ # ↑ ↑   walking up the left edge then across the top, steering around the spill (#).
+// ↑ → ↑ ↑
 
 ```
 

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -32,12 +32,14 @@ Vector Machines), all of Part 3 (k‑Means, Hierarchical Clustering, DBSCAN, PCA
 Association Rules, Recommender Systems), all of Part 4 — Time Series, the Perceptron interlude, Neural
 Networks, Convolutional Networks, Recurrent Networks, Transformers & Attention — and **Part 5
 (reinforcement learning)** now under way with **Ch 24 Multi-Armed Bandits** (the first model that
-*acts* rather than predicts — online select → reward → update, ε-greedy + UCB) and **Ch 25 Contextual
+*acts* rather than predicts — online select → reward → update, ε-greedy + UCB), **Ch 25 Contextual
 Bandits** (LinUCB: a per-arm ridge-regression model over the context, so the best offer depends on
-who's at the counter). **All three deep-learning frontier chapters (CNN, RNN, Transformer) became full
-trainable builds**, each gradient-checked, rather than the planned "adopts" explainers. Still roadmap:
-the rest of the reinforcement-learning arc (Ch 26–27), generative (Ch 28–29), and Bayesian (Ch 30).
-See the status column below.
+who's at the counter), and **Ch 26 MDPs & Q-Learning** (tabular, model-free, off-policy TD control —
+delayed consequences, the Bellman backup, taught through a café-floor grid world with a live value
+heatmap and policy arrows). **All three deep-learning frontier chapters (CNN, RNN, Transformer) became
+full trainable builds**, each gradient-checked, rather than the planned "adopts" explainers. Still
+roadmap: the close of the reinforcement-learning arc (Ch 27 deep RL), generative (Ch 28–29), and
+Bayesian (Ch 30). See the status column below.
 
 ---
 
@@ -188,7 +190,7 @@ Every row's "Wall" is the previous tool failing.
 |---|---|---|---|---|
 | 24 | **Multi-Armed Bandits** | Which daily special sells best? | Static prediction never *acts* or learns from outcomes → **explore vs. exploit**; regret; ε-greedy/UCB (the gentle RL entry) | ✅ `MultiArmedBandit` (first reinforcement-learning chapter — online select/reward/update; ε-greedy + UCB) |
 | 25 | **Contextual Bandits** | Personalized offers per customer context | One best arm for everyone is too coarse → condition the choice on context | ✅ `ContextualBandit` (LinUCB + ε-greedy — per-arm ridge regression over the context, online) |
-| 26 | **MDPs & Q-Learning** | A restocking / pricing **policy** over time | Actions have *delayed* consequences → states, actions, rewards, value, Bellman, Q-learning | ○ |
+| 26 | **MDPs & Q-Learning** | A restocking / pricing **policy** over time | Actions have *delayed* consequences → states, actions, rewards, value, Bellman, Q-learning | ✅ `QLearning` (tabular, model-free, off-policy TD control; taught via a café-floor grid world — value heatmap + policy arrows) |
 | 27 | **Deep RL (DQN / Policy Gradients)** | **Chain-scale** optimization where the state space explodes (many stores × SKUs × conditions) | *Tabular Q-learning's table is now impossibly large* → neural nets approximate value/policy. **NB: this is the weakest café hook** — keep it tied to chain-scale optimization, not a gimmicky "robot barista" | ○ (adopts) |
 
 ### Part 6 — The frontier (Season 5)

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -313,6 +313,47 @@ import * as ml from '../src/lib';
 }
 
 {
+    // Q-learning (reinforcement learning): a café runner learns the quickest tray route across the
+    // floor, from the kitchen (S) to a table (G), dodging a spill (#). Actions: up/right/down/left.
+    // Only the goal pays off (+1), the spill stings (−1), each step costs a little (−0.04) — so the
+    // agent must propagate that goal value *backward* through the floor to know which way to walk.
+    const COLS = 4, ROWS = 3, GOAL = 3, HAZARD = 5, START = 8; // state = row*COLS + col
+    //   . . . G        (top-right is the table)
+    //   . # . .        (centre-left is the spill)
+    //   S . . .        (bottom-left is the kitchen)
+    const step = (s: number, a: number) => {
+        let r = Math.floor(s / COLS), c = s % COLS;
+        if (a === 0) r--; else if (a === 1) c++; else if (a === 2) r++; else c--;
+        if (r < 0 || r >= ROWS || c < 0 || c >= COLS) { r = Math.floor(s / COLS); c = s % COLS; } // bump a wall, stay
+        const next = r * COLS + c;
+        if (next === GOAL) return { next, reward: 1, done: true };
+        if (next === HAZARD) return { next, reward: -1, done: true };
+        return { next, reward: -0.04, done: false };
+    };
+
+    const agent = new ml.QLearning().setNumberOfStates(ROWS * COLS).setNumberOfActions(4)
+        .setLearningRate(0.4).setDiscountFactor(0.95).setEpsilon(0.2).setSeed(0);
+    for (let episode = 0; episode < 3000; episode++) {
+        let state = START;
+        for (let t = 0; t < 50; t++) {
+            const action = agent.selectAction(state);
+            const { next, reward, done } = step(state, action);
+            agent.update(state, action, reward, next, done);
+            if (done) break;
+            state = next;
+        }
+    }
+
+    const arrows = ['↑', '→', '↓', '←'];
+    const policy = agent.getPolicy().map((a, s) =>
+        s === GOAL ? 'G' : s === HAZARD ? '#' : arrows[a]);
+    for (let r = 0; r < ROWS; r++) console.log(policy.slice(r * COLS, r * COLS + COLS).join(' '));
+    // → → → G     the learned policy — every cell points along a quickest safe route to the table.
+    // ↑ # ↑ ↑     From the kitchen it walks up the left edge, then right across the top, steering
+    // ↑ → ↑ ↑     around the spill (#) rather than through it.
+}
+
+{
     // Naive Bayes (multinomial): classify messages by word counts.
     // Vocabulary [free, money, table, tonight]; one-hot classes [spam, ham].
     const inputs = new ml.Matrix([[2, 1, 0, 0], [1, 2, 0, 0], [0, 0, 2, 1], [0, 0, 1, 2]]);

--- a/package.json
+++ b/package.json
@@ -82,7 +82,11 @@
     "epsilon-greedy",
     "ucb",
     "contextual bandit",
-    "linucb"
+    "linucb",
+    "q-learning",
+    "markov decision process",
+    "temporal difference",
+    "gridworld"
   ],
   "author": "Erik Gerrits <gerrits.erik@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-learning",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "TypeScript & JavaScript machine learning library",
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index",

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -35,6 +35,7 @@ const RNNTutorial = lazy(() => import('./content/rnn.mdx'));
 const TransformerTutorial = lazy(() => import('./content/transformer.mdx'));
 const BanditsTutorial = lazy(() => import('./content/bandits.mdx'));
 const ContextualBanditsTutorial = lazy(() => import('./content/contextual-bandits.mdx'));
+const QLearningTutorial = lazy(() => import('./content/q-learning.mdx'));
 
 export function App() {
     return (
@@ -254,6 +255,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <ContextualBanditsTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="q-learning"
+                    element={
+                        <TutorialPage>
+                            <QLearningTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -266,4 +266,13 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         chapter: 25,
         part: PART_5,
     },
+    {
+        id: 'q-learning',
+        path: '/q-learning',
+        title: 'MDPs & Q-Learning',
+        tagline: 'Actions with delayed consequences — learn a route home as value flows backward.',
+        status: 'live',
+        chapter: 26,
+        part: PART_5,
+    },
 ];

--- a/site/src/components/QLearningPlayground.module.css
+++ b/site/src/components/QLearningPlayground.module.css
@@ -1,0 +1,79 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 460px) minmax(240px, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.gridWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 1 / 1;
+    background: #0b1120;
+}
+
+.grid {
+    width: 100%;
+    height: 100%;
+}
+
+.legend {
+    position: absolute;
+    bottom: 10px;
+    left: 12px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 12px;
+    font-size: 12px;
+    color: var(--muted);
+    background: rgba(11, 17, 32, 0.66);
+    padding: 5px 10px;
+    border-radius: 12px;
+    backdrop-filter: blur(4px);
+}
+
+.legend span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.legend i {
+    width: 11px;
+    height: 11px;
+    border-radius: 3px;
+    display: inline-block;
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/QLearningPlayground.tsx
+++ b/site/src/components/QLearningPlayground.tsx
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { QLearning } from 'machine-learning';
+import { GRIDWORLD_MAPS, makeGridworld, type Gridworld } from '../ml/gridworldDatasets';
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+import { drawGridworld } from '../viz/gridworld';
+import { Card, Checkbox, ControlPanel, Hint, Metric, MetricsRow, NumberField, RunControls, Select, Slider } from './controls/Controls';
+import styles from './QLearningPlayground.module.css';
+
+const STEPS_PER_FRAME = 6; // environment steps per animation frame — enough to learn in a few seconds
+const MAX_EPISODE_STEPS = 80;
+
+export function QLearningPlayground() {
+    const [mapId, setMapId] = useState(GRIDWORLD_MAPS[0].id);
+    const [alphaSlider, setAlphaSlider] = useState(40); // α = slider / 100
+    const [gammaSlider, setGammaSlider] = useState(95); // γ = slider / 100
+    const [epsilonSlider, setEpsilonSlider] = useState(20); // ε = slider / 100
+    const [seed, setSeed] = useState(0);
+    const [showPolicy, setShowPolicy] = useState(true);
+    const [showValues, setShowValues] = useState(true);
+    const [running, setRunning] = useState(false);
+    const [metrics, setMetrics] = useState({ episodes: 0, lastReturn: 0, lastSteps: 0, success: 0 });
+
+    const alpha = alphaSlider / 100;
+    const gamma = gammaSlider / 100;
+    const epsilon = epsilonSlider / 100;
+
+    const agentRef = useRef<QLearning | null>(null);
+    const envRef = useRef<Gridworld | null>(null);
+    const stateRef = useRef(0);
+    const epReturnRef = useRef(0);
+    const epStepsRef = useRef(0);
+    const episodesRef = useRef(0);
+    const recentRef = useRef<number[]>([]); // 1 = reached goal, 0 = fell in / timed out
+    const frameRef = useRef(0);
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const draw = useCallback(() => {
+        const agent = agentRef.current;
+        const env = envRef.current;
+        const canvas = canvasRef.current;
+        if (!agent || !env || !canvas) return;
+        const states = Array.from({ length: env.numberOfStates }, (_, s) => s);
+        drawGridworld(canvas, {
+            rows: env.rows,
+            cols: env.cols,
+            cellTypes: env.cellTypes,
+            values: states.map(s => agent.getValue(s)),
+            policy: agent.getPolicy(),
+            agent: stateRef.current,
+            showPolicy,
+            showValues,
+        });
+    }, [showPolicy, showValues]);
+
+    const rebuild = useCallback(() => {
+        const map = GRIDWORLD_MAPS.find(m => m.id === mapId) ?? GRIDWORLD_MAPS[0];
+        const env = makeGridworld(map);
+        const agent = new QLearning()
+            .setNumberOfStates(env.numberOfStates)
+            .setNumberOfActions(env.numberOfActions)
+            .setLearningRate(alpha)
+            .setDiscountFactor(gamma)
+            .setEpsilon(epsilon)
+            .setSeed(seed);
+
+        agentRef.current = agent;
+        envRef.current = env;
+        stateRef.current = env.start;
+        epReturnRef.current = 0;
+        epStepsRef.current = 0;
+        episodesRef.current = 0;
+        recentRef.current = [];
+        frameRef.current = 0;
+
+        setMetrics({ episodes: 0, lastReturn: 0, lastSteps: 0, success: 0 });
+        setRunning(false);
+        draw();
+    }, [mapId, alpha, gamma, epsilon, seed, draw]);
+
+    useEffect(() => {
+        rebuild();
+    }, [rebuild]);
+
+    const step = useCallback(() => {
+        const agent = agentRef.current;
+        const env = envRef.current;
+        if (!agent || !env) return;
+
+        for (let i = 0; i < STEPS_PER_FRAME; i++) {
+            const state = stateRef.current;
+            const action = agent.selectAction(state);
+            const { nextState, reward, done } = env.step(state, action);
+            agent.update(state, action, reward, nextState, done);
+            epReturnRef.current += reward;
+            epStepsRef.current += 1;
+
+            if (done || epStepsRef.current >= MAX_EPISODE_STEPS) {
+                const reachedGoal = env.cellTypes[nextState] === 'goal' ? 1 : 0;
+                recentRef.current.push(reachedGoal);
+                if (recentRef.current.length > 50) recentRef.current.shift();
+                episodesRef.current += 1;
+                setMetrics({
+                    episodes: episodesRef.current,
+                    lastReturn: Math.round(epReturnRef.current * 100) / 100,
+                    lastSteps: epStepsRef.current,
+                    success: Math.round((recentRef.current.reduce((a, b) => a + b, 0) / recentRef.current.length) * 100),
+                });
+                stateRef.current = env.start;
+                epReturnRef.current = 0;
+                epStepsRef.current = 0;
+            } else {
+                stateRef.current = nextState;
+            }
+        }
+
+        draw();
+        frameRef.current += 1;
+    }, [draw]);
+
+    useAnimationFrame(step, running);
+
+    const handleStep = () => {
+        if (!running) step();
+    };
+    const handleReset = () => {
+        setRunning(false);
+        rebuild();
+    };
+
+    const map = GRIDWORLD_MAPS.find(m => m.id === mapId);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <RunControls
+                    running={running}
+                    onToggle={() => setRunning(r => !r)}
+                    onStep={handleStep}
+                    onReset={handleReset}
+                />
+                <Select
+                    label="Floor plan"
+                    value={mapId}
+                    options={GRIDWORLD_MAPS.map(m => ({ value: m.id, label: m.label }))}
+                    onChange={setMapId}
+                />
+                {map && <Hint>{map.blurb}</Hint>}
+                <Slider label="Learning rate α" value={alphaSlider} display={alpha.toFixed(2)} min={5} max={100} onChange={setAlphaSlider} />
+                <Slider label="Discount γ" value={gammaSlider} display={gamma.toFixed(2)} min={50} max={99} onChange={setGammaSlider} />
+                <Slider label="Explore rate ε" value={epsilonSlider} display={epsilon.toFixed(2)} min={0} max={60} onChange={setEpsilonSlider} />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+                <Checkbox label="Value heatmap" checked={showValues} onChange={setShowValues} />
+                <Checkbox label="Policy arrows" checked={showPolicy} onChange={setShowPolicy} />
+                <Hint>Hit Train and watch value spread out from the table (★) while the arrows lock into a route. The yellow dot is the runner, still exploring.</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.gridWrap}>
+                    <canvas ref={canvasRef} className={styles.grid} />
+                    <div className={styles.legend}>
+                        <span><i style={{ background: '#38bdf8' }} /> kitchen</span>
+                        <span><i style={{ background: '#34d399' }} /> table</span>
+                        <span><i style={{ background: '#f43f5e' }} /> spill</span>
+                        <span><i style={{ background: '#facc15', borderRadius: '50%' }} /> runner</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Episodes" value={String(metrics.episodes)} />
+                        <Metric label="Success" value={`${metrics.success}%`} />
+                    </MetricsRow>
+                    <MetricsRow>
+                        <Metric label="Last return" value={metrics.lastReturn.toFixed(2)} />
+                        <Metric label="Last steps" value={String(metrics.lastSteps)} />
+                    </MetricsRow>
+
+                    <Card title="Value, flowing backward" subtitle="the heatmap">
+                        <p className={styles.note}>
+                            Each cell&apos;s colour is its value <strong>V(s) = maxₐ Q(s, a)</strong> — the best
+                            long-run reward reachable from there. Only the table pays off, so early on the floor
+                            is dark; with each visit the goal&apos;s value seeps one cell further out, until a
+                            warm gradient points the whole floor home.
+                        </p>
+                    </Card>
+
+                    <Card title="The policy" subtitle="the arrows">
+                        <p className={styles.note}>
+                            Each arrow is the greedy action — the runner&apos;s learned move in that cell. Watch
+                            them swing into a coherent route as the values settle. On <em>Cliff walk</em>, the
+                            arrows deliberately steer up and over the spills; on <em>The back room</em>, the far
+                            room stays dark and arrow-less until value finally reaches it through the doorway.
+                        </p>
+                    </Card>
+
+                    <Card title="Explore vs. exploit" subtitle="ε and γ">
+                        <p className={styles.note}>
+                            <strong>ε</strong> is how often the runner wanders off-policy to discover new routes —
+                            needed early, a nuisance once it knows the way. <strong>γ</strong> sets how far ahead
+                            it plans: near 1 it values the distant table almost as much as a step saved now; turn
+                            it down and far cells fade, the runner growing short-sighted.
+                        </p>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/content/q-learning.mdx
+++ b/site/src/content/q-learning.mdx
@@ -1,0 +1,109 @@
+import { QLearningPlayground } from '../components/QLearningPlayground';
+
+# Chapter 26 — When choices echo
+
+> *Markov decision processes & Q-learning.* The bandits chose, got a reward, and forgot — every turn
+> stood alone. But most real decisions **echo**: where you step now changes where you are next, and the
+> payoff might be a dozen moves away. This is the leap to reinforcement learning proper — learning to
+> act when consequences are *delayed*.
+
+The café is busy and Nadia's runner is carrying a tray from the kitchen to a table across a crowded
+floor. There's a spill in the middle. No single step is "right" or "wrong" on its own — the goal is to
+get the whole tray home quickly without disaster. A step left now only makes sense because of where it
+leaves you three steps from now. The bandit's question — *which arm pays best right now?* — can't even
+be asked here.
+
+## The wall: the reward comes later, so who gets the credit?
+
+Every model so far learned from an immediate signal: the right answer, the sale, the reward for *this*
+choice. But the table only pays off at the very end. The hundred little steps that led there got no
+reward at all — yet some of them were good (toward the goal) and some were wasteful (into a wall, near
+the spill). When the payoff finally lands, **which earlier moves deserve the credit?** That's the
+*temporal credit-assignment* problem, and it's exactly what a one-shot learner has no machinery for.
+
+## The idea: states, value, and the Bellman backup
+
+Frame the floor as a **Markov decision process**: a set of **states** (the runner's cell), **actions**
+(up/right/down/left), a **reward** for each step, and a rule that moves you to the next state. We want a
+**policy** — an action for every state — that maximises the *total* reward collected over a whole trip,
+not just the next step. Future rewards are discounted by **γ** per step, so sooner is worth more than
+later.
+
+The trick is to learn a number for every move: **Q(s, a)** — the total long-run reward of taking action
+`a` in state `s`, then acting well after. If you had it, the policy is trivial: in each state pick the
+action with the biggest Q. Q-learning builds it from raw experience with one update per step:
+
+$$
+Q(s, a) \;\leftarrow\; Q(s, a) \;+\; \alpha \big[\, \underbrace{r + \gamma \max_{a'} Q(s', a')}_{\text{a fresher estimate}} \;-\; Q(s, a) \,\big]
+$$
+
+That bracket is the **temporal-difference error** — the gap between the old guess and a better one: the
+reward we just saw plus the value of the best move available where we landed. Bootstrapping off the
+*next* state's value is the magic: it lets the goal's reward seep **one cell backward per visit**, until
+value fills the whole floor and the arrows point home.
+
+Press **Train** and watch exactly that — the heatmap glowing outward from the table (★), the policy
+arrows snapping into a route, the runner (yellow dot) still exploring as it learns:
+
+<div className="breakout">
+  <QLearningPlayground />
+</div>
+
+## How it works: one line of backup, looped over experience
+
+The agent keeps a table `Q[state][action]`, all zeros to start, and refines it transition by
+transition — the whole of Q-learning, straight from the
+[`QLearning`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/reinforcement/QLearning.ts)
+source:
+
+```ts
+// update(state, action, reward, nextState, done)
+const futureValue = done ? 0 : this.q[nextState][argmax(this.q[nextState])]; // value of where we landed
+const target = reward + this.discountFactor * futureValue;                   // r + γ·maxₐ′ Q(s′,a′)
+this.q[state][action] += this.learningRate * (target - this.q[state][action]); // step toward the target
+```
+
+Actions are chosen **ε-greedily** — mostly the current best, but a slice of the time a random move, so
+the runner keeps discovering routes it would otherwise never try:
+
+```ts
+if (this.random() < this.epsilon) return Math.floor(this.random() * this.numberOfActions); // explore
+return this.bestAction(state);                                                              // exploit
+```
+
+Two properties make this work without a map of the world. It's **model-free** — it never needs to know
+the transition rules in advance, only to *experience* them. And it's **off-policy** — that `max` means
+it learns the value of the *optimal* greedy policy even while it's busy exploring with random steps. The
+`done` flag matters: on the step that reaches the table there is no "after", so the future term is
+dropped and `Q` there equals the raw reward — the anchor everything else discounts back from.
+
+## Try it yourself
+
+- **Café floor.** The cleanest view of value propagating: start with a dark floor and watch a warm
+  gradient bloom out from the table, every arrow eventually pointing along a shortest safe route.
+- **Cliff walk.** The direct path home hugs a row of spills. Watch the runner learn to climb up and
+  over instead — the arrows lifting *away* from the edge even though it's the long way.
+- **The back room.** A wall splits the floor with one doorway. The far room stays dark and confused
+  until value finally threads back through the gap — a vivid picture of credit travelling cell by cell.
+- **Discount γ.** Drop it toward 0.5 and the runner turns short-sighted: distant cells fade to nothing
+  and it can dither, unable to "see" the table from far away. Push it near 0.99 and far-off value stays
+  vivid. **ε** trades the same way over time — vital early, then just noise once the route is known.
+
+> **Field note — a table only gets you so far.** Q-learning here stores one number per (state, action).
+> That's perfect for a café floor with a few dozen cells, but the table's size is the *whole* state
+> space — and for real problems (every arrangement of a warehouse, every pixel-frame of a game) it
+> explodes past any memory. The fix is to stop storing Q and start *predicting* it with a function — a
+> neural network that generalises across similar states. That's **deep reinforcement learning**.
+
+## What broke — nothing; the café learned to plan
+
+Nothing broke. For the first time a model reasons across *time*: it took an action whose reward arrived
+only much later, and figured out which choices deserved the credit. The same machinery that routed a
+tray across the floor is, in spirit, what learns to restock a shelf, price a season, or play a game —
+anywhere a decision now reshapes the rewards later.
+
+But look back at that field note. Tabular Q-learning leans on one fragile assumption: that you can keep
+a slot for *every* state. The moment the world is too big to enumerate — a chain of cafés, each with
+its own stock, staff, and weather — the table can't be built, let alone filled. The way forward is to
+trade the table for a learned approximation, marrying the value ideas of this chapter to the neural
+networks of Part 4. That's the frontier the map (`docs/course-plan.md`) points to next.

--- a/site/src/ml/gridworldDatasets.ts
+++ b/site/src/ml/gridworldDatasets.ts
@@ -1,0 +1,124 @@
+// Grid-world maps for the Q-learning playground, plus a tiny environment that turns a map into the
+// (state, action) → (nextState, reward, done) transitions the agent learns from. Each map is drawn as
+// ASCII for readability:
+//   S = start (the kitchen)    G = goal (the table, +goalReward, ends the episode)
+//   X = hazard (a spill, hazardReward, ends the episode)    # = wall (can't enter; bumping it stays)
+//   . = open floor (each step costs stepReward, a small "hurry up" nudge)
+// State is row-major: state = row * cols + col. Actions: 0 up, 1 right, 2 down, 3 left.
+
+export interface GridworldMap {
+    id: string;
+    label: string;
+    blurb: string;
+    layout: string[];
+    stepReward: number;
+    goalReward: number;
+    hazardReward: number;
+}
+
+export type CellType = 'empty' | 'wall' | 'start' | 'goal' | 'hazard';
+
+export const GRIDWORLD_MAPS: GridworldMap[] = [
+    {
+        id: 'cafe-floor',
+        label: 'Café floor',
+        blurb: 'An open floor with a single spill. Watch the value heatmap glow outward from the table and the arrows all swing to point home.',
+        layout: [
+            '.....G',
+            '......',
+            '..X...',
+            '......',
+            'S.....',
+        ],
+        stepReward: -0.04,
+        goalReward: 1,
+        hazardReward: -1,
+    },
+    {
+        id: 'cliff-walk',
+        label: 'Cliff walk',
+        blurb: 'The short route home runs right along a row of spills. One slip ends the trip — so the runner learns to climb up and around rather than risk the edge.',
+        layout: [
+            '.......',
+            '.......',
+            '.......',
+            'SXXXXXG',
+        ],
+        stepReward: -0.04,
+        goalReward: 1,
+        hazardReward: -1,
+    },
+    {
+        id: 'back-room',
+        label: 'The back room',
+        blurb: 'A wall splits the floor in two with a single gap. The reward only makes sense once value has flowed back through that doorway — watch the far room stay dark until it does.',
+        layout: [
+            'S....',
+            '.....',
+            '###.#',
+            '.....',
+            '....G',
+        ],
+        stepReward: -0.04,
+        goalReward: 1,
+        hazardReward: -1,
+    },
+];
+
+const ACTION_DELTAS = [
+    [-1, 0], // 0 up
+    [0, 1],  // 1 right
+    [1, 0],  // 2 down
+    [0, -1], // 3 left
+];
+
+export interface Gridworld {
+    rows: number;
+    cols: number;
+    numberOfStates: number;
+    numberOfActions: number;
+    start: number;
+    cellTypes: CellType[];
+    step: (state: number, action: number) => { nextState: number; reward: number; done: boolean };
+    isTerminal: (state: number) => boolean;
+}
+
+const SYMBOL_TO_TYPE: Record<string, CellType> = {
+    '.': 'empty', '#': 'wall', 'S': 'start', 'G': 'goal', 'X': 'hazard',
+};
+
+/** Compile a map into a deterministic grid-world environment. */
+export function makeGridworld(map: GridworldMap): Gridworld {
+    const rows = map.layout.length;
+    const cols = map.layout[0].length;
+    const cellTypes: CellType[] = [];
+    let start = 0;
+
+    for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+            const type = SYMBOL_TO_TYPE[map.layout[r][c]] ?? 'empty';
+            cellTypes.push(type);
+            if (type === 'start') start = r * cols + c;
+        }
+    }
+
+    const isTerminal = (state: number) => cellTypes[state] === 'goal' || cellTypes[state] === 'hazard';
+
+    const step = (state: number, action: number) => {
+        const [dr, dc] = ACTION_DELTAS[action];
+        let row = Math.floor(state / cols) + dr;
+        let col = (state % cols) + dc;
+        let nextState = row * cols + col;
+
+        // Off the grid or into a wall → stay put (but still pay the step cost).
+        if (row < 0 || row >= rows || col < 0 || col >= cols || cellTypes[nextState] === 'wall') {
+            nextState = state;
+        }
+
+        if (cellTypes[nextState] === 'goal') return { nextState, reward: map.goalReward, done: true };
+        if (cellTypes[nextState] === 'hazard') return { nextState, reward: map.hazardReward, done: true };
+        return { nextState, reward: map.stepReward, done: false };
+    };
+
+    return { rows, cols, numberOfStates: rows * cols, numberOfActions: 4, start, cellTypes, step, isTerminal };
+}

--- a/site/src/viz/gridworld.ts
+++ b/site/src/viz/gridworld.ts
@@ -1,0 +1,119 @@
+import { fitCanvas } from './canvas';
+import type { CellType } from '../ml/gridworldDatasets';
+
+// Draws a grid world the way reinforcement-learning textbooks do: each open cell tinted by its learned
+// value V(s) (a heatmap that fills in from the goal outward as value propagates back), an arrow per
+// cell for the greedy action (the policy), and a dot for the runner's current position. Goal, spill
+// and wall cells get their own fixed colours.
+
+const ARROWS = ['↑', '→', '↓', '←'];
+
+export interface GridworldView {
+    rows: number;
+    cols: number;
+    cellTypes: CellType[];
+    values: number[];     // V(s) per state (max-Q); only meaningful for open cells
+    policy: number[];     // greedy action per state
+    agent: number;        // current state of the runner (-1 to hide)
+    showPolicy: boolean;
+    showValues: boolean;
+}
+
+export function drawGridworld(canvas: HTMLCanvasElement, view: GridworldView): void {
+    const { ctx, width, height } = fitCanvas(canvas);
+    ctx.fillStyle = '#0b1120';
+    ctx.fillRect(0, 0, width, height);
+
+    const pad = 10;
+    const cell = Math.floor(Math.min((width - pad * 2) / view.cols, (height - pad * 2) / view.rows));
+    const gridW = cell * view.cols;
+    const gridH = cell * view.rows;
+    const originX = (width - gridW) / 2;
+    const originY = (height - gridH) / 2;
+
+    // Value range across open cells, for normalising the heatmap.
+    let lo = Infinity;
+    let hi = -Infinity;
+    for (let s = 0; s < view.values.length; s++) {
+        if (view.cellTypes[s] === 'empty' || view.cellTypes[s] === 'start') {
+            lo = Math.min(lo, view.values[s]);
+            hi = Math.max(hi, view.values[s]);
+        }
+    }
+    const span = hi - lo > 1e-6 ? hi - lo : 1;
+
+    for (let s = 0; s < view.cellTypes.length; s++) {
+        const row = Math.floor(s / view.cols);
+        const col = s % view.cols;
+        const x = originX + col * cell;
+        const y = originY + row * cell;
+        const type = view.cellTypes[s];
+
+        // Cell fill.
+        if (type === 'wall') {
+            ctx.fillStyle = '#1e293b';
+        } else if (type === 'goal') {
+            ctx.fillStyle = '#34d399';
+        } else if (type === 'hazard') {
+            ctx.fillStyle = '#f43f5e';
+        } else if (view.showValues) {
+            ctx.fillStyle = valueColor((view.values[s] - lo) / span);
+        } else {
+            ctx.fillStyle = '#0f172a';
+        }
+        ctx.fillRect(x, y, cell, cell);
+
+        // Grid line.
+        ctx.strokeStyle = 'rgba(148, 163, 184, 0.18)';
+        ctx.lineWidth = 1;
+        ctx.strokeRect(x + 0.5, y + 0.5, cell, cell);
+
+        const cx = x + cell / 2;
+        const cy = y + cell / 2;
+
+        if (type === 'goal' || type === 'hazard') {
+            ctx.fillStyle = '#0b1120';
+            ctx.font = `${Math.round(cell * 0.4)}px system-ui, sans-serif`;
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.fillText(type === 'goal' ? '★' : '✕', cx, cy);
+        } else if (type !== 'wall' && view.showPolicy) {
+            // Greedy-action arrow.
+            ctx.fillStyle = 'rgba(226, 232, 240, 0.85)';
+            ctx.font = `${Math.round(cell * 0.42)}px system-ui, sans-serif`;
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.fillText(ARROWS[view.policy[s]], cx, cy);
+        }
+
+        if (type === 'start') {
+            ctx.strokeStyle = '#38bdf8';
+            ctx.lineWidth = 2;
+            ctx.strokeRect(x + 2, y + 2, cell - 4, cell - 4);
+        }
+    }
+
+    // The runner.
+    if (view.agent >= 0) {
+        const row = Math.floor(view.agent / view.cols);
+        const col = view.agent % view.cols;
+        ctx.fillStyle = '#facc15';
+        ctx.beginPath();
+        ctx.arc(originX + col * cell + cell / 2, originY + row * cell + cell / 2, cell * 0.2, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.strokeStyle = '#0b1120';
+        ctx.lineWidth = 2;
+        ctx.stroke();
+    }
+}
+
+// Low value → deep indigo, high value → warm amber: the classic "cold far from the goal, hot near it".
+function valueColor(t: number): string {
+    const u = Math.max(0, Math.min(1, t));
+    const lo: [number, number, number] = [30, 41, 89];   // indigo-ish
+    const hi: [number, number, number] = [251, 191, 36];  // amber-400
+    const r = Math.round(lo[0] + (hi[0] - lo[0]) * u);
+    const g = Math.round(lo[1] + (hi[1] - lo[1]) * u);
+    const b = Math.round(lo[2] + (hi[2] - lo[2]) * u);
+    return `rgb(${r}, ${g}, ${b})`;
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -23,6 +23,7 @@ export { default as NaiveBayes } from "./machine-learning/supervised/NaiveBayes"
 export { default as NearestNeighbors } from "./machine-learning/supervised/NearestNeighbors";
 export { default as PCA } from "./machine-learning/unsupervised/PCA";
 export { default as Perceptron } from "./machine-learning/supervised/Perceptron";
+export { default as QLearning } from "./machine-learning/reinforcement/QLearning";
 export { default as RandomForest } from "./machine-learning/supervised/RandomForest";
 export { default as RecurrentNeuralNetwork } from "./machine-learning/supervised/RecurrentNeuralNetwork";
 export { default as Recommender } from "./machine-learning/unsupervised/Recommender";

--- a/src/lib/machine-learning/reinforcement/QLearning.ts
+++ b/src/lib/machine-learning/reinforcement/QLearning.ts
@@ -1,0 +1,132 @@
+import mulberry32 from "../../math/random/mulberry32";
+
+/**
+ * **Tabular Q-learning** — the leap from bandits to full reinforcement learning. A bandit's reward
+ * depended only on the arm it pulled *now*; here actions have **delayed consequences**. The world is a
+ * **Markov decision process**: you're in a **state**, you take an **action**, you get a **reward** and
+ * land in a **new state**, and a choice now reshapes the rewards far down the line (a move toward the
+ * goal, a restock that empties tomorrow's shelf). The job is to learn a **policy** — which action to
+ * take in each state — that maximises the *total discounted reward* over time, not just the next step.
+ *
+ * Q-learning estimates the **action-value** `Q(s, a)`: the long-run reward of taking action `a` in
+ * state `s` and then acting well thereafter. It keeps a table of these and refines it from raw
+ * experience with one update per transition — the **temporal-difference** rule:
+ *
+ * ```
+ * Q(s, a) ← Q(s, a) + α · [ r + γ · maxₐ′ Q(s′, a′) − Q(s, a) ]
+ * ```
+ *
+ * The bracket is the **TD error**: the gap between what we thought `Q(s, a)` was and a fresher
+ * estimate — the reward we just saw plus the (discounted) value of the best move available in the
+ * state we landed in. Bootstrapping off `maxₐ′ Q(s′, a′)` is what carries value **backward** from
+ * rewards through the states that lead to them. `γ` (the **discount factor**) sets how much the future
+ * counts; `α` is the learning rate. It's **model-free** (no map of the world needed) and **off-policy**
+ * (it learns the optimal greedy policy even while exploring randomly).
+ *
+ * Like the bandits, it learns **online** — no `train(inputs, targets)`. You loop {@link selectAction}
+ * → step the environment → {@link update}. Seeded for reproducibility.
+ *
+ * @example
+ * const agent = new QLearning().setNumberOfStates(16).setNumberOfActions(4).setDiscountFactor(0.95);
+ * let state = env.start();
+ * for (let step = 0; step < 10000; step++) {
+ *   const action = agent.selectAction(state);
+ *   const { nextState, reward, done } = env.step(state, action);
+ *   agent.update(state, action, reward, nextState, done);
+ *   state = done ? env.start() : nextState;   // new episode when one ends
+ * }
+ * agent.getPolicy();                           // the learned best action for every state
+ */
+export default class QLearning {
+
+    private numberOfStates = 1;
+    private numberOfActions = 1;
+    private learningRate = 0.1;     // α — how far each update moves toward the new estimate
+    private discountFactor = 0.95;   // γ — how much future reward counts vs. immediate
+    private epsilon = 0.1;           // exploration rate for ε-greedy action selection
+    private seed = 0;
+
+    private q: number[][];           // q[state][action] — the action-value table
+    private random: () => number;
+
+    public constructor () {}
+
+    /** Choose an action in `state`: explore at random with probability ε, otherwise act greedily. */
+    public selectAction (state: number) {
+        this.ensureInitialized();
+        if (this.random() < this.epsilon) {
+            return Math.floor(this.random() * this.numberOfActions); // explore
+        }
+        return this.bestAction(state); // exploit the current best estimate
+    }
+
+    /** The greedy action in `state` — the learned policy's choice (no exploration). */
+    public bestAction (state: number) {
+        this.ensureInitialized();
+        return argmax(this.q[state]);
+    }
+
+    /**
+     * Fold one observed transition into the table via the temporal-difference rule. Pass `done = true`
+     * for a transition into a terminal state, so the future term is dropped (nothing comes after).
+     */
+    public update (state: number, action: number, reward: number, nextState: number, done = false) {
+        this.ensureInitialized();
+        const futureValue = done ? 0 : this.q[nextState][argmax(this.q[nextState])];
+        const target = reward + this.discountFactor * futureValue;
+        this.q[state][action] += this.learningRate * (target - this.q[state][action]);
+        return this;
+    }
+
+    public reset () {
+        this.q = undefined;
+        this.random = undefined;
+        return this;
+    }
+
+    /* Parameter setters */
+
+    public setNumberOfStates (numberOfStates: number) { this.numberOfStates = numberOfStates; return this; }
+    public setNumberOfActions (numberOfActions: number) { this.numberOfActions = numberOfActions; return this; }
+    public setLearningRate (learningRate: number) { this.learningRate = learningRate; return this; }
+    public setDiscountFactor (discountFactor: number) { this.discountFactor = discountFactor; return this; }
+    public setEpsilon (epsilon: number) { this.epsilon = epsilon; return this; }
+    public setSeed (seed: number) { this.seed = seed; return this; }
+
+    /* Parameter getters */
+
+    public getNumberOfStates () { return this.numberOfStates; }
+    public getNumberOfActions () { return this.numberOfActions; }
+    public getLearningRate () { return this.learningRate; }
+    public getDiscountFactor () { return this.discountFactor; }
+    public getEpsilon () { return this.epsilon; }
+    public getSeed () { return this.seed; }
+
+    /** Every action's Q-value in a state. */
+    public getQValues (state: number) { this.ensureInitialized(); return this.q[state].slice(); }
+    /** A single Q(state, action). */
+    public getQValue (state: number, action: number) { this.ensureInitialized(); return this.q[state][action]; }
+    /** A state's value V(s) = maxₐ Q(s, a) — how good it is to be there under the learned policy. */
+    public getValue (state: number) { this.ensureInitialized(); return this.q[state][argmax(this.q[state])]; }
+    /** The greedy policy: the best action for every state. */
+    public getPolicy () { this.ensureInitialized(); return this.q.map(row => argmax(row)); }
+
+    /* Private methods */
+
+    private ensureInitialized () {
+        if (this.q === undefined || this.q.length !== this.numberOfStates || this.q[0].length !== this.numberOfActions) {
+            this.q = Array.from({ length: this.numberOfStates }, () => new Array<number>(this.numberOfActions).fill(0));
+            this.random = mulberry32(this.seed);
+        }
+    }
+}
+
+function argmax (values: number[]) {
+    let best = 0;
+    for (let i = 1; i < values.length; i++) {
+        if (values[i] > values[best]) {
+            best = i;
+        }
+    }
+    return best;
+}

--- a/src/test/QLearning.test.ts
+++ b/src/test/QLearning.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import QLearning from '../lib/machine-learning/reinforcement/QLearning';
+
+// ── A 5-state corridor: 0 1 2 3 [4=goal]. Action 0 = left, 1 = right. Reaching state 4 pays +1 and
+// ends the episode; every other step pays 0. The only optimal move anywhere is "right", and the value
+// of each state should be the goal reward discounted by how many steps away it is: γ^(distance−1).
+function corridorStep(state: number, action: number) {
+    const nextState = action === 1 ? Math.min(state + 1, 4) : Math.max(state - 1, 0);
+    const done = nextState === 4;
+    return { nextState, reward: done ? 1 : 0, done };
+}
+
+// ── A 3×3 grid (row-major state = row*3 + col):
+//   . . G        start at bottom-left (6), goal at top-right (2), a hazard in the middle (4).
+//   . # .        Actions: 0 up, 1 right, 2 down, 3 left. Stepping off-grid stays put. Reaching the
+//   S . .        goal pays +1 (done), the hazard −1 (done), any other step −0.04.
+const GRID_COLS = 3;
+const GOAL = 2;
+const HAZARD = 4;
+function gridStep(state: number, action: number) {
+    let row = Math.floor(state / GRID_COLS);
+    let col = state % GRID_COLS;
+    if (action === 0) row -= 1;
+    else if (action === 1) col += 1;
+    else if (action === 2) row += 1;
+    else col -= 1;
+    if (row < 0 || row > 2 || col < 0 || col > 2) { row = Math.floor(state / GRID_COLS); col = state % GRID_COLS; }
+    const nextState = row * GRID_COLS + col;
+    if (nextState === GOAL) return { nextState, reward: 1, done: true };
+    if (nextState === HAZARD) return { nextState, reward: -1, done: true };
+    return { nextState, reward: -0.04, done: false };
+}
+
+function train(agent: QLearning, step: (s: number, a: number) => { nextState: number; reward: number; done: boolean }, start: number, episodes: number, maxSteps = 50) {
+    for (let e = 0; e < episodes; e++) {
+        let state = start;
+        for (let t = 0; t < maxSteps; t++) {
+            const action = agent.selectAction(state);
+            const { nextState, reward, done } = step(state, action);
+            agent.update(state, action, reward, nextState, done);
+            if (done) break;
+            state = nextState;
+        }
+    }
+}
+
+describe('QLearning', () => {
+
+    it('learns to walk toward the goal and values states by discounted distance', () => {
+        const agent = new QLearning().setNumberOfStates(5).setNumberOfActions(2)
+            .setLearningRate(0.5).setDiscountFactor(0.9).setEpsilon(0.2).setSeed(0);
+        train(agent, corridorStep, 0, 3000);
+
+        // Optimal policy: go right from every non-goal state.
+        expect(agent.bestAction(0)).toBe(1);
+        expect(agent.bestAction(3)).toBe(1);
+
+        // Values fall off as γ^(distance−1): one step away ≈ 1, then 0.9, 0.81, 0.729.
+        expect(agent.getValue(3)).toBeCloseTo(1, 1);
+        expect(agent.getValue(2)).toBeCloseTo(0.9, 1);
+        expect(agent.getValue(1)).toBeCloseTo(0.81, 1);
+        expect(agent.getValue(0)).toBeCloseTo(0.729, 1);
+    });
+
+    it('finds a path through a grid that reaches the goal and avoids the hazard', () => {
+        const agent = new QLearning().setNumberOfStates(9).setNumberOfActions(4)
+            .setLearningRate(0.4).setDiscountFactor(0.95).setEpsilon(0.2).setSeed(1);
+        train(agent, gridStep, 6, 4000);
+
+        // Follow the learned greedy policy from the start; it should march to the goal, never the hazard.
+        let state = 6;
+        const visited = [state];
+        for (let t = 0; t < 12 && state !== GOAL; t++) {
+            state = gridStep(state, agent.bestAction(state)).nextState;
+            visited.push(state);
+        }
+        expect(state).toBe(GOAL);
+        expect(visited).not.toContain(HAZARD);
+    });
+
+    it('drops the future term on terminal transitions', () => {
+        // Give state 1 a big value, then feed state 0 → state 1 transitions that are flagged terminal.
+        // A terminal update must NOT bootstrap off state 1's value, so Q(0,0) should settle at the
+        // reward (1), not reward + γ·V(1).
+        const terminal = new QLearning().setNumberOfStates(2).setNumberOfActions(1).setLearningRate(0.5).setDiscountFactor(0.9);
+        for (let i = 0; i < 50; i++) terminal.update(1, 0, 5, 1, true);   // V(1) ≈ 5
+        for (let i = 0; i < 50; i++) terminal.update(0, 0, 1, 1, true);   // terminal: ignore V(1)
+        expect(terminal.getQValue(0, 0)).toBeCloseTo(1, 5);
+
+        // The same transitions treated as non-terminal DO bootstrap → reward + γ·5 = 5.5.
+        const bootstrap = new QLearning().setNumberOfStates(2).setNumberOfActions(1).setLearningRate(0.5).setDiscountFactor(0.9);
+        for (let i = 0; i < 50; i++) bootstrap.update(1, 0, 5, 1, true);
+        for (let i = 0; i < 80; i++) bootstrap.update(0, 0, 1, 1, false);
+        expect(bootstrap.getQValue(0, 0)).toBeCloseTo(5.5, 1);
+    });
+
+    it('is deterministic for a fixed seed', () => {
+        const run = () => {
+            const agent = new QLearning().setNumberOfStates(5).setNumberOfActions(2).setEpsilon(0.3).setSeed(4);
+            train(agent, corridorStep, 0, 200);
+            return agent.getPolicy().concat(agent.getQValues(2));
+        };
+        expect(run()).toEqual(run());
+    });
+
+    it('round-trips its hyperparameters and chains setters', () => {
+        const agent = new QLearning();
+        expect(agent.getDiscountFactor()).toBe(0.95);
+
+        const returned = agent.setNumberOfStates(20).setNumberOfActions(4).setLearningRate(0.2).setDiscountFactor(0.8).setEpsilon(0.05).setSeed(6);
+        expect(returned).toBe(agent);
+        expect(agent.getNumberOfStates()).toBe(20);
+        expect(agent.getNumberOfActions()).toBe(4);
+        expect(agent.getLearningRate()).toBe(0.2);
+        expect(agent.getDiscountFactor()).toBe(0.8);
+        expect(agent.getEpsilon()).toBe(0.05);
+        expect(agent.getSeed()).toBe(6);
+    });
+});


### PR DESCRIPTION
Chapter 26 — **MDPs & Q-Learning**, the conceptual leap of **Part 5 · Learning by doing**: actions now have *delayed* consequences, so the agent reasons about **states over time** rather than one-shot rewards.

## Library
- `QLearning` (in `src/lib/machine-learning/reinforcement/`): tabular, model-free, off-policy TD control. `selectAction(state)` (ε-greedy) → `update(state, action, reward, nextState, done)` applying the Bellman backup `Q ← Q + α[r + γ·maxₐ′Q(s′,a′) − Q]`. Plus `bestAction`, `getValue`, `getPolicy`, `getQValues`. Seeded, chainable.
- 5 tests: corridor values converge to the exact `γ^distance`; grid world reaches the goal and avoids the hazard; terminal transitions drop the bootstrap term; determinism; setter round-trip. (189 total pass.)
- Demo block (prints the learned policy as arrows), README section + keywords.

## Site
- `ml/gridworldDatasets.ts` — three maps (Café floor / Cliff walk / The back room) + a `makeGridworld` environment.
- `viz/gridworld.ts` — value heatmap that fills in from the goal, greedy-policy arrows, the runner as a moving dot.
- `QLearningPlayground.tsx` + MDX tutorial (`content/q-learning.mdx`), registered as Ch 26.
- `docs/course-plan.md` flipped Ch 26 ✅.

## Release
- Version bumped 0.12.0 → **0.13.0** (minor bump per new-algorithm batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)