### PR TITLE
Release 0.16.0: Generative Models / VAE (Chapter 29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Below are some simple code usage examples.
 * [Q-Learning (reinforcement learning)](#q-learning-reinforcement-learning)
 * [Deep Q-Network (DQN)](#deep-q-network-dqn)
 * [Autoencoder](#autoencoder)
+* [Variational Autoencoder (VAE)](#variational-autoencoder-vae)
 
 ### Feedforward Neural Network
 ```TypeScript
@@ -725,6 +726,42 @@ for (let y = 0; y < W; y++) console.log('  ' + render(noisy, y) + '      ' + ren
 //    .#++..      .:++:                 blob, roughly here") and dropped the rest. That same code, read
 //   :.###        .:++:.                on its own, is a 2-D map of the data — and a high reconstruction
 //   ::#:.+       .:++.                 error flags an anomaly that looks like nothing it ever learned.
+
+```
+
+### Variational Autoencoder (VAE)
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// VAE: the autoencoder turned into a *generator*. The encoder outputs a distribution (mean + variance)
+// per input, a KL term shapes the latent space into a standard normal, and the reparameterisation trick
+// keeps it trainable. So afterwards you can draw a random code z ~ N(0, 1), decode it, and get a
+// brand-new, plausible image that was never in the training set.
+const W = 7;
+const blob = (cx: number, cy: number) => {
+    const img: number[] = [];
+    for (let y = 0; y < W; y++) for (let x = 0; x < W; x++) img.push(Math.exp(-((x - cx) ** 2 + (y - cy) ** 2) / 4));
+    return img;
+};
+let lcg = 1;
+const rng = () => (lcg = (lcg * 48271) % 2147483647) / 2147483647;
+const images = Array.from({ length: 200 }, () => blob(1.5 + rng() * 4, 1.5 + rng() * 4));
+
+const vae = new ml.VariationalAutoencoder();
+vae.setHiddenSize(32).setCodeSize(2).setBeta(1).setLearningRate(0.06).setNumberOfEpochs(2000).setSeed(0);
+vae.train(new ml.Matrix(images));
+
+const samples = vae.sample(3, 7).toArray();        // 3 fresh blobs drawn from the prior — none memorised
+const render = (img: number[], y: number) => img.slice(y * W, y * W + W).map(v => ' .:+#'[Math.min(4, Math.floor(v * 5))]).join('');
+console.log('three invented blobs (z ~ N(0,1) -> decode):');
+for (let y = 0; y < W; y++) console.log('  ' + [0, 1, 2].map(i => render(samples[i], y)).join('    '));
+// three invented blobs (z ~ N(0,1) -> decode):     <- each column is a clean blob at a different spot,
+//                  .                                   generated from a random latent code. The decoder
+//                .:::.           .::.                  became a generator: feed it a point in the smooth
+//     ..         .+++.       :++:                      latent space and a new image comes out. (Constrain
+//    .+:.        .::.        :++:                      that space to N(0,1) and that's exactly what makes
+//   .:##:.                   .::.                      the random draws land on plausible images.)
 
 ```
 

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -39,10 +39,12 @@ world), and **Ch 27 Deep RL** (a from-scratch **DQN** with experience replay and
 reusing the Chapter-20 neural network to approximate value over a *continuous* floor). **Part 6 (the
 frontier)** is now under way with **Ch 28 Autoencoders** (a from-scratch symmetric encoder/decoder with
 MSE backprop and gradient checking — compression, denoising, and anomaly detection all from one
-reconstruction objective, taught with a live latent-manifold playground). **The deep-RL and autoencoder
-chapters, like the three deep-learning frontier chapters (CNN, RNN, Transformer), became full trainable
-builds** rather than the planned "adopts" explainers. Still roadmap: the rest of Part 6 — generative
-models (Ch 29) and Bayesian (Ch 30). See the status column below.
+reconstruction objective) and **Ch 29 Generative Models** (a from-scratch **variational autoencoder** —
+reparameterisation trick + KL regulariser, gradient-checked — that *samples brand-new images* from the
+prior; GANs and diffusion covered as a field note). **The deep-RL, autoencoder, and VAE chapters, like
+the three deep-learning frontier chapters (CNN, RNN, Transformer), became full trainable builds** rather
+than the planned "adopts" explainers. Still roadmap: the course's final chapter — Bayesian / probabilistic
+models (Ch 30). See the status column below.
 
 ---
 
@@ -200,7 +202,7 @@ Every row's "Wall" is the previous tool failing.
 | # | Chapter | Café problem | The Wall → The Idea | Status |
 |---|---|---|---|---|
 | 28 | **Autoencoders** | Compress & denoise data; anomaly detection with nets | Need compact learned representations → encode→decode | ✅ `Autoencoder` (from scratch — symmetric encoder/decoder, MSE backprop, gradient-checked; compress + denoise + anomaly via reconstruction error; latent-manifold playground) |
-| 29 | **Generative Models (VAE/GAN/Diffusion)** | Invent new recipe ideas & marketing images | Don't classify — *create* → generative modeling | ○ (adopts) |
+| 29 | **Generative Models (VAE/GAN/Diffusion)** | Invent new recipe ideas & marketing images | Don't classify — *create* → generative modeling | ✅ `VariationalAutoencoder` (built from scratch — reparameterisation trick + KL regulariser, gradient-checked; sample new images from the prior; exceeded the "adopts" plan. GAN/Diffusion covered as a field note) |
 | 30 | **Bayesian / Probabilistic Models** | "How *sure* are we?" before a big bet (signing the lease for store #3, a huge catering order) | Point predictions hide uncertainty → priors, posteriors, reasoning under uncertainty | ○ |
 
 **Cross-cutting "Field Notes"** (recurring sidebars, threaded through the story, not standalone

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -428,6 +428,31 @@ import * as ml from '../src/lib';
 }
 
 {
+    // Variational autoencoder (VAE): the autoencoder turned into a *generator*. It learns a latent
+    // space shaped like a standard normal, so we can draw a random code z ~ N(0, 1), decode it, and get
+    // a brand-new blob that was never in the training set. Same 7×7 blobs as before.
+    const W = 7;
+    const blob = (cx: number, cy: number) => {
+        const img: number[] = [];
+        for (let y = 0; y < W; y++) for (let x = 0; x < W; x++) img.push(Math.exp(-((x - cx) ** 2 + (y - cy) ** 2) / 4));
+        return img;
+    };
+    let lcg = 1;
+    const rng = () => (lcg = (lcg * 48271) % 2147483647) / 2147483647;
+    const images = Array.from({ length: 200 }, () => blob(1.5 + rng() * 4, 1.5 + rng() * 4));
+
+    const vae = new ml.VariationalAutoencoder().setHiddenSize(32).setCodeSize(2).setBeta(1).setLearningRate(0.06).setNumberOfEpochs(2000).setSeed(0);
+    vae.train(new ml.Matrix(images));
+
+    const samples = vae.sample(3, 7).toArray(); // 3 fresh blobs, drawn from the prior — not memorised
+    const render = (img: number[], y: number) => img.slice(y * W, y * W + W).map(v => ' .:+#'[Math.min(4, Math.floor(v * 5))]).join('');
+    console.log('three invented blobs (z ~ N(0,1) → decode):');
+    for (let y = 0; y < W; y++) console.log('  ' + [0, 1, 2].map(i => render(samples[i], y)).join('    '));
+    // Each column is a clean, plausible blob at a different spot — none of them copied from the data.
+    // The decoder became a little generator: feed it a point in latent space, get a new image out.
+}
+
+{
     // Naive Bayes (multinomial): classify messages by word counts.
     // Vocabulary [free, money, table, tonight]; one-hot classes [spam, ham].
     const inputs = new ml.Matrix([[2, 1, 0, 0], [1, 2, 0, 0], [0, 0, 2, 1], [0, 0, 1, 2]]);

--- a/package.json
+++ b/package.json
@@ -94,7 +94,11 @@
     "autoencoder",
     "representation learning",
     "denoising",
-    "bottleneck"
+    "bottleneck",
+    "variational autoencoder",
+    "vae",
+    "generative model",
+    "generative ai"
   ],
   "author": "Erik Gerrits <gerrits.erik@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-learning",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "TypeScript & JavaScript machine learning library",
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index",

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -38,6 +38,7 @@ const ContextualBanditsTutorial = lazy(() => import('./content/contextual-bandit
 const QLearningTutorial = lazy(() => import('./content/q-learning.mdx'));
 const DeepRlTutorial = lazy(() => import('./content/deep-rl.mdx'));
 const AutoencodersTutorial = lazy(() => import('./content/autoencoders.mdx'));
+const GenerativeModelsTutorial = lazy(() => import('./content/generative-models.mdx'));
 
 export function App() {
     return (
@@ -281,6 +282,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <AutoencodersTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="generative-models"
+                    element={
+                        <TutorialPage>
+                            <GenerativeModelsTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -294,4 +294,13 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         chapter: 28,
         part: PART_6,
     },
+    {
+        id: 'generative-models',
+        path: '/generative-models',
+        title: 'Generative Models (VAE)',
+        tagline: 'Shape the latent space into a samplable prior — then invent images that never existed.',
+        status: 'live',
+        chapter: 29,
+        part: PART_6,
+    },
 ];

--- a/site/src/components/VariationalAutoencoderPlayground.module.css
+++ b/site/src/components/VariationalAutoencoderPlayground.module.css
@@ -1,0 +1,77 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 420px) minmax(240px, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.gridWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 1 / 1;
+    background: #0b1120;
+}
+
+.grid {
+    width: 100%;
+    height: 100%;
+}
+
+.caption {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    font-size: 11px;
+    color: var(--muted);
+    background: rgba(11, 17, 32, 0.7);
+    padding: 5px 10px;
+    text-align: center;
+    backdrop-filter: blur(4px);
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.galleryWrap {
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    background: #0b1120;
+    aspect-ratio: 1 / 1;
+}
+
+.gallery {
+    width: 100%;
+    height: 100%;
+}
+
+.note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/VariationalAutoencoderPlayground.tsx
+++ b/site/src/components/VariationalAutoencoderPlayground.tsx
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { VariationalAutoencoder, Matrix } from 'machine-learning';
+import { AUTOENCODER_SCENARIOS, type AutoencoderScenario } from '../ml/autoencoderDatasets';
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+import { drawGenerativeManifold, drawSampleGallery } from '../viz/vae';
+import { Card, ControlPanel, Hint, Metric, MetricsRow, RunControls, Select, Slider } from './controls/Controls';
+import styles from './VariationalAutoencoderPlayground.module.css';
+
+const EPOCHS_PER_FRAME = 15;
+const DATA_COUNT = 160;
+const MANIFOLD_RES = 9;     // tiles per side over the prior
+const PRIOR_SPAN = 2.2;     // grid spans [-PRIOR_SPAN, PRIOR_SPAN]² of the N(0,1) latent
+const GALLERY = 16;
+
+// Box–Muller standard-normal from a uniform generator.
+function gaussian(rand: () => number) {
+    let u = 0; while (u === 0) u = rand();
+    let v = 0; while (v === 0) v = rand();
+    return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+export function VariationalAutoencoderPlayground() {
+    const [scenarioId, setScenarioId] = useState(AUTOENCODER_SCENARIOS[0].id);
+    const [betaSlider, setBetaSlider] = useState(100); // beta = slider / 100
+    const [lrSlider, setLrSlider] = useState(6);        // lr = slider / 100
+    const [seed, setSeed] = useState(0);
+    const [running, setRunning] = useState(false);
+    const [metrics, setMetrics] = useState({ epochs: 0, loss: 0 });
+
+    const beta = betaSlider / 100;
+    const lr = lrSlider / 100;
+
+    // Fixed prior grid (constant) for the generative manifold.
+    const gridCodes = useMemo(() => {
+        const pts: number[][] = [];
+        for (let r = 0; r < MANIFOLD_RES; r++) {
+            for (let c = 0; c < MANIFOLD_RES; c++) {
+                pts.push([
+                    -PRIOR_SPAN + (2 * PRIOR_SPAN) * (c / (MANIFOLD_RES - 1)),
+                    -PRIOR_SPAN + (2 * PRIOR_SPAN) * (r / (MANIFOLD_RES - 1)),
+                ]);
+            }
+        }
+        return pts;
+    }, []);
+
+    const vaeRef = useRef<VariationalAutoencoder | null>(null);
+    const dataRef = useRef<Matrix | null>(null);
+    const colorsRef = useRef<number[]>([]);
+    const scenarioRef = useRef<AutoencoderScenario>(AUTOENCODER_SCENARIOS[0]);
+    const galleryCodesRef = useRef<number[][]>([]);
+    const epochsRef = useRef(0);
+    const manifoldCanvasRef = useRef<HTMLCanvasElement | null>(null);
+    const galleryCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const draw = useCallback(() => {
+        const vae = vaeRef.current;
+        const data = dataRef.current;
+        const scenario = scenarioRef.current;
+        const manifoldCanvas = manifoldCanvasRef.current;
+        const galleryCanvas = galleryCanvasRef.current;
+        if (!vae || !data || !manifoldCanvas || !galleryCanvas) return;
+
+        const tiles = vae.generate(new Matrix(gridCodes)).toArray();
+        drawGenerativeManifold(manifoldCanvas, {
+            gridRes: MANIFOLD_RES,
+            tiles,
+            imageWidth: scenario.width,
+            dataCodes: vae.encode(data).toArray(),
+            dataColors: colorsRef.current,
+            codeMin: [-PRIOR_SPAN, -PRIOR_SPAN],
+            codeMax: [PRIOR_SPAN, PRIOR_SPAN],
+            showData: true,
+        });
+
+        const samples = vae.generate(new Matrix(galleryCodesRef.current)).toArray();
+        drawSampleGallery(galleryCanvas, { images: samples, imageWidth: scenario.width, cols: 4 });
+    }, [gridCodes]);
+
+    const rebuild = useCallback(() => {
+        const scenario = AUTOENCODER_SCENARIOS.find(s => s.id === scenarioId) ?? AUTOENCODER_SCENARIOS[0];
+        const { images, colors } = scenario.generate(seed + 1, DATA_COUNT);
+        const vae = new VariationalAutoencoder()
+            .setHiddenSize(32).setCodeSize(2).setBeta(beta).setLearningRate(lr).setNumberOfEpochs(EPOCHS_PER_FRAME).setSeed(seed);
+
+        vaeRef.current = vae;
+        dataRef.current = new Matrix(images);
+        colorsRef.current = colors;
+        scenarioRef.current = scenario;
+
+        // A fixed set of random latent codes, so the gallery shows the *same* draws sharpening over time.
+        let s = seed + 31;
+        const rand = () => (s = (s * 48271) % 2147483647) / 2147483647;
+        galleryCodesRef.current = Array.from({ length: GALLERY }, () => [gaussian(rand), gaussian(rand)]);
+
+        epochsRef.current = 0;
+        setMetrics({ epochs: 0, loss: 0 });
+        setRunning(false);
+        vae.train(dataRef.current); // one chunk so the network exists to draw
+        epochsRef.current = EPOCHS_PER_FRAME;
+        draw();
+    }, [scenarioId, beta, lr, seed, draw]);
+
+    useEffect(() => {
+        rebuild();
+    }, [rebuild]);
+
+    const step = useCallback(() => {
+        const vae = vaeRef.current;
+        const data = dataRef.current;
+        if (!vae || !data) return;
+
+        vae.train(data);
+        epochsRef.current += EPOCHS_PER_FRAME;
+        draw();
+        if (epochsRef.current % (EPOCHS_PER_FRAME * 4) === 0) {
+            setMetrics({ epochs: epochsRef.current, loss: Math.round(vae.computeLoss(data) * 1000) / 1000 });
+        }
+    }, [draw]);
+
+    useAnimationFrame(step, running);
+
+    const handleStep = () => {
+        if (!running) step();
+    };
+    const handleReset = () => {
+        setRunning(false);
+        rebuild();
+    };
+
+    const scenario = AUTOENCODER_SCENARIOS.find(s => s.id === scenarioId);
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <RunControls
+                    running={running}
+                    onToggle={() => setRunning(r => !r)}
+                    onStep={handleStep}
+                    onReset={handleReset}
+                />
+                <Select
+                    label="Data"
+                    value={scenarioId}
+                    options={AUTOENCODER_SCENARIOS.map(s => ({ value: s.id, label: s.label }))}
+                    onChange={setScenarioId}
+                />
+                {scenario && <Hint>{scenario.blurb}</Hint>}
+                <Slider label="KL weight β" value={betaSlider} display={beta.toFixed(2)} min={0} max={300} onChange={setBetaSlider} />
+                <Slider label="Learning rate" value={lrSlider} display={lr.toFixed(2)} min={2} max={15} onChange={setLrSlider} />
+                <Slider label="Random seed" value={seed} display={String(seed)} min={0} max={9} onChange={setSeed} />
+                <Hint>Press Train: the gallery&apos;s random codes sharpen into real samples, and the big panel fills with images the VAE invents across its latent space.</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.gridWrap}>
+                    <canvas ref={manifoldCanvasRef} className={styles.grid} />
+                    <div className={styles.caption}>generative manifold · every tile is a latent code decoded into a new image; dots are real data</div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Epochs" value={String(metrics.epochs)} />
+                        <Metric label="Loss" value={metrics.loss.toFixed(3)} />
+                    </MetricsRow>
+
+                    <div className={styles.galleryWrap}>
+                        <canvas ref={galleryCanvasRef} className={styles.gallery} />
+                    </div>
+
+                    <Card title="Samples from nothing" subtitle="z ~ N(0,1) → decode">
+                        <p className={styles.note}>
+                            These 16 images are decoded from <em>fixed random codes</em> — pure noise drawn from
+                            a standard normal. Watch them morph from static into clean samples as training pulls
+                            the latent space into shape. None are copied from the data; the VAE <em>invents</em> them.
+                        </p>
+                    </Card>
+
+                    <Card title="Why a distribution" subtitle="the KL weight β">
+                        <p className={styles.note}>
+                            A plain autoencoder leaves gaps between codes, so a random draw decodes to garbage.
+                            The <strong>KL term</strong> presses every input&apos;s code toward N(0,1), packing them
+                            into one smooth blob with no gaps — so sampling works. Raise <strong>β</strong> for a
+                            tidier, more samplable space (but blurrier); lower it for sharper images on a gappier map.
+                        </p>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/content/generative-models.mdx
+++ b/site/src/content/generative-models.mdx
@@ -1,0 +1,107 @@
+import { VariationalAutoencoderPlayground } from '../components/VariationalAutoencoderPlayground';
+
+# Chapter 29 — Inventing what was never there
+
+> *Generative models (the VAE).* Last chapter's decoder could already turn a code into an image — but
+> only codes it had seen. This chapter makes the latent space so smooth and well-organised that you can
+> pluck a code *at random* and get something new and plausible. The café stops summarising its data and
+> starts **dreaming up** new examples of it.
+
+Nadia's autoencoder learned the *shape* of her data — a 2-number summary of each floor heatmap, each
+receipt. Now she wants more than a summary. Could the model **invent** plausible new heatmaps to
+stress-test staffing? Sketch fresh latte-art ideas? That means *generating* data, not just rebuilding
+it — and the autoencoder is tantalisingly close, since its decoder already turns numbers into images.
+
+## The wall: the gaps between the codes
+
+So just feed the trained decoder a random code and see what comes out? Try it and you mostly get
+mush. A plain autoencoder was only ever asked to reconstruct *its* inputs, so it parks their codes
+wherever is convenient — scattered islands with **no-man's-land in between**. The data points decode
+fine; the empty space between them decodes to nonsense. There's no reason a random code should land on
+anything meaningful, because nothing ever told the model to fill the space in. To sample, we need a
+latent space with **no gaps** and a **known shape** to sample from.
+
+## The idea: encode a distribution, and tidy the space
+
+Two changes turn the autoencoder into a **variational autoencoder**. First, the encoder stops emitting
+a single point and instead outputs a little **distribution** for each input — a mean `μ` and a spread
+`σ` per latent dimension — and the code is **sampled** from it. That blurs each input across a small
+region instead of a pin-point, forcing nearby codes to also decode sensibly. (To keep it trainable, the
+sample is written `z = μ + σ·ε` with `ε ~ N(0, 1)` — the *reparameterisation trick* — so the
+randomness sits in `ε` and the gradient still flows through `μ` and `σ`.)
+
+Second, a **KL-divergence** penalty pulls every input's distribution toward a standard normal
+`N(0, 1)`. That gently packs all the codes into one smooth, gap-free blob centred on the origin — a
+shape we know exactly how to sample. Now the recipe to generate is trivial: **draw `z ~ N(0, 1)`,
+decode it, done.** The weight `β` sets how hard that tidying pulls.
+
+Below, the big panel decodes a grid of latent codes — every tile is an image the VAE *invents* — and
+the gallery decodes 16 fixed random codes. Press **Train** and watch noise resolve into samples:
+
+<div className="breakout">
+  <VariationalAutoencoderPlayground />
+</div>
+
+## How it works: a sampled code and two loss terms
+
+The encoder produces `μ` and `logσ²`; a code is sampled with external noise so gradients survive; the
+decoder rebuilds the input — straight from the
+[`VariationalAutoencoder`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/unsupervised/VariationalAutoencoder.ts)
+source:
+
+```ts
+const std = Matrix.transform(logVar, v => Math.exp(0.5 * v));
+const z = Matrix.add(mean, hadamard(std, noise)); // z = μ + σ·ε  — the reparameterisation trick
+```
+
+Training minimises two terms at once — rebuild the input **and** keep each code close to `N(0, 1)`:
+
+```ts
+// KL = −½ Σ(1 + logσ² − μ² − e^{logσ²}); its gradients flow back into the two encoder heads:
+const dMean   = Matrix.add(dz, Matrix.multiply(mean, this.beta));                         // dKL/dμ = μ
+const dLogVar = Matrix.add(dLogVarRecon, Matrix.multiply(/* ½(e^{logσ²} − 1) */, this.beta)); // dKL/dlogσ²
+```
+
+The reconstruction term keeps samples *sharp*; the KL term keeps the space *samplable*; `β` balances
+them. The gradient path — through the sampled `z` and the KL — is finite-difference verified by a
+shipped `checkGradients()`. Generating is then just the decoder on a fresh draw:
+
+```ts
+public sample (count: number) {                 // z ~ N(0,1) → decode → a brand-new image
+    const codes = /* `count` rows of standard-normal noise */;
+    return this.generate(new Matrix(codes));
+}
+```
+
+## Try it yourself
+
+- **Watch the gallery resolve.** The 16 thumbnails start as static — random codes through an untrained
+  decoder. As the KL term organises the space, those same codes decode into clean, varied samples. None
+  are copied from the data; the VAE is making them up.
+- **Read the manifold.** The big panel is latent space laid bare: move across it and the generated image
+  sweeps smoothly from one form to another, with no dead patches. The dots are the real data&apos;s codes
+  — note how they sit inside the same `N(0, 1)` cloud the samples are drawn from.
+- **Turn β up and down.** High **β** tidies the space hard: samples get more reliable but blurrier. Low
+  β sharpens reconstructions but tears gaps back open, and some random draws start decoding to mush —
+  the exact trade-off at the heart of generative modelling.
+
+> **Field note — the same idea, scaled and varied.** This is a *small* VAE on *tiny* images, but the
+> recipe generalises. Make the decoder a big convolutional or transformer network and you get models
+> that synthesise faces and photographs. Swap the approach and you meet the VAE&apos;s famous cousins:
+> **GANs** pit a generator against a critic that learns to spot fakes; **diffusion models** (behind
+> today&apos;s image generators) learn to reverse a gradual noising process, denoising pure static into a
+> picture step by step. Different machinery, same goal you just watched — sampling new data from learned
+> structure.
+
+## What broke — nothing; the café learned to imagine
+
+Nothing broke. By asking for a *distribution* instead of a point and tidying the latent space toward a
+shape it could sample, the café crossed the line from *describing* data to *creating* it. The decoder
+you trained in Chapter 28 became a generator — feed it noise, get something that never existed but
+could have.
+
+That leaves one last thread. Every model in this course, generators included, hands back an answer with
+total confidence — a blob, a class, a sampled image — and never says how *sure* it is. But Nadia&apos;s
+biggest decisions (sign the lease for store #3? take the giant catering order?) need exactly that:
+honest uncertainty, not a single confident guess. Putting numbers on doubt — priors, posteriors, and
+reasoning when the data is thin — is the final chapter on the map (`docs/course-plan.md`).

--- a/site/src/viz/vae.ts
+++ b/site/src/viz/vae.ts
@@ -1,0 +1,102 @@
+import { fitCanvas } from './canvas';
+import { CLUSTER_HEX } from './clusters';
+
+// Two views of a VAE. The generative manifold decodes a fixed grid of latent codes spanning the
+// N(0,1) prior — every tile is an *invented* image, and because the latent space is smooth they sweep
+// continuously into one another, the real data's codes scattered on top. The gallery decodes a fixed
+// handful of random codes; watch them morph from noise into clean samples as training proceeds.
+
+function drawImage(ctx: CanvasRenderingContext2D, x: number, y: number, size: number, img: number[], width: number) {
+    const cell = size / width;
+    for (let r = 0; r < width; r++) {
+        for (let c = 0; c < width; c++) {
+            const v = Math.max(0, Math.min(1, img[r * width + c]));
+            const shade = Math.round(v * 255);
+            ctx.fillStyle = `rgb(${shade}, ${Math.round(shade * 0.95 + 10)}, ${Math.round(shade * 0.8 + 20)})`;
+            ctx.fillRect(x + c * cell, y + r * cell, cell + 0.5, cell + 0.5);
+        }
+    }
+}
+
+export interface ManifoldView {
+    gridRes: number;
+    tiles: number[][];      // decoded image at each prior-grid point, row-major (z2 ascending up)
+    imageWidth: number;
+    dataCodes: number[][];  // latent means of the real data
+    dataColors: number[];
+    codeMin: [number, number];
+    codeMax: [number, number];
+    showData: boolean;
+}
+
+export function drawGenerativeManifold(canvas: HTMLCanvasElement, view: ManifoldView): void {
+    const { ctx, width, height } = fitCanvas(canvas);
+    ctx.fillStyle = '#0b1120';
+    ctx.fillRect(0, 0, width, height);
+
+    const pad = 6;
+    const size = Math.min(width, height) - pad * 2;
+    const originX = (width - size) / 2;
+    const originY = (height - size) / 2;
+    const tile = size / view.gridRes;
+
+    for (let r = 0; r < view.gridRes; r++) {
+        for (let c = 0; c < view.gridRes; c++) {
+            drawImage(ctx, originX + c * tile, originY + (view.gridRes - 1 - r) * tile, tile, view.tiles[r * view.gridRes + c], view.imageWidth);
+        }
+    }
+
+    if (view.showData) {
+        const spanX = view.codeMax[0] - view.codeMin[0] || 1;
+        const spanY = view.codeMax[1] - view.codeMin[1] || 1;
+        for (let i = 0; i < view.dataCodes.length; i++) {
+            const px = originX + ((view.dataCodes[i][0] - view.codeMin[0]) / spanX) * size;
+            const py = originY + (1 - (view.dataCodes[i][1] - view.codeMin[1]) / spanY) * size;
+            if (px < originX || px > originX + size || py < originY || py > originY + size) continue;
+            ctx.beginPath();
+            ctx.arc(px, py, 2.5, 0, Math.PI * 2);
+            ctx.fillStyle = colorRamp(view.dataColors[i]);
+            ctx.globalAlpha = 0.8;
+            ctx.fill();
+            ctx.globalAlpha = 1;
+        }
+    }
+}
+
+export interface GalleryView {
+    images: number[][];
+    imageWidth: number;
+    cols: number;
+}
+
+export function drawSampleGallery(canvas: HTMLCanvasElement, view: GalleryView): void {
+    const { ctx, width, height } = fitCanvas(canvas);
+    ctx.fillStyle = '#0b1120';
+    ctx.fillRect(0, 0, width, height);
+
+    const rows = Math.ceil(view.images.length / view.cols);
+    const gap = 4;
+    const size = Math.min((width - gap * (view.cols + 1)) / view.cols, (height - gap * (rows + 1)) / rows);
+    const totalW = size * view.cols + gap * (view.cols - 1);
+    const totalH = size * rows + gap * (rows - 1);
+    const startX = (width - totalW) / 2;
+    const startY = (height - totalH) / 2;
+
+    for (let i = 0; i < view.images.length; i++) {
+        const r = Math.floor(i / view.cols);
+        const c = i % view.cols;
+        drawImage(ctx, startX + c * (size + gap), startY + r * (size + gap), size, view.images[i], view.imageWidth);
+    }
+}
+
+function colorRamp(t: number): string {
+    const u = Math.max(0, Math.min(1, t));
+    const a = hexToRgb(CLUSTER_HEX[0]);
+    const b = hexToRgb(CLUSTER_HEX[1]);
+    return `rgb(${Math.round(a[0] + (b[0] - a[0]) * u)}, ${Math.round(a[1] + (b[1] - a[1]) * u)}, ${Math.round(a[2] + (b[2] - a[2]) * u)})`;
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+    const v = parseInt(hex.slice(1), 16);
+    return [(v >> 16) & 255, (v >> 8) & 255, v & 255];
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -30,5 +30,6 @@ export { default as RandomForest } from "./machine-learning/supervised/RandomFor
 export { default as RecurrentNeuralNetwork } from "./machine-learning/supervised/RecurrentNeuralNetwork";
 export { default as Recommender } from "./machine-learning/unsupervised/Recommender";
 export { default as SupportVectorMachine } from "./machine-learning/supervised/SupportVectorMachine";
+export { default as VariationalAutoencoder } from "./machine-learning/unsupervised/VariationalAutoencoder";
 export type { Kernel } from "./machine-learning/supervised/SupportVectorMachine";
 export { default as Transformer } from "./machine-learning/supervised/Transformer";

--- a/src/lib/machine-learning/unsupervised/VariationalAutoencoder.ts
+++ b/src/lib/machine-learning/unsupervised/VariationalAutoencoder.ts
@@ -1,0 +1,329 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+import mulberry32 from "../../math/random/mulberry32";
+
+/**
+ * A **variational autoencoder (VAE)** — the {@link Autoencoder} turned into a true *generative* model,
+ * and the chapter where the café stops describing data and starts inventing it. A plain autoencoder
+ * maps each input to a single point in code space; sample a random code and the decoder usually returns
+ * garbage, because the points it learned sit in scattered islands with nonsense in between. The VAE
+ * fixes that by making the code space **well-organised and samplable**:
+ *
+ * - The encoder outputs not a point but a little **distribution** per input — a mean `μ` and a
+ *   (log-)variance `logσ²` for each latent dimension.
+ * - A code is **sampled** from it via the *reparameterisation trick*: `z = μ + σ·ε`, with `ε ~ N(0, 1)`.
+ *   Writing the randomness as an external `ε` keeps `z` differentiable in `μ` and `σ`, so backprop
+ *   still works.
+ * - The loss adds a **KL-divergence** term that pulls every input's latent distribution toward a
+ *   standard normal `N(0, 1)`. This packs the codes into one smooth, gap-free blob centred on the
+ *   origin — so afterwards you can **draw `z ~ N(0, 1)`, decode it, and get a brand-new, plausible
+ *   sample** ({@link sample}). `β` trades reconstruction sharpness against how tidy that latent space is.
+ *
+ * Loss = reconstruction (binary cross-entropy, for sigmoid pixels in `[0, 1]`) + β·KL. One hidden layer
+ * each side; the full path — including the gradient through the sampling and the KL — is finite-
+ * difference checked by {@link checkGradients}.
+ *
+ * @example
+ * const vae = new VariationalAutoencoder().setHiddenSize(32).setCodeSize(2).setNumberOfEpochs(2000);
+ * vae.train(images);            // rows of pixels in [0, 1]
+ * vae.sample(16);               // 16 freshly generated images, drawn from the prior
+ * vae.generate(new Matrix([[0, 0]])); // decode a specific point in latent space
+ */
+export default class VariationalAutoencoder {
+
+    private inputSize = 0;
+    private hiddenSize = 32;
+    private codeSize = 2;
+    private beta = 1;
+    private learningRate = 0.05;
+    private numberOfEpochs = 2000;
+    private seed = 0;
+
+    private encoderHidden: Matrix;  // (inputSize + 1) × hiddenSize
+    private meanHead: Matrix;       // (hiddenSize + 1) × codeSize
+    private logVarHead: Matrix;     // (hiddenSize + 1) × codeSize
+    private decoderHidden: Matrix;  // (codeSize + 1) × hiddenSize
+    private decoderOutput: Matrix;  // (hiddenSize + 1) × inputSize
+    private random: () => number;
+    private built = false;
+
+    public constructor () {}
+
+    /** Train to reconstruct `inputs` (rows of features in [0, 1]) while shaping the latent space. */
+    public train (inputs: Matrix) {
+        this.ensureBuilt(inputs.getColumnCount());
+        const n = inputs.getRowCount();
+        for (let epoch = 0; epoch < this.numberOfEpochs; epoch++) {
+            const noise = this.sampleNoise(n);
+            this.applyGradients(this.computeGradients(inputs, noise));
+        }
+        return this;
+    }
+
+    /** Encode inputs to their latent means μ (the deterministic code, ignoring the sampling noise). */
+    public encode (inputs: Matrix) {
+        this.ensureBuilt(inputs.getColumnCount());
+        const hidden = Matrix.transform(this.affine(inputs, this.encoderHidden), tanh);
+        return this.affine(hidden, this.meanHead);
+    }
+
+    /** Decode latent codes back into inputs (the generator). */
+    public generate (codes: Matrix) {
+        const hidden = Matrix.transform(this.affine(codes, this.decoderHidden), tanh);
+        return Matrix.transform(this.affine(hidden, this.decoderOutput), sigmoid);
+    }
+
+    /** Reconstruct inputs by encoding to the mean and decoding (no sampling noise). */
+    public reconstruct (inputs: Matrix) {
+        return this.generate(this.encode(inputs));
+    }
+
+    /** Draw `count` brand-new samples: z ~ N(0, 1) → decode. Pass a seed for reproducibility. */
+    public sample (count: number, seed?: number) {
+        this.ensureBuilt(this.inputSize);
+        const random = seed === undefined ? this.random : mulberry32(seed);
+        const codes: number[][] = [];
+        for (let i = 0; i < count; i++) {
+            const row: number[] = [];
+            for (let k = 0; k < this.codeSize; k++) row.push(gaussian(random));
+            codes.push(row);
+        }
+        return this.generate(new Matrix(codes));
+    }
+
+    /** Per-row reconstruction (binary cross-entropy) — usable as an anomaly / typicality score. */
+    public reconstructionError (inputs: Matrix): number[] {
+        const reconstructed = this.reconstruct(inputs).toArray();
+        const original = inputs.toArray();
+        return original.map((row, i) => {
+            let sum = 0;
+            for (let j = 0; j < row.length; j++) sum += crossEntropy(reconstructed[i][j], row[j]);
+            return sum / row.length;
+        });
+    }
+
+    /** The training objective at the latent means (reconstruction BCE + β·KL), averaged over rows. */
+    public computeLoss (inputs: Matrix): number {
+        this.ensureBuilt(inputs.getColumnCount());
+        const hidden = Matrix.transform(this.affine(inputs, this.encoderHidden), tanh);
+        const mean = this.affine(hidden, this.meanHead);
+        const logVar = this.affine(hidden, this.logVarHead);
+        const output = this.generate(mean); // decode the mean (zero noise) for a stable monitor
+        return this.loss(output, inputs, mean, logVar);
+    }
+
+    /**
+     * Verifies the analytic gradients against numerical ones on a small random problem, with the
+     * sampling noise held fixed so the objective is deterministic. Returns true if every gradient
+     * matches to a tight tolerance — the proof the reparameterised + KL backprop is correct.
+     */
+    public checkGradients (): boolean {
+        const probe = new VariationalAutoencoder().setHiddenSize(5).setCodeSize(2).setBeta(0.7).setSeed(2);
+        const inputs = Matrix.rand(4, 6, 0.4, 3).transform(v => v + 0.5); // 4 rows of 6 features in (0, 1)
+        probe.ensureBuilt(6);
+        const noise = probe.sampleNoise(4);
+
+        const analytic = probe.computeGradients(inputs, noise);
+        const epsilon = 1e-4;
+        let maxError = 0;
+
+        for (const name of GRADIENT_ORDER) {
+            const weight = probe.weightFor(name);
+            const gradient = analytic[name];
+            for (let r = 0; r < weight.getRowCount(); r++) {
+                for (let c = 0; c < weight.getColumnCount(); c++) {
+                    const original = weight.getElement(r, c);
+                    weight.setElement(r, c, original + epsilon);
+                    const lossPlus = probe.lossWith(inputs, noise);
+                    weight.setElement(r, c, original - epsilon);
+                    const lossMinus = probe.lossWith(inputs, noise);
+                    weight.setElement(r, c, original);
+
+                    const numeric = (lossPlus - lossMinus) / (2 * epsilon);
+                    const denominator = Math.max(1e-8, Math.abs(numeric) + Math.abs(gradient.getElement(r, c)));
+                    maxError = Math.max(maxError, Math.abs(numeric - gradient.getElement(r, c)) / denominator);
+                }
+            }
+        }
+        return maxError < 1e-4;
+    }
+
+    /* Parameter setters */
+
+    public setInputSize (inputSize: number) { this.inputSize = inputSize; return this; }
+    public setHiddenSize (hiddenSize: number) { this.hiddenSize = hiddenSize; return this; }
+    public setCodeSize (codeSize: number) { this.codeSize = codeSize; return this; }
+    public setBeta (beta: number) { this.beta = beta; return this; }
+    public setLearningRate (learningRate: number) { this.learningRate = learningRate; return this; }
+    public setNumberOfEpochs (numberOfEpochs: number) { this.numberOfEpochs = numberOfEpochs; return this; }
+    public setSeed (seed: number) { this.seed = seed; return this; }
+
+    /* Parameter getters */
+
+    public getInputSize () { return this.inputSize; }
+    public getHiddenSize () { return this.hiddenSize; }
+    public getCodeSize () { return this.codeSize; }
+    public getBeta () { return this.beta; }
+    public getLearningRate () { return this.learningRate; }
+    public getNumberOfEpochs () { return this.numberOfEpochs; }
+    public getSeed () { return this.seed; }
+
+    /* Private methods */
+
+    private ensureBuilt (inputSize: number) {
+        if (this.built && this.inputSize === inputSize) return;
+        if (inputSize > 0) this.inputSize = inputSize;
+        const i = this.inputSize, h = this.hiddenSize, k = this.codeSize;
+        this.encoderHidden = Matrix.rand(i + 1, h, Math.sqrt(6) / Math.sqrt(i + h), this.seed + 1);
+        this.meanHead = Matrix.rand(h + 1, k, Math.sqrt(6) / Math.sqrt(h + k), this.seed + 2);
+        this.logVarHead = Matrix.rand(h + 1, k, 0.01, this.seed + 3); // tiny → start near logσ²=0 (σ≈1), stable
+        this.decoderHidden = Matrix.rand(k + 1, h, Math.sqrt(6) / Math.sqrt(k + h), this.seed + 4);
+        this.decoderOutput = Matrix.rand(h + 1, i, Math.sqrt(6) / Math.sqrt(h + i), this.seed + 5);
+        this.random = mulberry32(this.seed);
+        this.built = true;
+    }
+
+    /** Append a bias column and multiply by a weight matrix: [1 | input] · weights. */
+    private affine (input: Matrix, weights: Matrix) {
+        return Matrix.multiply(Matrix.appendLeft(input, Matrix.ones(input.getRowCount(), 1)), weights);
+    }
+
+    private sampleNoise (n: number): Matrix {
+        const rows: number[][] = [];
+        for (let i = 0; i < n; i++) {
+            const row: number[] = [];
+            for (let k = 0; k < this.codeSize; k++) row.push(gaussian(this.random));
+            rows.push(row);
+        }
+        return new Matrix(rows);
+    }
+
+    private computeGradients (inputs: Matrix, noise: Matrix): Record<GradientName, Matrix> {
+        const n = inputs.getRowCount();
+
+        // ---- Forward, keeping every intermediate the backward pass needs.
+        const encHiddenZ = this.affine(inputs, this.encoderHidden);
+        const encHidden = Matrix.transform(encHiddenZ, tanh);
+        const mean = this.affine(encHidden, this.meanHead);
+        const logVar = this.affine(encHidden, this.logVarHead);
+        const std = Matrix.transform(logVar, v => Math.exp(0.5 * v));
+        const z = Matrix.add(mean, hadamard(std, noise)); // reparameterisation
+        const decHiddenZ = this.affine(z, this.decoderHidden);
+        const decHidden = Matrix.transform(decHiddenZ, tanh);
+        const outputZ = this.affine(decHidden, this.decoderOutput);
+        const output = Matrix.transform(outputZ, sigmoid);
+
+        // ---- Backward. Gradients are summed over the batch, then scaled by 1/n at the end.
+        // Decoder: BCE + sigmoid output ⇒ output-layer error is simply (output − input).
+        const dOutput = Matrix.subtract(output, inputs);
+        const gradDecoderOutput = Matrix.multiply(Matrix.transpose(withBias(decHidden)), dOutput);
+
+        let dDecHidden = hadamard(Matrix.multiply(dOutput, Matrix.transpose(dropBias(this.decoderOutput))), Matrix.transform(decHiddenZ, tanhPrime));
+        const gradDecoderHidden = Matrix.multiply(Matrix.transpose(withBias(z)), dDecHidden);
+
+        const dz = Matrix.multiply(dDecHidden, Matrix.transpose(dropBias(this.decoderHidden))); // recon grad wrt z
+
+        // z = mean + std·noise ⇒ split into the two heads, then add the KL term's gradients.
+        // KL = −½ Σ(1 + logVar − mean² − e^logVar): dKL/dmean = mean, dKL/dlogVar = ½(e^logVar − 1).
+        const dMean = Matrix.add(dz, Matrix.multiply(mean, this.beta));
+        const dLogVarRecon = hadamard(dz, Matrix.multiply(hadamard(std, noise), 0.5)); // ∂z/∂logVar = ½·std·ε
+        const dLogVarKl = Matrix.multiply(Matrix.transform(logVar, v => 0.5 * (Math.exp(v) - 1)), this.beta);
+        const dLogVar = Matrix.add(dLogVarRecon, dLogVarKl);
+
+        const gradMeanHead = Matrix.multiply(Matrix.transpose(withBias(encHidden)), dMean);
+        const gradLogVarHead = Matrix.multiply(Matrix.transpose(withBias(encHidden)), dLogVar);
+
+        const dEncHidden = hadamard(
+            Matrix.add(Matrix.multiply(dMean, Matrix.transpose(dropBias(this.meanHead))),
+                       Matrix.multiply(dLogVar, Matrix.transpose(dropBias(this.logVarHead)))),
+            Matrix.transform(encHiddenZ, tanhPrime),
+        );
+        const gradEncoderHidden = Matrix.multiply(Matrix.transpose(withBias(inputs)), dEncHidden);
+
+        const scale = 1 / n;
+        return {
+            encoderHidden: Matrix.multiply(gradEncoderHidden, scale),
+            meanHead: Matrix.multiply(gradMeanHead, scale),
+            logVarHead: Matrix.multiply(gradLogVarHead, scale),
+            decoderHidden: Matrix.multiply(gradDecoderHidden, scale),
+            decoderOutput: Matrix.multiply(gradDecoderOutput, scale),
+        };
+    }
+
+    private applyGradients (gradients: Record<GradientName, Matrix>) {
+        for (const name of GRADIENT_ORDER) {
+            const updated = Matrix.subtract(this.weightFor(name), Matrix.multiply(gradients[name], this.learningRate));
+            this.setWeightFor(name, updated);
+        }
+    }
+
+    /** The loss for a fixed sampling noise — used by both the monitor-free gradient check and forward. */
+    private lossWith (inputs: Matrix, noise: Matrix): number {
+        const encHidden = Matrix.transform(this.affine(inputs, this.encoderHidden), tanh);
+        const mean = this.affine(encHidden, this.meanHead);
+        const logVar = this.affine(encHidden, this.logVarHead);
+        const std = Matrix.transform(logVar, v => Math.exp(0.5 * v));
+        const z = Matrix.add(mean, hadamard(std, noise));
+        const output = this.generate(z);
+        return this.loss(output, inputs, mean, logVar);
+    }
+
+    private loss (output: Matrix, target: Matrix, mean: Matrix, logVar: Matrix): number {
+        const o = output.toArray(), t = target.toArray(), m = mean.toArray(), lv = logVar.toArray();
+        const n = o.length;
+        let recon = 0;
+        for (let i = 0; i < n; i++) for (let j = 0; j < o[i].length; j++) recon += crossEntropy(o[i][j], t[i][j]);
+        let kl = 0;
+        for (let i = 0; i < n; i++) for (let k = 0; k < m[i].length; k++) kl += -0.5 * (1 + lv[i][k] - m[i][k] ** 2 - Math.exp(lv[i][k]));
+        return (recon + this.beta * kl) / n;
+    }
+
+    private weightFor (name: GradientName): Matrix {
+        return this[name];
+    }
+
+    private setWeightFor (name: GradientName, value: Matrix) {
+        this[name] = value;
+    }
+}
+
+type GradientName = 'encoderHidden' | 'meanHead' | 'logVarHead' | 'decoderHidden' | 'decoderOutput';
+const GRADIENT_ORDER: GradientName[] = ['encoderHidden', 'meanHead', 'logVarHead', 'decoderHidden', 'decoderOutput'];
+
+function withBias (m: Matrix) {
+    return Matrix.appendLeft(m, Matrix.ones(m.getRowCount(), 1));
+}
+
+function dropBias (weights: Matrix) {
+    return weights.getRows(1); // drop the bias row (row 0)
+}
+
+function hadamard (a: Matrix, b: Matrix) {
+    return a.getClone().multiplyElementWise(b);
+}
+
+function tanh (value: number) {
+    return Math.tanh(value);
+}
+
+function tanhPrime (value: number) {
+    const t = Math.tanh(value);
+    return 1 - t * t;
+}
+
+function sigmoid (value: number) {
+    return 1 / (1 + Math.exp(-value));
+}
+
+function crossEntropy (prediction: number, target: number) {
+    const p = Math.min(1 - 1e-7, Math.max(1e-7, prediction));
+    return -(target * Math.log(p) + (1 - target) * Math.log(1 - p));
+}
+
+/** One standard-normal sample via Box–Muller, drawn from the given uniform generator. */
+function gaussian (random: () => number) {
+    let u = 0;
+    while (u === 0) u = random();
+    let v = 0;
+    while (v === 0) v = random();
+    return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}

--- a/src/test/VariationalAutoencoder.test.ts
+++ b/src/test/VariationalAutoencoder.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import VariationalAutoencoder from '../lib/machine-learning/unsupervised/VariationalAutoencoder';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+
+// 7×7 blobs again — a soft spot that only moves, so the data really has 2 degrees of freedom. A VAE
+// should both reconstruct them and organise its latent space into a standard normal we can sample.
+const W = 7;
+const SIZE = W * W;
+function blob(cx: number, cy: number): number[] {
+    const img: number[] = [];
+    for (let y = 0; y < W; y++) for (let x = 0; x < W; x++) img.push(Math.exp(-((x - cx) ** 2 + (y - cy) ** 2) / 4));
+    return img;
+}
+function blobDataset(count: number, seed = 1): Matrix {
+    let s = seed;
+    const rand = () => (s = (s * 48271) % 2147483647) / 2147483647;
+    const rows: number[][] = [];
+    for (let i = 0; i < count; i++) rows.push(blob(1.5 + rand() * 4, 1.5 + rand() * 4));
+    return new Matrix(rows);
+}
+const average = (values: number[]) => values.reduce((a, b) => a + b, 0) / values.length;
+
+// One trained VAE, reused across the reconstruction / latent / sampling tests.
+const data = blobDataset(80);
+const trained = new VariationalAutoencoder().setHiddenSize(24).setCodeSize(2).setBeta(1).setLearningRate(0.06).setNumberOfEpochs(1200).setSeed(0);
+const errorBeforeTraining = average(trained.reconstructionError(data));
+trained.train(data);
+
+describe('VariationalAutoencoder', () => {
+
+    it('verifies its reparameterised + KL backprop against finite differences', () => {
+        expect(new VariationalAutoencoder().checkGradients()).toBe(true);
+    });
+
+    it('learns to reconstruct its inputs', () => {
+        expect(average(trained.reconstructionError(data))).toBeLessThan(errorBeforeTraining);
+        expect(average(trained.reconstructionError(data))).toBeLessThan(0.45);
+    });
+
+    it('shapes the latent space into a standard normal', () => {
+        const codes = trained.encode(data).toArray();
+        for (let k = 0; k < 2; k++) {
+            const column = codes.map(c => c[k]);
+            const mean = average(column);
+            const std = Math.sqrt(average(column.map(v => (v - mean) ** 2)));
+            expect(Math.abs(mean)).toBeLessThan(0.4);          // centred near the origin…
+            expect(std).toBeGreaterThan(0.6);                  // …with roughly unit spread — the N(0,1)
+            expect(std).toBeLessThan(1.5);                     //   prior the KL term pulls it toward.
+        }
+    });
+
+    it('generates new, varied, blob-like samples from the prior', () => {
+        const samples = trained.sample(24, 9).toArray();
+        expect(samples.length).toBe(24);
+        expect(samples[0].length).toBe(SIZE);
+
+        // Each sample has a clear bright spot (not washed-out noise)…
+        const peaks = samples.map(img => Math.max(...img));
+        expect(average(peaks)).toBeGreaterThan(0.5);
+
+        // …and the blobs land in different places (the generator isn't collapsed to one image).
+        const centroids = samples.map(img => {
+            let cx = 0, sum = 0;
+            for (let y = 0; y < W; y++) for (let x = 0; x < W; x++) { cx += x * img[y * W + x]; sum += img[y * W + x]; }
+            return cx / (sum || 1);
+        });
+        const mean = average(centroids);
+        const spread = Math.sqrt(average(centroids.map(v => (v - mean) ** 2)));
+        expect(spread).toBeGreaterThan(0.3);
+    });
+
+    it('encodes, generates, and samples with the right shapes', () => {
+        expect(trained.encode(data).getColumnCount()).toBe(2);
+        expect(trained.generate(new Matrix([[0, 0], [1, -1]])).getColumnCount()).toBe(SIZE);
+        const drawn = trained.sample(5, 3);
+        expect(drawn.getRowCount()).toBe(5);
+        expect(drawn.getColumnCount()).toBe(SIZE);
+    });
+
+    it('is deterministic for a fixed seed', () => {
+        const run = () => {
+            const vae = new VariationalAutoencoder().setHiddenSize(8).setCodeSize(2).setNumberOfEpochs(80).setSeed(4);
+            vae.train(blobDataset(20));
+            return vae.sample(3, 1).toArray();
+        };
+        expect(run()).toEqual(run());
+    });
+
+    it('round-trips its hyperparameters and chains setters', () => {
+        const vae = new VariationalAutoencoder();
+        expect(vae.getCodeSize()).toBe(2);
+
+        const returned = vae.setInputSize(64).setHiddenSize(40).setCodeSize(3).setBeta(2).setLearningRate(0.01).setNumberOfEpochs(500).setSeed(7);
+        expect(returned).toBe(vae);
+        expect(vae.getInputSize()).toBe(64);
+        expect(vae.getHiddenSize()).toBe(40);
+        expect(vae.getCodeSize()).toBe(3);
+        expect(vae.getBeta()).toBe(2);
+        expect(vae.getLearningRate()).toBe(0.01);
+        expect(vae.getNumberOfEpochs()).toBe(500);
+        expect(vae.getSeed()).toBe(7);
+    });
+});


### PR DESCRIPTION
Chapter 29 — **Generative Models (VAE)**, continuing **Part 6 · The frontier**. Turns Chapter 28's autoencoder into a true generative model: shape the latent space into a samplable prior, then **invent** images that never existed.

## Library
- `VariationalAutoencoder` (in `src/lib/machine-learning/unsupervised/`): a from-scratch VAE. The encoder emits a per-input distribution (μ, logσ²); the **reparameterization trick** (`z = μ + σ·ε`) keeps the sampled code differentiable; a **KL term** presses the latent toward N(0,1). `train`, `encode`, `generate`, `reconstruct`, `sample` (z~N(0,1)→decode), `computeLoss`, finite-difference `checkGradients()` through the sampling + KL. Seeded, chainable.
- 7 tests: gradient check, reconstruction improves, **latent becomes ~N(0,1)** (μ≈0, σ≈1), generates peaked + varied samples, shapes, determinism, setter round-trip. (208 total pass.)
- Demo block (renders invented blobs from random codes), README section + keywords.

## Site
- `viz/vae.ts` — the **generative manifold** (decode a grid over the prior into a sheet of invented images) and a **sample gallery** (fixed random codes morphing into samples as it trains).
- `VariationalAutoencoderPlayground.tsx` + MDX tutorial (`content/generative-models.mdx`), registered as Ch 29 (reuses the Ch 28 datasets).
- `docs/course-plan.md` flipped Ch 29 ✅.

## Release
- Version bumped 0.15.0 → **0.16.0** (minor bump per new-algorithm batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)