### PR TITLE
Release 0.14.0: Deep RL / DQN (Chapter 27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Below are some simple code usage examples.
 * [Multi-Armed Bandit (reinforcement learning)](#multi-armed-bandit-reinforcement-learning)
 * [Contextual Bandit (LinUCB)](#contextual-bandit-linucb)
 * [Q-Learning (reinforcement learning)](#q-learning-reinforcement-learning)
+* [Deep Q-Network (DQN)](#deep-q-network-dqn)
 
 ### Feedforward Neural Network
 ```TypeScript
@@ -639,6 +640,53 @@ for (let r = 0; r < ROWS; r++) console.log(policy.slice(r * COLS, r * COLS + COL
 // → → → G   the learned policy: every cell points along a quickest safe route to the table,
 // ↑ # ↑ ↑   walking up the left edge then across the top, steering around the spill (#).
 // ↑ → ↑ ↑
+
+```
+
+### Deep Q-Network (DQN)
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// DQN: the same value idea as Q-learning, but the floor is now *continuous*. The runner's state is a
+// real position (x, y) — far too many states to tabulate — so a neural network learns to predict
+// Q(state) and generalises to spots it never stepped on. (Experience replay + a target network keep
+// the training stable.) Goal: reach the table near the top-right; every other step pays 0.
+const STEP = 0.12, GOAL: [number, number] = [0.85, 0.85], RADIUS = 0.18;
+const dist = (x: number, y: number) => Math.hypot(x - GOAL[0], y - GOAL[1]);
+const step = (s: number[], a: number) => {
+    const x = Math.min(1, Math.max(0, s[0] + (a === 1 ? STEP : a === 3 ? -STEP : 0)));
+    const y = Math.min(1, Math.max(0, s[1] + (a === 0 ? STEP : a === 2 ? -STEP : 0)));
+    return dist(x, y) < RADIUS ? { next: [x, y], reward: 1, done: true } : { next: [x, y], reward: 0, done: false };
+};
+
+const dqn = new ml.DeepQNetwork();
+dqn.setStateSize(2).setNumberOfActions(4).setHiddenSizes([24, 24]).setLearningRate(0.2).setDiscountFactor(0.9).setEpsilon(0.3).setSeed(1);
+
+let lcg = 3;
+const rng = () => (lcg = (lcg * 48271) % 2147483647) / 2147483647;
+for (let episode = 0; episode < 4000; episode++) {
+    let state = [rng(), rng()];                 // start anywhere, so the goal is found often
+    for (let t = 0; t < 60; t++) {
+        const action = dqn.selectAction(state);
+        const { next, reward, done } = step(state, action);
+        dqn.observe(state, action, reward, next, done); // remember + learn from a replayed minibatch
+        if (done) break;
+        state = next;
+    }
+}
+
+const shades = ['·', '░', '▒', '▓', '█'];        // sample the learned value V(x, y) over the floor
+for (let row = 4; row >= 0; row--) {
+    let line = '';
+    for (let col = 0; col < 5; col++) line += shades[Math.min(4, Math.floor(dqn.getValue([col / 4, row / 4]) * 5))] + ' ';
+    console.log(line);
+}
+// ▓ ▓ █ █ █   the value surface the network painted over the whole floor — brightest at the table
+// ▒ ▓ ▓ █ █   (top-right), fading with distance. The runner walks uphill (greedy on Q) all the way
+// ░ ▒ ▓ ▓ █   home — even from spots it never visited in training, because the network interpolates
+// ░ ░ ▒ ▓ █   between the ones it did. That generalisation is what a lookup table could never do.
+// ░ ░ ░ ▒ ▓
 
 ```
 

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -26,20 +26,20 @@ generative). The built algorithms become the spine; everything else is roadmap.
 
 **Goal:** engaging, fun, genuinely educational, and very cool.
 
-**Status (this release).** Woven through **Ch 0–25** with no built-but-unwoven gaps: all of Part 1,
+**Status (this release).** Woven through **Ch 0–27** with no built-but-unwoven gaps: all of Part 1,
 the whole of Part 2 (k‑NN, Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support
 Vector Machines), all of Part 3 (k‑Means, Hierarchical Clustering, DBSCAN, PCA, Anomaly Detection,
 Association Rules, Recommender Systems), all of Part 4 — Time Series, the Perceptron interlude, Neural
-Networks, Convolutional Networks, Recurrent Networks, Transformers & Attention — and **Part 5
-(reinforcement learning)** now under way with **Ch 24 Multi-Armed Bandits** (the first model that
-*acts* rather than predicts — online select → reward → update, ε-greedy + UCB), **Ch 25 Contextual
-Bandits** (LinUCB: a per-arm ridge-regression model over the context, so the best offer depends on
-who's at the counter), and **Ch 26 MDPs & Q-Learning** (tabular, model-free, off-policy TD control —
-delayed consequences, the Bellman backup, taught through a café-floor grid world with a live value
-heatmap and policy arrows). **All three deep-learning frontier chapters (CNN, RNN, Transformer) became
-full trainable builds**, each gradient-checked, rather than the planned "adopts" explainers. Still
-roadmap: the close of the reinforcement-learning arc (Ch 27 deep RL), generative (Ch 28–29), and
-Bayesian (Ch 30). See the status column below.
+Networks, Convolutional Networks, Recurrent Networks, Transformers & Attention — and **all of Part 5
+(reinforcement learning)**: **Ch 24 Multi-Armed Bandits** (the first model that *acts* rather than
+predicts — online select → reward → update, ε-greedy + UCB), **Ch 25 Contextual Bandits** (LinUCB: a
+per-arm ridge-regression model over the context), **Ch 26 MDPs & Q-Learning** (tabular, model-free,
+off-policy TD control — delayed consequences and the Bellman backup, taught through a café-floor grid
+world), and **Ch 27 Deep RL** (a from-scratch **DQN** with experience replay and a target network,
+reusing the Chapter-20 neural network to approximate value over a *continuous* floor). **The deep-RL
+chapter, like the three deep-learning frontier chapters (CNN, RNN, Transformer), became a full
+trainable build** rather than the planned "adopts" explainer. Still roadmap: Part 6 — generative
+(Ch 28–29) and Bayesian (Ch 30). See the status column below.
 
 ---
 
@@ -191,7 +191,7 @@ Every row's "Wall" is the previous tool failing.
 | 24 | **Multi-Armed Bandits** | Which daily special sells best? | Static prediction never *acts* or learns from outcomes → **explore vs. exploit**; regret; ε-greedy/UCB (the gentle RL entry) | ✅ `MultiArmedBandit` (first reinforcement-learning chapter — online select/reward/update; ε-greedy + UCB) |
 | 25 | **Contextual Bandits** | Personalized offers per customer context | One best arm for everyone is too coarse → condition the choice on context | ✅ `ContextualBandit` (LinUCB + ε-greedy — per-arm ridge regression over the context, online) |
 | 26 | **MDPs & Q-Learning** | A restocking / pricing **policy** over time | Actions have *delayed* consequences → states, actions, rewards, value, Bellman, Q-learning | ✅ `QLearning` (tabular, model-free, off-policy TD control; taught via a café-floor grid world — value heatmap + policy arrows) |
-| 27 | **Deep RL (DQN / Policy Gradients)** | **Chain-scale** optimization where the state space explodes (many stores × SKUs × conditions) | *Tabular Q-learning's table is now impossibly large* → neural nets approximate value/policy. **NB: this is the weakest café hook** — keep it tied to chain-scale optimization, not a gimmicky "robot barista" | ○ (adopts) |
+| 27 | **Deep RL (DQN / Policy Gradients)** | **Chain-scale** optimization where the state space explodes (many stores × SKUs × conditions) | *Tabular Q-learning's table is now impossibly large* → neural nets approximate value/policy. **NB: this is the weakest café hook** — keep it tied to chain-scale optimization, not a gimmicky "robot barista" | ✅ `DeepQNetwork` (built from scratch — DQN with experience replay + target network, reusing `FeedforwardNeuralNetwork`; exceeded the "adopts" plan; taught via a *continuous* café floor) |
 
 ### Part 6 — The frontier (Season 5)
 | # | Chapter | Café problem | The Wall → The Idea | Status |

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -354,6 +354,51 @@ import * as ml from '../src/lib';
 }
 
 {
+    // Deep Q-network (DQN): the same value idea, but the floor is now *continuous*. The runner's state
+    // is a real position (x, y) in [0,1]², far too many states to tabulate — so a neural network learns
+    // to predict Q(state) and generalises to spots it never stepped on. Goal: reach the table near the
+    // top-right corner (+1, ends the trip); every other step pays 0, discounted by γ.
+    const STEP = 0.12, GOAL: [number, number] = [0.85, 0.85], RADIUS = 0.18;
+    const dist = (x: number, y: number) => Math.hypot(x - GOAL[0], y - GOAL[1]);
+    const step = (s: number[], a: number) => {
+        const x = Math.min(1, Math.max(0, s[0] + (a === 1 ? STEP : a === 3 ? -STEP : 0)));
+        const y = Math.min(1, Math.max(0, s[1] + (a === 0 ? STEP : a === 2 ? -STEP : 0)));
+        return dist(x, y) < RADIUS ? { next: [x, y], reward: 1, done: true } : { next: [x, y], reward: 0, done: false };
+    };
+
+    const dqn = new ml.DeepQNetwork().setStateSize(2).setNumberOfActions(4).setHiddenSizes([24, 24])
+        .setLearningRate(0.2).setDiscountFactor(0.9).setEpsilon(0.3).setSeed(1);
+    let lcg = 3;
+    const rng = () => (lcg = (lcg * 48271) % 2147483647) / 2147483647;
+    for (let episode = 0; episode < 4000; episode++) {
+        let state = [rng(), rng()]; // start anywhere on the floor, so the goal is found often
+        for (let t = 0; t < 60; t++) {
+            const action = dqn.selectAction(state);
+            const { next, reward, done } = step(state, action);
+            dqn.observe(state, action, reward, next, done);
+            if (done) break;
+            state = next;
+        }
+    }
+
+    // Sample the learned value V(x, y) on a coarse grid — high (▓) near the table, low (·) far away.
+    const shades = ['·', '░', '▒', '▓', '█'];
+    for (let row = 4; row >= 0; row--) {
+        let line = '';
+        for (let col = 0; col < 5; col++) {
+            const v = dqn.getValue([col / 4, row / 4]);
+            line += shades[Math.min(4, Math.floor(v * 5))] + ' ';
+        }
+        console.log(line);
+    }
+    // ▓ ▓ █ █ █     the value surface the network painted over the whole floor — brightest at the
+    // ▒ ▓ ▓ █ █     table (top-right) and fading with distance. The runner just walks uphill: in every
+    // ░ ▒ ▓ ▓ █     state it picks the action whose Q is highest, and that leads it home — even from
+    // ░ ░ ▒ ▓ █     spots it never actually visited while training, because the net interpolates
+    // ░ ░ ░ ▒ ▓     between the ones it did.
+}
+
+{
     // Naive Bayes (multinomial): classify messages by word counts.
     // Vocabulary [free, money, table, tonight]; one-hot classes [spam, ham].
     const inputs = new ml.Matrix([[2, 1, 0, 0], [1, 2, 0, 0], [0, 0, 2, 1], [0, 0, 1, 2]]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-learning",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "TypeScript & JavaScript machine learning library",
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,11 @@
     "q-learning",
     "markov decision process",
     "temporal difference",
-    "gridworld"
+    "gridworld",
+    "deep reinforcement learning",
+    "deep q-network",
+    "dqn",
+    "experience replay"
   ],
   "author": "Erik Gerrits <gerrits.erik@gmail.com>",
   "license": "MIT",

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -36,6 +36,7 @@ const TransformerTutorial = lazy(() => import('./content/transformer.mdx'));
 const BanditsTutorial = lazy(() => import('./content/bandits.mdx'));
 const ContextualBanditsTutorial = lazy(() => import('./content/contextual-bandits.mdx'));
 const QLearningTutorial = lazy(() => import('./content/q-learning.mdx'));
+const DeepRlTutorial = lazy(() => import('./content/deep-rl.mdx'));
 
 export function App() {
     return (
@@ -263,6 +264,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <QLearningTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="deep-rl"
+                    element={
+                        <TutorialPage>
+                            <DeepRlTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -275,4 +275,13 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         chapter: 26,
         part: PART_5,
     },
+    {
+        id: 'deep-rl',
+        path: '/deep-rl',
+        title: 'Deep RL (DQN)',
+        tagline: 'Too many states to tabulate — let a neural network predict value across a continuous floor.',
+        status: 'live',
+        chapter: 27,
+        part: PART_5,
+    },
 ];

--- a/site/src/components/DeepQNetworkPlayground.module.css
+++ b/site/src/components/DeepQNetworkPlayground.module.css
@@ -1,0 +1,79 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 460px) minmax(240px, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.gridWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 1 / 1;
+    background: #0b1120;
+}
+
+.grid {
+    width: 100%;
+    height: 100%;
+}
+
+.legend {
+    position: absolute;
+    bottom: 10px;
+    left: 12px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 12px;
+    font-size: 12px;
+    color: var(--muted);
+    background: rgba(11, 17, 32, 0.66);
+    padding: 5px 10px;
+    border-radius: 12px;
+    backdrop-filter: blur(4px);
+}
+
+.legend span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.legend i {
+    width: 11px;
+    height: 11px;
+    border-radius: 3px;
+    display: inline-block;
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/DeepQNetworkPlayground.tsx
+++ b/site/src/components/DeepQNetworkPlayground.tsx
@@ -1,0 +1,224 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { DeepQNetwork } from 'machine-learning';
+import { NAV_SCENARIOS, makeNavEnv, type NavEnv } from '../ml/navDatasets';
+import { mulberry32 } from '../ml/rng';
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+import { drawDeepRl } from '../viz/deepRl';
+import { Card, Checkbox, ControlPanel, Hint, Metric, MetricsRow, NumberField, RunControls, Select, Slider } from './controls/Controls';
+import styles from './DeepQNetworkPlayground.module.css';
+
+const STEPS_PER_FRAME = 12;
+const MAX_EPISODE_STEPS = 60;
+const HEAT_RES = 26;   // value-heatmap resolution
+const ARROW_RES = 9;   // policy-arrow resolution
+
+// Pre-tuned to learn reliably in a couple of minutes in the browser.
+const DEFAULT_LR = 20;   // /100
+const DEFAULT_GAMMA = 90; // /100
+const DEFAULT_EPS = 30;   // /100
+
+export function DeepQNetworkPlayground() {
+    const [scenarioId, setScenarioId] = useState(NAV_SCENARIOS[0].id);
+    const [lrSlider, setLrSlider] = useState(DEFAULT_LR);
+    const [gammaSlider, setGammaSlider] = useState(DEFAULT_GAMMA);
+    const [epsilonSlider, setEpsilonSlider] = useState(DEFAULT_EPS);
+    const [seed, setSeed] = useState(1);
+    const [showValues, setShowValues] = useState(true);
+    const [showPolicy, setShowPolicy] = useState(true);
+    const [running, setRunning] = useState(false);
+    const [metrics, setMetrics] = useState({ episodes: 0, success: 0, lastSteps: 0 });
+
+    const lr = lrSlider / 100;
+    const gamma = gammaSlider / 100;
+    const epsilon = epsilonSlider / 100;
+
+    // Fixed sample points for the heatmap and arrow grids (arena coords, y increasing upward).
+    const heatPoints = useMemo(() => {
+        const pts: number[][] = [];
+        for (let r = 0; r < HEAT_RES; r++) for (let c = 0; c < HEAT_RES; c++) pts.push([(c + 0.5) / HEAT_RES, (r + 0.5) / HEAT_RES]);
+        return pts;
+    }, []);
+    const arrowPoints = useMemo(() => {
+        const pts: number[][] = [];
+        for (let r = 0; r < ARROW_RES; r++) for (let c = 0; c < ARROW_RES; c++) pts.push([(c + 0.5) / ARROW_RES, (r + 0.5) / ARROW_RES]);
+        return pts;
+    }, []);
+
+    const dqnRef = useRef<DeepQNetwork | null>(null);
+    const envRef = useRef<NavEnv | null>(null);
+    const stateRef = useRef<number[]>([0, 0]);
+    const trailRef = useRef<number[][]>([]);
+    const epStepsRef = useRef(0);
+    const episodesRef = useRef(0);
+    const recentRef = useRef<number[]>([]);
+    const envRandomRef = useRef<() => number>(() => 0);
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const draw = useCallback(() => {
+        const dqn = dqnRef.current;
+        const env = envRef.current;
+        const canvas = canvasRef.current;
+        if (!dqn || !env || !canvas) return;
+        const heatValues = dqn.getQValuesBatch(heatPoints).map(q => Math.max(...q));
+        const arrowActions = dqn.getQValuesBatch(arrowPoints).map(q => q.indexOf(Math.max(...q)));
+        drawDeepRl(canvas, {
+            goal: env.goal,
+            radius: env.radius,
+            heatRes: HEAT_RES,
+            heatValues,
+            arrowRes: ARROW_RES,
+            arrowActions,
+            agent: stateRef.current,
+            trail: trailRef.current,
+            showValues,
+            showPolicy,
+        });
+    }, [heatPoints, arrowPoints, showValues, showPolicy]);
+
+    const rebuild = useCallback(() => {
+        const scenario = NAV_SCENARIOS.find(s => s.id === scenarioId) ?? NAV_SCENARIOS[0];
+        const env = makeNavEnv(scenario);
+        const dqn = new DeepQNetwork()
+            .setStateSize(2).setNumberOfActions(4).setHiddenSizes([24, 24])
+            .setLearningRate(lr).setDiscountFactor(gamma).setEpsilon(epsilon).setSeed(seed);
+
+        dqnRef.current = dqn;
+        envRef.current = env;
+        envRandomRef.current = mulberry32(seed + 101);
+        stateRef.current = env.randomStart(envRandomRef.current);
+        trailRef.current = [stateRef.current];
+        epStepsRef.current = 0;
+        episodesRef.current = 0;
+        recentRef.current = [];
+
+        setMetrics({ episodes: 0, success: 0, lastSteps: 0 });
+        setRunning(false);
+        draw();
+    }, [scenarioId, lr, gamma, epsilon, seed, draw]);
+
+    useEffect(() => {
+        rebuild();
+    }, [rebuild]);
+
+    const step = useCallback(() => {
+        const dqn = dqnRef.current;
+        const env = envRef.current;
+        if (!dqn || !env) return;
+
+        for (let i = 0; i < STEPS_PER_FRAME; i++) {
+            const state = stateRef.current;
+            const action = dqn.selectAction(state);
+            const { nextState, reward, done } = env.step(state, action);
+            dqn.observe(state, action, reward, nextState, done);
+            epStepsRef.current += 1;
+
+            const trail = trailRef.current;
+            trail.push(nextState);
+            if (trail.length > 40) trail.shift();
+
+            if (done || epStepsRef.current >= MAX_EPISODE_STEPS) {
+                recentRef.current.push(done ? 1 : 0); // only the goal is terminal → done means success
+                if (recentRef.current.length > 50) recentRef.current.shift();
+                episodesRef.current += 1;
+                setMetrics({
+                    episodes: episodesRef.current,
+                    success: Math.round((recentRef.current.reduce((a, b) => a + b, 0) / recentRef.current.length) * 100),
+                    lastSteps: epStepsRef.current,
+                });
+                stateRef.current = env.randomStart(envRandomRef.current);
+                trailRef.current = [stateRef.current];
+                epStepsRef.current = 0;
+            } else {
+                stateRef.current = nextState;
+            }
+        }
+
+        draw();
+    }, [draw]);
+
+    useAnimationFrame(step, running);
+
+    const handleStep = () => {
+        if (!running) step();
+    };
+    const handleReset = () => {
+        setRunning(false);
+        rebuild();
+    };
+
+    const scenario = NAV_SCENARIOS.find(s => s.id === scenarioId);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <RunControls
+                    running={running}
+                    onToggle={() => setRunning(r => !r)}
+                    onStep={handleStep}
+                    onReset={handleReset}
+                />
+                <Select
+                    label="Table"
+                    value={scenarioId}
+                    options={NAV_SCENARIOS.map(s => ({ value: s.id, label: s.label }))}
+                    onChange={setScenarioId}
+                />
+                {scenario && <Hint>{scenario.blurb}</Hint>}
+                <Slider label="Learning rate α" value={lrSlider} display={lr.toFixed(2)} min={5} max={40} onChange={setLrSlider} />
+                <Slider label="Discount γ" value={gammaSlider} display={gamma.toFixed(2)} min={50} max={98} onChange={setGammaSlider} />
+                <Slider label="Explore rate ε" value={epsilonSlider} display={epsilon.toFixed(2)} min={0} max={60} onChange={setEpsilonSlider} />
+                <NumberField label="Random seed" value={seed} onChange={setSeed} />
+                <Checkbox label="Value heatmap" checked={showValues} onChange={setShowValues} />
+                <Checkbox label="Policy arrows" checked={showPolicy} onChange={setShowPolicy} />
+                <Hint>Reinforcement learning is slow — give it a minute or two. The heatmap sharpens and the arrows lock onto the table as the network learns.</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.gridWrap}>
+                    <canvas ref={canvasRef} className={styles.grid} />
+                    <div className={styles.legend}>
+                        <span><i style={{ background: '#34d399' }} /> table</span>
+                        <span><i style={{ background: '#facc15', borderRadius: '50%' }} /> runner</span>
+                        <span><i style={{ background: 'linear-gradient(90deg,#1e2959,#fbbf24)' }} /> low→high value</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Episodes" value={String(metrics.episodes)} />
+                        <Metric label="Success" value={`${metrics.success}%`} />
+                        <Metric label="Last steps" value={String(metrics.lastSteps)} />
+                    </MetricsRow>
+
+                    <Card title="A function, not a table" subtitle="why this scales">
+                        <p className={styles.note}>
+                            Chapter 26 stored one value per cell. Here the floor is continuous — infinitely many
+                            states — so a neural network <strong>predicts</strong> V(s) instead. The smooth heatmap
+                            is that network evaluated everywhere at once, including spots the runner never stepped:
+                            it <em>generalises</em>. That&apos;s what lets RL scale past anything you could tabulate.
+                        </p>
+                    </Card>
+
+                    <Card title="Replay & a target net" subtitle="keeping it stable">
+                        <p className={styles.note}>
+                            Bootstrapping a network off its own shifting predictions is unstable, so DQN adds two
+                            fixes: an <strong>experience-replay</strong> buffer it learns from in random minibatches
+                            (breaking the correlation between consecutive steps), and a periodically-frozen
+                            <strong> target network</strong> to supply a steady learning target. Both are running
+                            under the hood here.
+                        </p>
+                    </Card>
+
+                    <Card title="Be patient" subtitle="and watch it form">
+                        <p className={styles.note}>
+                            Early on the surface is flat and noisy and the runner wanders. As reward from the table
+                            propagates back through the network, a clean gradient appears and the arrows snap into a
+                            field that points home from everywhere. Nudge <strong>γ</strong> down to watch the far
+                            floor go short-sighted, or drop <strong>ε</strong> once it knows the way.
+                        </p>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/content/deep-rl.mdx
+++ b/site/src/content/deep-rl.mdx
@@ -1,0 +1,114 @@
+import { DeepQNetworkPlayground } from '../components/DeepQNetworkPlayground';
+
+# Chapter 27 — Too big for a table
+
+> *Deep reinforcement learning (DQN).* Q-learning routed a tray across a floor by keeping a number for
+> every cell. But the moment the floor isn't tiled — a *continuous* position, or a whole chain of cafés
+> with their own stock and staff — there are too many states to ever list. The fix marries Part 4 to
+> Part 5: stop storing the value table and let a **neural network predict it**.
+
+The café is thriving, and Nadia is mapping out store #3. The same routing problem keeps coming back —
+move a tray, a delivery, a restock toward where it should be — but now she wants it to work on a real
+floor, where the runner's position is a smooth `(x, y)`, not one of nine tiles. And eventually across a
+*chain*, where the "state" is the stock and queue and weather of every store at once.
+
+## The wall: you can't tabulate a continuous world
+
+Chapter 26's Q-learning kept a slot `Q[state][action]` for every state. That only works because you
+can **list** the states — nine cells, sixteen, a few hundred. A continuous position has *infinitely
+many* states; a chain of stores has more joint states than atoms in the room. There's no table to
+build, and even if you discretised it finely, the runner would have to visit **every** cell to learn
+its value — it could never say anything sensible about a spot it hadn't already stood on. The lookup
+table can't generalise, and that's exactly what a big world demands.
+
+## The idea: approximate Q with a network
+
+So replace the table with a **function**. A neural network takes the state vector `(x, y)` and outputs
+a Q-value for each action. Now "learning Q" means *training the network* — and because a network
+interpolates, it gives sensible values for states between the ones it visited. It **generalises**. The
+target is the very same temporal-difference idea from Chapter 26, just used as a regression target the
+network is nudged toward:
+
+$$
+\text{target} \;=\; r + \gamma \max_{a'} Q(s', a';\, \theta^{-}), \qquad \text{minimise } \big(Q(s, a;\, \theta) - \text{target}\big)^2
+$$
+
+Bootstrapping a network off its own moving predictions is unstable, so **DQN** (DeepMind's Atari
+breakthrough) adds two stabilisers: an **experience-replay** buffer it trains on in random minibatches,
+and a periodically-frozen **target network** (`θ⁻`) that supplies a *steady* target instead of one that
+lurches every step.
+
+Below, the floor is continuous and the table (★) sits in a corner. Press **Train** and watch the
+network paint a value surface over the *whole* floor — including spots the runner never steps — while
+the arrows lock into a field that points home. Reinforcement learning is slow; give it a minute.
+
+<div className="breakout">
+  <DeepQNetworkPlayground />
+</div>
+
+## How it works: the table becomes a regression
+
+The agent stores each transition and learns from a **random minibatch** of past ones. For each sampled
+transition it builds a target vector — the network's current outputs, with only the *taken* action's
+entry overwritten by the TD target — then takes one gradient step toward it, straight from the
+[`DeepQNetwork`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/reinforcement/DeepQNetwork.ts)
+source:
+
+```ts
+const targets = this.online.predict(new Matrix(states)).toArray();   // start from current Q (untaken
+const nextQ = this.target.predict(new Matrix(nextStates)).toArray(); //  actions then get zero error)
+
+for (let i = 0; i < this.batchSize; i++) {
+    const t = batch[i];
+    const future = t.done ? 0 : nextQ[i][argmax(nextQ[i])];          // bootstrap off the *target* net
+    targets[i][t.action] = t.reward + this.discountFactor * future;  // r + γ·maxₐ′ Q⁻(s′,a′)
+}
+this.online.train(new Matrix(states), new Matrix(targets));          // one gradient step
+```
+
+Every so often the target network is re-frozen from the online one, so it tracks slowly:
+
+```ts
+if (this.learnSteps % this.targetSyncInterval === 0) {
+    this.target.setWeightMatrices(this.online.getWeightMatrices());
+}
+```
+
+The network reuses the exact [`FeedforwardNeuralNetwork`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/supervised/FeedforwardNeuralNetwork.ts)
+from Chapter 20 — Part 5's value ideas riding on Part 4's backprop. Its sigmoid output means values
+live in `(0, 1)`, so the reward is shaped to fit: `+1` at the table, `0` elsewhere, discounted by `γ`,
+which keeps every value in range while still rewarding shorter routes.
+
+## Try it yourself
+
+- **Watch the surface form.** Early on it's flat and noisy and the runner wanders aimlessly. Reward
+  from the table slowly seeps back through the network until a smooth gradient covers the floor and the
+  arrows point home from everywhere — the table you saw in Chapter 26, now *drawn by a function*.
+- **Generalisation, made visible.** The heatmap is coloured at far more points than the runner ever
+  visits — every one is the network *predicting* a value it was never directly taught. That smooth
+  fill-in is the whole reason DQN scales where a lookup table can't.
+- **Move the table.** Switch to *Window seat* or *Corner booth*: same runner, same network, a brand-new
+  value landscape learned from scratch.
+- **γ and ε.** Drop **γ** and the far floor goes dark — the runner turns short-sighted, unable to
+  value a table many steps away. Drop **ε** once it knows the route and the wandering stops.
+
+> **Field note — this is the small end of a vast field.** What you're watching is a faithful DQN, just
+> tiny: a two-input state, a few-dozen-neuron network, one floor. Scale the state to the pixels of a
+> screen and the network to millions of weights and the *same* loop learns to play Atari from raw
+> video. Swap "predict the value" for "predict the action directly" and you get **policy-gradient**
+> methods; combine the two and you get the actor-critic algorithms behind robotics and game-playing
+> agents — and, in spirit, the reinforcement-learning-from-feedback that tunes assistants like the one
+> that wrote this page.
+
+## What broke — nothing; and the café ran out of new algorithms to need
+
+Nothing broke — and that's the quiet milestone. From a shoebox of receipts in Chapter 0, the café has
+arrived at an agent that learns to act in a world too large to enumerate, by *predicting* value rather
+than memorising it. Every thread of Part 5 — bandits, contexts, states over time — comes together here:
+choose, observe, and improve, with a neural network carrying the weight.
+
+This closes the reinforcement-learning arc. What's left on the map (`docs/course-plan.md`) isn't about
+deciding better but about *seeing* differently: compressing data into its essence (autoencoders),
+*inventing* new data rather than labelling it (generative models), and putting honest numbers on doubt
+before a big bet (Bayesian methods). The café that started by guessing tomorrow's croissants now has a
+whole toolbox — and the frontier it's walking toward is the same one the rest of the field is.

--- a/site/src/ml/navDatasets.ts
+++ b/site/src/ml/navDatasets.ts
@@ -1,0 +1,80 @@
+// Scenarios for the deep-RL playground. Unlike Chapter 26's tiled grid, the floor here is *continuous*:
+// the runner's state is a real position (x, y) in [0,1]², so there's no table of cells to fill — a
+// neural network has to learn a value for the whole surface. The scenarios differ only in where the
+// table (the goal) sits, which gives each a distinct value landscape. Actions: 0 up, 1 right, 2 down,
+// 3 left (each a fixed step). Reaching within `radius` of the table pays +1 and ends the trip; every
+// other step pays 0, so discounting alone rewards shorter routes — and values stay in (0,1), which is
+// what the network's sigmoid output can represent.
+
+export interface NavScenario {
+    id: string;
+    label: string;
+    blurb: string;
+    goal: [number, number];
+    radius: number;
+    step: number;
+}
+
+export const NAV_SCENARIOS: NavScenario[] = [
+    {
+        id: 'far-table',
+        label: 'Corner table',
+        blurb: 'The table sits in the far corner. Watch the value surface bloom out from it across the whole floor and the arrows everywhere swing to point home.',
+        goal: [0.85, 0.85],
+        radius: 0.18,
+        step: 0.12,
+    },
+    {
+        id: 'window-seat',
+        label: 'Window seat',
+        blurb: 'The table moves to the middle of the top wall. Same runner, same network — a completely different value landscape learned from scratch.',
+        goal: [0.5, 0.9],
+        radius: 0.18,
+        step: 0.12,
+    },
+    {
+        id: 'corner-booth',
+        label: 'Corner booth',
+        blurb: 'A table low on the right. Notice the network gives sensible values for far-off spots it rarely visits — the generalisation a lookup table can’t.',
+        goal: [0.85, 0.15],
+        radius: 0.18,
+        step: 0.12,
+    },
+];
+
+const ACTION_DELTAS = [
+    [0, 1],  // 0 up    (+y)
+    [1, 0],  // 1 right (+x)
+    [0, -1], // 2 down  (−y)
+    [-1, 0], // 3 left  (−x)
+];
+
+export interface NavEnv {
+    stateSize: number;
+    numberOfActions: number;
+    goal: [number, number];
+    radius: number;
+    randomStart: (rand: () => number) => number[];
+    step: (state: number[], action: number) => { nextState: number[]; reward: number; done: boolean };
+}
+
+/** Compile a scenario into a continuous navigation environment. */
+export function makeNavEnv(scenario: NavScenario): NavEnv {
+    const { goal, radius, step } = scenario;
+    const dist = (x: number, y: number) => Math.hypot(x - goal[0], y - goal[1]);
+
+    return {
+        stateSize: 2,
+        numberOfActions: 4,
+        goal,
+        radius,
+        randomStart: (rand: () => number) => [rand(), rand()], // anywhere on the floor
+        step: (state: number[], action: number) => {
+            const [dx, dy] = ACTION_DELTAS[action];
+            const x = Math.min(1, Math.max(0, state[0] + dx * step)); // bumping a wall just clamps
+            const y = Math.min(1, Math.max(0, state[1] + dy * step));
+            if (dist(x, y) < radius) return { nextState: [x, y], reward: 1, done: true };
+            return { nextState: [x, y], reward: 0, done: false };
+        },
+    };
+}

--- a/site/src/viz/deepRl.ts
+++ b/site/src/viz/deepRl.ts
@@ -1,0 +1,111 @@
+import { fitCanvas } from './canvas';
+
+// Renders the continuous floor: a fine value heatmap the network paints over the whole arena (the
+// star of the chapter — a *function*, not a table, so it's defined at every point), a coarser field of
+// greedy-policy arrows, the table (goal disc), and the runner with a fading trail. The whole point is
+// that the heatmap is smooth and covers everywhere, including spots the runner never actually stepped.
+
+const ARROWS = ['↑', '→', '↓', '←'];
+
+export interface DeepRlView {
+    goal: [number, number];
+    radius: number;
+    heatRes: number;        // heatmap grid resolution (heatRes × heatRes)
+    heatValues: number[];   // V at each heat cell, row-major with y increasing upward
+    arrowRes: number;       // policy grid resolution
+    arrowActions: number[]; // greedy action at each arrow point, row-major with y increasing upward
+    agent: number[] | null; // runner position [x, y]
+    trail: number[][];      // recent positions
+    showValues: boolean;
+    showPolicy: boolean;
+}
+
+export function drawDeepRl(canvas: HTMLCanvasElement, view: DeepRlView): void {
+    const { ctx, width, height } = fitCanvas(canvas);
+    ctx.fillStyle = '#0b1120';
+    ctx.fillRect(0, 0, width, height);
+
+    const pad = 8;
+    const size = Math.min(width, height) - pad * 2;
+    const originX = (width - size) / 2;
+    const originY = (height - size) / 2;
+
+    // Arena coords (x right, y UP) → canvas pixels (y flipped so up is up).
+    const px = (x: number) => originX + x * size;
+    const py = (y: number) => originY + (1 - y) * size;
+
+    // Value heatmap.
+    if (view.showValues) {
+        let lo = Infinity;
+        let hi = -Infinity;
+        for (const v of view.heatValues) { lo = Math.min(lo, v); hi = Math.max(hi, v); }
+        const span = hi - lo > 1e-6 ? hi - lo : 1;
+        const cell = size / view.heatRes;
+        for (let r = 0; r < view.heatRes; r++) {
+            for (let c = 0; c < view.heatRes; c++) {
+                const v = view.heatValues[r * view.heatRes + c];
+                ctx.fillStyle = valueColor((v - lo) / span);
+                // Row 0 is the bottom (y = 0); flip to canvas rows.
+                ctx.fillRect(originX + c * cell, originY + (view.heatRes - 1 - r) * cell, cell + 1, cell + 1);
+            }
+        }
+    }
+
+    // Policy arrows.
+    if (view.showPolicy) {
+        ctx.fillStyle = 'rgba(226, 232, 240, 0.8)';
+        ctx.font = `${Math.round(size / view.arrowRes * 0.5)}px system-ui, sans-serif`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        for (let r = 0; r < view.arrowRes; r++) {
+            for (let c = 0; c < view.arrowRes; c++) {
+                const x = (c + 0.5) / view.arrowRes;
+                const y = (r + 0.5) / view.arrowRes;
+                ctx.fillText(ARROWS[view.arrowActions[r * view.arrowRes + c]], px(x), py(y));
+            }
+        }
+    }
+
+    // The table (goal).
+    ctx.beginPath();
+    ctx.arc(px(view.goal[0]), py(view.goal[1]), view.radius * size, 0, Math.PI * 2);
+    ctx.fillStyle = 'rgba(52, 211, 153, 0.35)';
+    ctx.fill();
+    ctx.strokeStyle = '#34d399';
+    ctx.lineWidth = 2;
+    ctx.stroke();
+    ctx.fillStyle = '#022c22';
+    ctx.font = `${Math.round(view.radius * size * 0.9)}px system-ui, sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('★', px(view.goal[0]), py(view.goal[1]));
+
+    // Trail.
+    if (view.trail.length > 1) {
+        ctx.strokeStyle = 'rgba(250, 204, 21, 0.45)';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(px(view.trail[0][0]), py(view.trail[0][1]));
+        for (let i = 1; i < view.trail.length; i++) ctx.lineTo(px(view.trail[i][0]), py(view.trail[i][1]));
+        ctx.stroke();
+    }
+
+    // The runner.
+    if (view.agent) {
+        ctx.beginPath();
+        ctx.arc(px(view.agent[0]), py(view.agent[1]), size * 0.018, 0, Math.PI * 2);
+        ctx.fillStyle = '#facc15';
+        ctx.fill();
+        ctx.strokeStyle = '#0b1120';
+        ctx.lineWidth = 2;
+        ctx.stroke();
+    }
+}
+
+// Low value → deep indigo, high → warm amber: cold far from the table, hot near it.
+function valueColor(t: number): string {
+    const u = Math.max(0, Math.min(1, t));
+    const lo: [number, number, number] = [30, 41, 89];
+    const hi: [number, number, number] = [251, 191, 36];
+    return `rgb(${Math.round(lo[0] + (hi[0] - lo[0]) * u)}, ${Math.round(lo[1] + (hi[1] - lo[1]) * u)}, ${Math.round(lo[2] + (hi[2] - lo[2]) * u)})`;
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -5,6 +5,7 @@ export { default as ContextualBandit } from "./machine-learning/reinforcement/Co
 export type { ContextualStrategy } from "./machine-learning/reinforcement/ContextualBandit";
 export { default as ConvolutionalNeuralNetwork } from "./machine-learning/supervised/ConvolutionalNeuralNetwork";
 export { default as DBSCAN } from "./machine-learning/unsupervised/DBSCAN";
+export { default as DeepQNetwork } from "./machine-learning/reinforcement/DeepQNetwork";
 export { default as DecisionTree } from "./machine-learning/supervised/DecisionTree";
 export type { DecisionTreeNode } from "./machine-learning/supervised/DecisionTree";
 export { default as ExponentialSmoothing } from "./machine-learning/time-series/ExponentialSmoothing";

--- a/src/lib/machine-learning/reinforcement/DeepQNetwork.ts
+++ b/src/lib/machine-learning/reinforcement/DeepQNetwork.ts
@@ -1,0 +1,208 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+import FeedforwardNeuralNetwork from "../supervised/FeedforwardNeuralNetwork";
+import mulberry32 from "../../math/random/mulberry32";
+
+interface Transition {
+    state: number[];
+    action: number;
+    reward: number;
+    nextState: number[];
+    done: boolean;
+}
+
+/**
+ * A **Deep Q-Network (DQN)** — the close of the reinforcement-learning arc, and the bridge back to
+ * the neural networks of Part 4. Tabular {@link QLearning} kept one number per (state, action), which
+ * only works when you can *enumerate* the states. The moment a state is a vector of real numbers — a
+ * position on a smooth floor, the stock levels across a chain of cafés — that table can't be built.
+ *
+ * DQN's fix: stop storing Q and start **predicting** it. A neural network maps a state vector to a
+ * Q-value for every action, so it **generalises** — it gives sensible values for states it has never
+ * visited, by interpolating from ones it has. It's the same value idea as Chapter 26, with a function
+ * approximator in place of the lookup table. Two tricks (from DeepMind's Atari work) keep the
+ * bootstrapping from spiralling:
+ *
+ * - **Experience replay** — every transition is stored in a buffer, and learning happens on *random
+ *   minibatches* drawn from it. This breaks the correlation between consecutive steps and lets each
+ *   experience teach more than once.
+ * - **A target network** — a periodically-frozen copy of the network supplies the `maxₐ′ Q(s′, a′)`
+ *   in the update target. Chasing a fixed target for a while, rather than one that shifts every step,
+ *   is far more stable.
+ *
+ * The network has a sigmoid output, so it represents values in `(0, 1)` — design rewards to stay in
+ * that range (e.g. `+1` at the goal, `0` elsewhere, discounted by `γ < 1`). Learns **online**: loop
+ * {@link selectAction} → step the world → {@link observe}. Seeded for reproducibility.
+ *
+ * @example
+ * const dqn = new DeepQNetwork().setStateSize(2).setNumberOfActions(4).setDiscountFactor(0.9);
+ * let state = env.start();
+ * for (let step = 0; step < 20000; step++) {
+ *   const action = dqn.selectAction(state);
+ *   const { nextState, reward, done } = env.step(state, action);
+ *   dqn.observe(state, action, reward, nextState, done);  // remember + learn from a minibatch
+ *   state = done ? env.start() : nextState;
+ * }
+ * dqn.getValue([0.5, 0.5]);   // the network's value for any state — even unseen ones
+ */
+export default class DeepQNetwork {
+
+    private stateSize = 2;
+    private numberOfActions = 4;
+    private hiddenSizes = [24, 24];
+    private learningRate = 0.05;
+    private discountFactor = 0.95;
+    private epsilon = 0.1;
+    private batchSize = 32;
+    private replayCapacity = 5000;
+    private targetSyncInterval = 250; // learning steps between freezes of the target network
+    private seed = 0;
+
+    private online: FeedforwardNeuralNetwork;
+    private target: FeedforwardNeuralNetwork;
+    private buffer: Transition[];
+    private writeIndex = 0;
+    private learnSteps = 0;
+    private random: () => number;
+
+    public constructor () {}
+
+    /** Choose an action in `state`: explore at random with probability ε, else act greedily. */
+    public selectAction (state: number[]) {
+        this.ensureInitialized();
+        if (this.random() < this.epsilon) {
+            return Math.floor(this.random() * this.numberOfActions);
+        }
+        return this.bestAction(state);
+    }
+
+    /** The greedy action — argmax of the network's predicted Q-values for `state`. */
+    public bestAction (state: number[]) {
+        return argmax(this.getQValues(state));
+    }
+
+    /** The network's predicted Q-value for every action in `state`. */
+    public getQValues (state: number[]) {
+        this.ensureInitialized();
+        return this.online.predict(new Matrix([state])).toArray()[0];
+    }
+
+    /** A state's value V(s) = maxₐ Q(s, a) under the current network. */
+    public getValue (state: number[]) {
+        const q = this.getQValues(state);
+        return q[argmax(q)];
+    }
+
+    /** Q-values for many states at once, in a single forward pass — handy for sweeping a whole grid. */
+    public getQValuesBatch (states: number[][]) {
+        this.ensureInitialized();
+        return this.online.predict(new Matrix(states)).toArray();
+    }
+
+    /** Remember one transition and take a learning step on a replayed minibatch. */
+    public observe (state: number[], action: number, reward: number, nextState: number[], done: boolean) {
+        this.ensureInitialized();
+        this.remember({ state, action, reward, nextState, done });
+        this.learn();
+        return this;
+    }
+
+    public reset () {
+        this.online = undefined;
+        this.target = undefined;
+        this.buffer = undefined;
+        this.writeIndex = 0;
+        this.learnSteps = 0;
+        this.random = undefined;
+        return this;
+    }
+
+    /* Parameter setters */
+
+    public setStateSize (stateSize: number) { this.stateSize = stateSize; return this; }
+    public setNumberOfActions (numberOfActions: number) { this.numberOfActions = numberOfActions; return this; }
+    public setHiddenSizes (hiddenSizes: number[]) { this.hiddenSizes = hiddenSizes; return this; }
+    public setLearningRate (learningRate: number) { this.learningRate = learningRate; return this; }
+    public setDiscountFactor (discountFactor: number) { this.discountFactor = discountFactor; return this; }
+    public setEpsilon (epsilon: number) { this.epsilon = epsilon; return this; }
+    public setBatchSize (batchSize: number) { this.batchSize = batchSize; return this; }
+    public setReplayCapacity (replayCapacity: number) { this.replayCapacity = replayCapacity; return this; }
+    public setTargetSyncInterval (targetSyncInterval: number) { this.targetSyncInterval = targetSyncInterval; return this; }
+    public setSeed (seed: number) { this.seed = seed; return this; }
+
+    /* Parameter getters */
+
+    public getStateSize () { return this.stateSize; }
+    public getNumberOfActions () { return this.numberOfActions; }
+    public getHiddenSizes () { return this.hiddenSizes.slice(); }
+    public getLearningRate () { return this.learningRate; }
+    public getDiscountFactor () { return this.discountFactor; }
+    public getEpsilon () { return this.epsilon; }
+    public getBatchSize () { return this.batchSize; }
+    public getReplayCapacity () { return this.replayCapacity; }
+    public getTargetSyncInterval () { return this.targetSyncInterval; }
+    public getSeed () { return this.seed; }
+    /** How many learning steps (replayed minibatches) have been taken. */
+    public getLearnSteps () { return this.learnSteps; }
+
+    /* Private methods */
+
+    private ensureInitialized () {
+        if (this.online !== undefined) return;
+        const layers = [this.stateSize, ...this.hiddenSizes, this.numberOfActions];
+        this.online = new FeedforwardNeuralNetwork(layers, this.seed).setLearningRate(this.learningRate).setNumberOfEpochs(1).setBatchSize(0);
+        this.target = new FeedforwardNeuralNetwork(layers, this.seed).setLearningRate(this.learningRate).setNumberOfEpochs(1).setBatchSize(0);
+        this.target.setWeightMatrices(this.online.getWeightMatrices());
+        this.buffer = [];
+        this.writeIndex = 0;
+        this.learnSteps = 0;
+        this.random = mulberry32(this.seed);
+    }
+
+    private remember (transition: Transition) {
+        if (this.buffer.length < this.replayCapacity) {
+            this.buffer.push(transition);
+        } else {
+            this.buffer[this.writeIndex] = transition;          // ring buffer: overwrite the oldest
+            this.writeIndex = (this.writeIndex + 1) % this.replayCapacity;
+        }
+    }
+
+    private learn () {
+        if (this.buffer.length < this.batchSize) return; // wait until there's a minibatch to draw
+
+        const batch: Transition[] = [];
+        for (let i = 0; i < this.batchSize; i++) {
+            batch.push(this.buffer[Math.floor(this.random() * this.buffer.length)]);
+        }
+
+        const states = batch.map(t => t.state);
+        const nextStates = batch.map(t => t.nextState);
+        // Start the targets from the network's current outputs, so untaken actions carry zero error,
+        // then overwrite the taken action with its TD target r + γ·maxₐ′ Q_target(s′, a′).
+        const targets = this.online.predict(new Matrix(states)).toArray();
+        const nextQ = this.target.predict(new Matrix(nextStates)).toArray();
+
+        for (let i = 0; i < this.batchSize; i++) {
+            const t = batch[i];
+            const future = t.done ? 0 : nextQ[i][argmax(nextQ[i])];
+            targets[i][t.action] = t.reward + this.discountFactor * future;
+        }
+
+        this.online.train(new Matrix(states), new Matrix(targets));
+        this.learnSteps++;
+
+        if (this.learnSteps % this.targetSyncInterval === 0) {
+            this.target.setWeightMatrices(this.online.getWeightMatrices()); // freeze a fresh target
+        }
+    }
+}
+
+function argmax (values: number[]) {
+    let best = 0;
+    for (let i = 1; i < values.length; i++) {
+        if (values[i] > values[best]) {
+            best = i;
+        }
+    }
+    return best;
+}

--- a/src/lib/machine-learning/supervised/FeedforwardNeuralNetwork.ts
+++ b/src/lib/machine-learning/supervised/FeedforwardNeuralNetwork.ts
@@ -150,6 +150,16 @@ export default class FeedforwardNeuralNetwork {
         return this.weightMatrices.map(weightMatrix => weightMatrix.getClone());
     }
 
+    /**
+     * Replaces the network's weights with clones of the given matrices — the inverse of
+     * {@link getWeightMatrices}. Useful for restoring saved weights, or copying one network's
+     * parameters into another (e.g. syncing a reinforcement-learning target network).
+     */
+    public setWeightMatrices (weightMatrices: Matrix[]) {
+        this.weightMatrices = weightMatrices.map(weightMatrix => weightMatrix.getClone());
+        return this;
+    }
+
     /* Private methods */
 
     private trainBatch (inputs: Matrix, targets: Matrix) {

--- a/src/test/DeepQNetwork.test.ts
+++ b/src/test/DeepQNetwork.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import DeepQNetwork from '../lib/machine-learning/reinforcement/DeepQNetwork';
+
+// A continuous 1-D line: state is [x] with x in [0, 1]. Action 0 steps left, 1 steps right (by 0.12).
+// Reaching x ≥ 0.85 pays +1 and ends the episode; every other step pays 0. The state is a real number,
+// not a table index — so the network has to *generalise* a value across the whole line.
+const STEP = 0.12;
+const GOAL = 0.85;
+function lineStep(x: number, action: number) {
+    const next = Math.min(1, Math.max(0, x + (action === 1 ? STEP : -STEP)));
+    return next >= GOAL ? { next: [next], reward: 1, done: true } : { next: [next], reward: 0, done: false };
+}
+
+function trainOnLine(dqn: DeepQNetwork, episodes: number, envSeed = 7) {
+    let a = envSeed;
+    const rand = () => (a = (a * 48271) % 2147483647) / 2147483647;
+    for (let e = 0; e < episodes; e++) {
+        let state = [rand() * 0.6];
+        for (let t = 0; t < 30; t++) {
+            const action = dqn.selectAction(state);
+            const { next, reward, done } = lineStep(state[0], action);
+            dqn.observe(state, action, reward, next, done);
+            if (done) break;
+            state = next;
+        }
+    }
+}
+
+describe('DeepQNetwork', () => {
+
+    it('learns to move toward the goal and values states by closeness to it', () => {
+        const dqn = new DeepQNetwork().setStateSize(1).setNumberOfActions(2).setHiddenSizes([16, 16])
+            .setLearningRate(0.2).setDiscountFactor(0.9).setEpsilon(0.3).setSeed(0);
+        trainOnLine(dqn, 800);
+
+        // From anywhere short of the goal, the learned move is "right" (toward it).
+        expect(dqn.bestAction([0.3])).toBe(1);
+        expect(dqn.bestAction([0.55])).toBe(1);
+        // And the value rises as you near the goal.
+        expect(dqn.getValue([0.75])).toBeGreaterThan(dqn.getValue([0.15]) + 0.2);
+    });
+
+    it('gives a value for any state, including ones it never visited', () => {
+        const dqn = new DeepQNetwork().setStateSize(1).setNumberOfActions(2).setSeed(0);
+
+        // The network is defined everywhere — a fresh agent already answers for an arbitrary state.
+        const q = dqn.getQValues([0.123]);
+        expect(q.length).toBe(2);
+        expect(q.every(v => Number.isFinite(v))).toBe(true);
+
+        // Batched lookups match the per-state ones (used to paint a value heatmap in one pass).
+        const batch = dqn.getQValuesBatch([[0.1], [0.42], [0.9]]);
+        expect(batch.length).toBe(3);
+        expect(batch[1]).toEqual(dqn.getQValues([0.42]));
+    });
+
+    it('waits for a full minibatch before learning, then steps', () => {
+        const dqn = new DeepQNetwork().setStateSize(1).setNumberOfActions(2).setBatchSize(8).setSeed(0);
+        for (let i = 0; i < 7; i++) dqn.observe([i / 10], i % 2, 0, [(i + 1) / 10], false);
+        expect(dqn.getLearnSteps()).toBe(0); // only 7 transitions buffered — no batch yet
+
+        for (let i = 0; i < 20; i++) dqn.observe([i / 10], i % 2, 0, [(i + 1) / 10], false);
+        expect(dqn.getLearnSteps()).toBeGreaterThan(0);
+    });
+
+    it('is deterministic for a fixed seed', () => {
+        const run = () => {
+            const dqn = new DeepQNetwork().setStateSize(1).setNumberOfActions(2).setBatchSize(8).setSeed(3);
+            for (let i = 0; i < 200; i++) dqn.observe([(i % 9) / 10], i % 2, i % 9 === 8 ? 1 : 0, [((i % 9) + 1) / 10], i % 9 === 8);
+            return dqn.getQValues([0.4]);
+        };
+        expect(run()).toEqual(run());
+    });
+
+    it('round-trips its hyperparameters and chains setters', () => {
+        const dqn = new DeepQNetwork();
+        expect(dqn.getDiscountFactor()).toBe(0.95);
+
+        const returned = dqn.setStateSize(3).setNumberOfActions(5).setHiddenSizes([8, 8]).setLearningRate(0.01)
+            .setDiscountFactor(0.8).setEpsilon(0.05).setBatchSize(16).setReplayCapacity(1000).setTargetSyncInterval(100).setSeed(9);
+        expect(returned).toBe(dqn);
+        expect(dqn.getStateSize()).toBe(3);
+        expect(dqn.getNumberOfActions()).toBe(5);
+        expect(dqn.getHiddenSizes()).toEqual([8, 8]);
+        expect(dqn.getLearningRate()).toBe(0.01);
+        expect(dqn.getDiscountFactor()).toBe(0.8);
+        expect(dqn.getEpsilon()).toBe(0.05);
+        expect(dqn.getBatchSize()).toBe(16);
+        expect(dqn.getReplayCapacity()).toBe(1000);
+        expect(dqn.getTargetSyncInterval()).toBe(100);
+        expect(dqn.getSeed()).toBe(9);
+    });
+});


### PR DESCRIPTION
Chapter 27 — **Deep RL (DQN)**, which **completes Part 5 · Learning by doing** (the whole reinforcement-learning arc). Tabular Q-learning can't scale once states are too many to enumerate, so a neural network predicts Q(state) instead — generalising across a *continuous* floor.

## Library
- `DeepQNetwork` (in `src/lib/machine-learning/reinforcement/`): a from-scratch DQN with **experience replay** (ring buffer + random minibatches) and a periodically-frozen **target network**. `selectAction` → `observe` (remember + learn). Plus `getValue`, `getQValues`, `getQValuesBatch`. Reuses the Chapter-20 `FeedforwardNeuralNetwork` as the online + target value nets. Seeded, chainable.
- `FeedforwardNeuralNetwork.setWeightMatrices` — small, generally-useful addition (sync the target network / load saved weights).
- 5 tests: learns toward a goal on a continuous line + value gradient; values for unseen states & batched-predict parity; minibatch gating; determinism; setter round-trip. (194 total pass.)
- Demo block (prints the learned value surface as an ASCII heatmap), README section + keywords.

## Site
- `ml/navDatasets.ts` — three continuous-floor scenarios + `makeNavEnv`.
- `viz/deepRl.ts` — the network's value surface as a fine heatmap (batched predict), a policy-arrow field, the runner + trail.
- `DeepQNetworkPlayground.tsx` + MDX tutorial (`content/deep-rl.mdx`), registered as Ch 27.
- `docs/course-plan.md` flipped Ch 27 ✅ — **Part 5 complete**.

## Release
- Version bumped 0.13.0 → **0.14.0** (minor bump per new-algorithm batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)