### PR TITLE
Release 0.17.0: Bayesian Inference — course complete (Chapter 30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Below are some simple code usage examples.
 * [Deep Q-Network (DQN)](#deep-q-network-dqn)
 * [Autoencoder](#autoencoder)
 * [Variational Autoencoder (VAE)](#variational-autoencoder-vae)
+* [Bayesian Linear Regression](#bayesian-linear-regression)
 
 ### Feedforward Neural Network
 ```TypeScript
@@ -762,6 +763,37 @@ for (let y = 0; y < W; y++) console.log('  ' + [0, 1, 2].map(i => render(samples
 //     ..         .+++.       :++:                      latent space and a new image comes out. (Constrain
 //    .+:.        .::.        :++:                      that space to N(0,1) and that's exactly what makes
 //   .:##:.                   .::.                      the random draws land on plausible images.)
+
+```
+
+### Bayesian Linear Regression
+
+```TypeScript
+import * as ml from 'machine-learning';
+
+// Bayesian linear regression: a model that reports how *sure* it is. Instead of one best-fit curve it
+// keeps a whole distribution over curves, so every prediction comes with an error bar — tight where it
+// has data, fanning wide open where it doesn't (a gap, or past the edge). Here it sees noisy points from
+// a hidden sine, but only over the middle of the range.
+const truth = (x: number) => Math.sin(2 * Math.PI * x) * 0.5;
+let lcg = 1;
+const rng = () => (lcg = (lcg * 48271) % 2147483647) / 2147483647;
+const xs: number[][] = [], ys: number[][] = [];
+for (let i = 0; i < 30; i++) { const x = 0.25 + rng() * 0.4; xs.push([x]); ys.push([truth(x) + (rng() - 0.5) * 0.1]); }
+
+const model = new ml.BayesianLinearRegression();
+model.setBasis('gaussian').setNumberOfBases(6).setBasisWidth(0.15).setBeta(40);
+model.train(new ml.Matrix(xs), new ml.Matrix(ys));   // observed only over x in [0.25, 0.65]
+
+const grid = [0, 0.25, 0.45, 0.65, 1];
+const mean = model.predict(new ml.Matrix(grid.map(x => [x]))).toArray().map(r => r[0]);
+const std = model.predictiveStandardDeviation(new ml.Matrix(grid.map(x => [x])));
+grid.forEach((x, i) => console.log(`x=${x.toFixed(2)}  mean=${mean[i].toFixed(2)}  +/-${std[i].toFixed(2)}  ${'#'.repeat(Math.round(std[i] * 20))}`));
+// x=0.00  mean=-0.02  +/-0.57  ###########       <- no data out here: huge error bars (honest doubt)
+// x=0.25  mean= 0.45  +/-0.18  ####               <- has data: tight
+// x=0.45  mean= 0.17  +/-0.16  ###                <- has data: tight
+// x=0.65  mean=-0.36  +/-0.18  ####               <- has data: tight
+// x=1.00  mean=-0.14  +/-0.66  #############       <- extrapolating: the bars fan wide open
 
 ```
 

--- a/docs/course-plan.md
+++ b/docs/course-plan.md
@@ -26,7 +26,15 @@ generative). The built algorithms become the spine; everything else is roadmap.
 
 **Goal:** engaging, fun, genuinely educational, and very cool.
 
-**Status (this release).** Woven through **Ch 0–27** with no built-but-unwoven gaps: all of Part 1,
+**Status (this release).** 🎉 **The course is complete — all 31 chapters (Ch 0–30) across all six
+parts are built and woven into the story**, every algorithm written from scratch in `src/lib` with a
+playground and a tutorial chapter. The arc runs from the baseline predictors through regression,
+classification, trees/forests/boosting, SVMs, the unsupervised toolbox, time series, the full
+deep-learning stack (neural nets, CNNs, RNNs, Transformers), the reinforcement-learning arc (bandits →
+contextual bandits → Q-learning → deep RL), and the frontier (autoencoders, a VAE, and — the finale —
+Bayesian inference). Earlier status detail, retained for reference:
+
+Woven through **Ch 0–27** with no built-but-unwoven gaps: all of Part 1,
 the whole of Part 2 (k‑NN, Naive Bayes, Decision Trees, Random Forests, Gradient Boosting, Support
 Vector Machines), all of Part 3 (k‑Means, Hierarchical Clustering, DBSCAN, PCA, Anomaly Detection,
 Association Rules, Recommender Systems), all of Part 4 — Time Series, the Perceptron interlude, Neural
@@ -203,7 +211,7 @@ Every row's "Wall" is the previous tool failing.
 |---|---|---|---|---|
 | 28 | **Autoencoders** | Compress & denoise data; anomaly detection with nets | Need compact learned representations → encode→decode | ✅ `Autoencoder` (from scratch — symmetric encoder/decoder, MSE backprop, gradient-checked; compress + denoise + anomaly via reconstruction error; latent-manifold playground) |
 | 29 | **Generative Models (VAE/GAN/Diffusion)** | Invent new recipe ideas & marketing images | Don't classify — *create* → generative modeling | ✅ `VariationalAutoencoder` (built from scratch — reparameterisation trick + KL regulariser, gradient-checked; sample new images from the prior; exceeded the "adopts" plan. GAN/Diffusion covered as a field note) |
-| 30 | **Bayesian / Probabilistic Models** | "How *sure* are we?" before a big bet (signing the lease for store #3, a huge catering order) | Point predictions hide uncertainty → priors, posteriors, reasoning under uncertainty | ○ |
+| 30 | **Bayesian / Probabilistic Models** | "How *sure* are we?" before a big bet (signing the lease for store #3, a huge catering order) | Point predictions hide uncertainty → priors, posteriors, reasoning under uncertainty | ✅ `BayesianLinearRegression` (from scratch — conjugate posterior over weights, predictive mean + credible band that fans out away from data, posterior function samples; the course finale) |
 
 **Cross-cutting "Field Notes"** (recurring sidebars, threaded through the story, not standalone
 chapters): evaluation metrics (accuracy, precision/recall, RMSE, ROC), cross-validation,

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -453,6 +453,31 @@ import * as ml from '../src/lib';
 }
 
 {
+    // Bayesian linear regression: a model that reports how *sure* it is. We give it noisy points from a
+    // hidden curve, but only over the middle of the range — and ask it to predict everywhere, with error
+    // bars. Where it has data the bars are tight; out past the edges (extrapolation) they fan wide open.
+    const truth = (x: number) => Math.sin(2 * Math.PI * x) * 0.5;
+    let lcg = 1;
+    const rng = () => (lcg = (lcg * 48271) % 2147483647) / 2147483647;
+    const xs: number[][] = [], ys: number[][] = [];
+    for (let i = 0; i < 30; i++) { const x = 0.25 + rng() * 0.4; xs.push([x]); ys.push([truth(x) + (rng() - 0.5) * 0.1]); }
+
+    const model = new ml.BayesianLinearRegression().setBasis('gaussian').setNumberOfBases(6).setBasisWidth(0.15).setBeta(40);
+    model.train(new ml.Matrix(xs), new ml.Matrix(ys)); // observed only over x in [0.25, 0.65]
+
+    const grid = [0, 0.1, 0.25, 0.45, 0.65, 0.8, 1];
+    const mean = model.predict(new ml.Matrix(grid.map(x => [x]))).toArray().map(r => r[0]);
+    const std = model.predictiveStandardDeviation(new ml.Matrix(grid.map(x => [x])));
+    console.log('   x     mean    ±std   (■ = uncertainty)');
+    grid.forEach((x, i) => {
+        const inData = x >= 0.25 && x <= 0.65;
+        console.log(`  ${x.toFixed(2)}   ${mean[i].toFixed(2).padStart(5)}   ${std[i].toFixed(2)}  ${'■'.repeat(Math.round(std[i] * 20))}${inData ? '  <- has data' : ''}`);
+    });
+    // The ±std bars are short where the café has data (x in 0.25..0.65) and balloon at the edges —
+    // the model is honest that it's guessing out there. That admitted doubt is the whole point.
+}
+
+{
     // Naive Bayes (multinomial): classify messages by word counts.
     // Vocabulary [free, money, table, tonight]; one-hot classes [spam, ham].
     const inputs = new ml.Matrix([[2, 1, 0, 0], [1, 2, 0, 0], [0, 0, 2, 1], [0, 0, 1, 2]]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-learning",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "TypeScript & JavaScript machine learning library",
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,11 @@
     "variational autoencoder",
     "vae",
     "generative model",
-    "generative ai"
+    "generative ai",
+    "bayesian",
+    "bayesian regression",
+    "uncertainty",
+    "probabilistic"
   ],
   "author": "Erik Gerrits <gerrits.erik@gmail.com>",
   "license": "MIT",

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -39,6 +39,7 @@ const QLearningTutorial = lazy(() => import('./content/q-learning.mdx'));
 const DeepRlTutorial = lazy(() => import('./content/deep-rl.mdx'));
 const AutoencodersTutorial = lazy(() => import('./content/autoencoders.mdx'));
 const GenerativeModelsTutorial = lazy(() => import('./content/generative-models.mdx'));
+const BayesianRegressionTutorial = lazy(() => import('./content/bayesian-regression.mdx'));
 
 export function App() {
     return (
@@ -290,6 +291,14 @@ export function App() {
                     element={
                         <TutorialPage>
                             <GenerativeModelsTutorial />
+                        </TutorialPage>
+                    }
+                />
+                <Route
+                    path="bayesian-regression"
+                    element={
+                        <TutorialPage>
+                            <BayesianRegressionTutorial />
                         </TutorialPage>
                     }
                 />

--- a/site/src/algorithms.ts
+++ b/site/src/algorithms.ts
@@ -303,4 +303,13 @@ export const ALGORITHMS: AlgorithmEntry[] = [
         chapter: 29,
         part: PART_6,
     },
+    {
+        id: 'bayesian-regression',
+        path: '/bayesian-regression',
+        title: 'Bayesian Inference',
+        tagline: 'Predict with honest error bars — tight where there is data, wide where there is not.',
+        status: 'live',
+        chapter: 30,
+        part: PART_6,
+    },
 ];

--- a/site/src/components/BayesianLinearRegressionPlayground.module.css
+++ b/site/src/components/BayesianLinearRegressionPlayground.module.css
@@ -1,0 +1,65 @@
+.playground {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 520px) minmax(220px, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+.plotWrap {
+    position: relative;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
+    aspect-ratio: 4 / 3;
+    background: #0b1120;
+}
+
+.plot {
+    width: 100%;
+    height: 100%;
+}
+
+.legend {
+    position: absolute;
+    bottom: 10px;
+    left: 12px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 14px;
+    font-size: 12px;
+    background: rgba(11, 17, 32, 0.6);
+    padding: 4px 10px;
+    border-radius: 999px;
+    backdrop-filter: blur(4px);
+}
+
+.side {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.note {
+    margin: 0;
+    font-size: 13px;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+
+    .stage {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/BayesianLinearRegressionPlayground.tsx
+++ b/site/src/components/BayesianLinearRegressionPlayground.tsx
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { BayesianLinearRegression, Matrix } from 'machine-learning';
+import type { BayesianBasis } from 'machine-learning';
+import { BAYESIAN_SCENARIOS, type BayesianScenario } from '../ml/bayesianDatasets';
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+import { drawBayesian } from '../viz/bayesian';
+import { Card, Checkbox, ControlPanel, Hint, Metric, MetricsRow, RunControls, Select, Slider } from './controls/Controls';
+import styles from './BayesianLinearRegressionPlayground.module.css';
+
+const GRID = 120;
+const SAMPLES = 8;
+const REVEAL_EVERY = 5; // frames between revealing one more observation
+
+export function BayesianLinearRegressionPlayground() {
+    const [scenarioId, setScenarioId] = useState(BAYESIAN_SCENARIOS[0].id);
+    const [basis, setBasis] = useState<BayesianBasis>('gaussian');
+    const [complexity, setComplexity] = useState(6);  // gaussian bases, or polynomial degree
+    const [alphaSlider, setAlphaSlider] = useState(10); // alpha = slider / 10
+    const [betaSlider, setBetaSlider] = useState(40);   // beta = slider
+    const [seed, setSeed] = useState(0);
+    const [showSamples, setShowSamples] = useState(true);
+    const [showTruth, setShowTruth] = useState(true);
+    const [running, setRunning] = useState(false);
+    const [metrics, setMetrics] = useState({ points: 0, avgStd: 0 });
+
+    const alpha = alphaSlider / 10;
+    const beta = betaSlider;
+
+    const scenario = useMemo<BayesianScenario>(() => BAYESIAN_SCENARIOS.find(s => s.id === scenarioId) ?? BAYESIAN_SCENARIOS[0], [scenarioId]);
+    const gridX = useMemo(() => Array.from({ length: GRID }, (_, i) => scenario.domain[0] + (scenario.domain[1] - scenario.domain[0]) * (i / (GRID - 1))), [scenario]);
+    const trueY = useMemo(() => gridX.map(scenario.truth), [gridX, scenario]);
+
+    const pointsRef = useRef<{ x: number; y: number }[]>([]);
+    const revealedRef = useRef(1);
+    const frameRef = useRef(0);
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const fitAndDraw = useCallback(() => {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        const shown = pointsRef.current.slice(0, revealedRef.current);
+
+        const model = new BayesianLinearRegression()
+            .setBasis(basis)
+            .setNumberOfBases(complexity).setDegree(complexity)
+            .setBasisWidth((scenario.domain[1] - scenario.domain[0]) / complexity)
+            .setAlpha(alpha).setBeta(beta).setSeed(seed + 1);
+        model.train(new Matrix(shown.map(p => [p.x])), new Matrix(shown.map(p => [p.y])));
+
+        const gridMatrix = new Matrix(gridX.map(x => [x]));
+        const meanY = model.predict(gridMatrix).toArray().map(r => r[0]);
+        const stdY = model.predictiveStandardDeviation(gridMatrix);
+        const samples = showSamples ? model.sample(gridMatrix, SAMPLES, seed + 7) : [];
+
+        drawBayesian(canvas, {
+            domain: scenario.domain, yRange: scenario.yRange,
+            gridX, meanY, stdY, samples, trueY, points: shown, showSamples, showTruth,
+        });
+        setMetrics({ points: shown.length, avgStd: Math.round((stdY.reduce((a, b) => a + b, 0) / stdY.length) * 1000) / 1000 });
+    }, [basis, complexity, alpha, beta, seed, showSamples, showTruth, scenario, gridX, trueY]);
+
+    const reset = useCallback(() => {
+        pointsRef.current = scenario.generate(seed + 1);
+        revealedRef.current = 1;
+        frameRef.current = 0;
+        setRunning(false);
+        fitAndDraw();
+    }, [scenario, seed, fitAndDraw]);
+
+    useEffect(() => { reset(); }, [reset]);
+    // Refit (without re-revealing) when only the model knobs change.
+    useEffect(() => { fitAndDraw(); }, [fitAndDraw]);
+
+    const tick = useCallback(() => {
+        frameRef.current += 1;
+        if (frameRef.current % REVEAL_EVERY !== 0) return;
+        if (revealedRef.current >= pointsRef.current.length) { setRunning(false); return; }
+        revealedRef.current += 1;
+        fitAndDraw();
+    }, [fitAndDraw]);
+
+    useAnimationFrame(tick, running);
+
+    const handleStep = () => {
+        if (running) return;
+        if (revealedRef.current < pointsRef.current.length) revealedRef.current += 1;
+        fitAndDraw();
+    };
+    const handleReset = () => { setRunning(false); reset(); };
+
+    return (
+        <div className={styles.playground}>
+            <ControlPanel>
+                <RunControls running={running} onToggle={() => setRunning(r => !r)} onStep={handleStep} onReset={handleReset} />
+                <Select label="Data" value={scenarioId} options={BAYESIAN_SCENARIOS.map(s => ({ value: s.id, label: s.label }))} onChange={setScenarioId} />
+                <Hint>{scenario.blurb}</Hint>
+                <Select
+                    label="Basis"
+                    value={basis}
+                    options={[{ value: 'gaussian', label: 'Gaussian bumps' }, { value: 'polynomial', label: 'Polynomial' }]}
+                    onChange={v => setBasis(v as BayesianBasis)}
+                />
+                <Slider label={basis === 'gaussian' ? 'Bumps' : 'Degree'} value={complexity} display={String(complexity)} min={2} max={9} onChange={setComplexity} />
+                <Slider label="Prior strength α" value={alphaSlider} display={alpha.toFixed(1)} min={1} max={60} onChange={setAlphaSlider} />
+                <Slider label="Noise precision β" value={betaSlider} display={String(beta)} min={5} max={120} onChange={setBetaSlider} />
+                <Slider label="Random seed" value={seed} display={String(seed)} min={0} max={9} onChange={setSeed} />
+                <Checkbox label="Posterior samples" checked={showSamples} onChange={setShowSamples} />
+                <Checkbox label="Show hidden truth" checked={showTruth} onChange={setShowTruth} />
+                <Hint>Press Train to reveal the data point by point — watch the shaded band collapse onto the evidence and stay wide where there is none.</Hint>
+            </ControlPanel>
+
+            <div className={styles.stage}>
+                <div className={styles.plotWrap}>
+                    <canvas ref={canvasRef} className={styles.plot} />
+                    <div className={styles.legend}>
+                        <span style={{ color: '#fb923c' }}>● data</span>
+                        <span style={{ color: '#38bdf8' }}>— mean fit</span>
+                        <span style={{ color: 'rgba(56,189,248,0.7)' }}>▭ ±2σ band</span>
+                        <span style={{ color: '#94a3b8' }}>┄ truth</span>
+                    </div>
+                </div>
+
+                <div className={styles.side}>
+                    <MetricsRow>
+                        <Metric label="Observations" value={String(metrics.points)} />
+                        <Metric label="Avg ±σ" value={metrics.avgStd.toFixed(3)} />
+                    </MetricsRow>
+
+                    <Card title="The band is the point" subtitle="honest doubt">
+                        <p className={styles.note}>
+                            The shaded region is the model&apos;s <strong>95% credible band</strong> — where it
+                            believes the true curve lies. It hugs the data tightly and flares open wherever points
+                            are missing. That admitted uncertainty, not just the blue mean line, is what tells you
+                            when the model is guessing.
+                        </p>
+                    </Card>
+
+                    <Card title="Prior vs. evidence" subtitle="α and β">
+                        <p className={styles.note}>
+                            Before any data the band is the <em>prior</em> — a vague flat guess. Each point is
+                            <em> evidence</em> that sharpens it. <strong>α</strong> sets how strongly the prior pulls
+                            toward a flat line (more α = steadier but stiffer); <strong>β</strong> is how much the
+                            model trusts each point (more β = it hugs the data harder). The posterior is their balance.
+                        </p>
+                    </Card>
+
+                    <Card title="The whole course, in one band" subtitle="the finale">
+                        <p className={styles.note}>
+                            Chapter 1 fit a single line. This one fits a <em>distribution</em> over lines and reports
+                            what it doesn&apos;t know — the difference between a confident guess and an honest one.
+                            From a shoebox of receipts to reasoning under uncertainty: that&apos;s the whole arc.
+                        </p>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/site/src/content/bayesian-regression.mdx
+++ b/site/src/content/bayesian-regression.mdx
@@ -1,0 +1,110 @@
+import { BayesianLinearRegressionPlayground } from '../components/BayesianLinearRegressionPlayground';
+
+# Chapter 30 — Knowing what you don't know
+
+> *Bayesian inference.* Every model in this course has answered with total confidence — a number, a
+> class, an image — and never once said how *sure* it was. The final idea fixes that: instead of a
+> single best fit, keep a whole **distribution** over answers, and report the spread. A model that
+> knows the difference between a good guess and a wild one.
+
+Nadia is about to sign the lease on store #3 — the biggest bet of her life. Her demand model says it'll
+work. But that model is the same kind that, back in Chapter 1, drew one confident line through the
+data. One line. What she actually needs to know isn't just the prediction — it's *how much to trust
+it*, especially for a neighbourhood unlike any café she's run. A point estimate can't tell her that.
+
+## The wall: a single answer hides its own doubt
+
+Every regressor so far returned one curve — the best fit to the data it saw. But "best fit" says
+nothing about confidence. Two situations can give the identical line: one where a thousand points pin
+it down, and one where three points barely suggest it. The line looks just as bold either way.
+Worse, ask it to predict somewhere it has *no* data — a new neighbourhood, next year's prices — and it
+answers with the same flat confidence as it does in the thick of the data. The model can't distinguish
+*"I know this"* from *"I'm guessing."* For a decision that matters, that missing humility is the whole
+ballgame.
+
+## The idea: keep the whole distribution
+
+So stop committing to one curve. Start with a **prior** — a vague belief about what curves are
+plausible before seeing data (gentle, not-too-wiggly ones). Then treat each observation as **evidence**
+that updates that belief into a **posterior**: a distribution over *all* the curves still consistent
+with what you've seen. Many curves fit the data near the points, so confidence is high there; but far
+from any data, wildly different curves all remain plausible, so the posterior stays broad. That spread,
+turned into an error bar at every input, is the model saying exactly how much it knows where.
+
+For a linear model with Gaussian noise this is **closed-form** — no training loop, just algebra. The
+posterior over the weights is itself a Gaussian, and so is the prediction at any point, with a variance
+that grows wherever the data didn't constrain things:
+
+$$
+\text{prediction at } x \sim \mathcal{N}\big(m_N^{\top}\phi(x),\;\; \underbrace{1/\beta}_{\text{noise}} + \underbrace{\phi(x)^{\top} S_N\, \phi(x)}_{\text{how unsure}}\big)
+$$
+
+Below, the data is revealed point by point. Press **Train** and watch the shaded band — the model's
+*credible region* — collapse onto the evidence as it arrives, while staying wide open everywhere it has
+none:
+
+<div className="breakout">
+  <BayesianLinearRegressionPlayground />
+</div>
+
+## How it works: a posterior in closed form
+
+The input `x` is expanded through basis functions `φ(x)` (Gaussian bumps or polynomial powers) so the
+fit can curve. A Gaussian prior on the weights meets the data, and the posterior covariance and mean
+come straight out — from the
+[`BayesianLinearRegression`](https://github.com/erikgerrits/machine-learning/blob/master/src/lib/machine-learning/supervised/BayesianLinearRegression.ts)
+source:
+
+```ts
+// A = α·I + β·ΦᵀΦ ;  posterior covariance Sₙ = A⁻¹ ;  posterior mean mₙ = β·Sₙ·Φᵀy
+const a = Matrix.add(Matrix.multiply(Matrix.identity(m), this.alpha), Matrix.multiply(Matrix.multiply(phiT, phi), this.beta));
+this.covariance = a.getInverse();
+this.meanWeights = Matrix.multiply(Matrix.multiply(Matrix.multiply(this.covariance, phiT), targets), this.beta);
+```
+
+The error bar at a new point is the noise floor plus an *epistemic* term — the part that shrinks with
+evidence and grows without it:
+
+```ts
+// predictive variance = 1/β + φ(x)ᵀ Sₙ φ(x)
+result.push(Math.sqrt(noiseVariance + epistemic));
+```
+
+And because the posterior over weights is a full Gaussian, you can **draw whole curves** from it — each
+a plausible explanation of the data. They thread tightly through the points and spray apart where the
+evidence runs out, which is exactly the picture of uncertainty the band summarises.
+
+## Try it yourself
+
+- **Watch the band breathe.** Start with one point — the band is huge, barely past the flat prior. Each
+  new observation snaps it tighter *locally*. By the end it clings to the data and balloons only at the
+  edges, where the model is honestly extrapolating.
+- **The gap.** Switch to that dataset: even *surrounded* by data, the band bulges across the hole in the
+  middle. The model won't pretend to know what happens where it never looked.
+- **α and β.** Raise **α** and the prior pulls harder — a steadier fit that resists the data (good when
+  points are scarce, stubborn when they're plentiful). Raise **β** and the model trusts each point more,
+  hugging them closely. The posterior is the tug-of-war between prior belief and evidence.
+- **Posterior samples.** Toggle them on: each thin curve is one plausible truth. Where they bunch into a
+  rope, the model is sure; where they fan into a brush, it isn't.
+
+> **Field note — Bayes is a lens, not one algorithm.** The same prior → evidence → posterior move
+> underlies far more than this line. Put a prior on a coin's bias and you get the Beta-Bernoulli updates
+> behind A/B tests; put it over functions directly and you get **Gaussian processes**; carry posteriors
+> through a neural network and you get the Bayesian deep learning used where calibrated uncertainty is
+> safety-critical. When the data is thin and the stakes are high, reasoning about *distributions* rather
+> than point estimates is the move.
+
+## What broke — nothing; and the ledger comes full circle
+
+Nothing broke. Nadia's model can finally say not just *"demand will be this"* but *"…and here's how
+sure I am"* — tight bars over familiar ground, wide ones over the unknown neighbourhood. That honesty,
+not a bolder point estimate, is what lets her weigh the lease with open eyes.
+
+And that closes the book. Thirty chapters ago there was a failing café and a shoebox of receipts, and
+the only tools were the average and a hunch. From there: a line through demand, then many features,
+then the wall of overfitting; classifiers and trees and forests; clustering and compression and
+recommendation; neural networks that see and read and attend; agents that act and learn from
+consequences; models that dream up new data; and now, at the end, a model that knows the limits of its
+own knowledge. Every chapter was the same move — find the wall, then find the idea that breaks it — and
+every one is built from scratch in this little library, no magic imported. The café learned to think.
+The map (`docs/course-plan.md`) has no chapters left unbuilt. Thanks for reading to the end. ☕

--- a/site/src/ml/bayesianDatasets.ts
+++ b/site/src/ml/bayesianDatasets.ts
@@ -1,0 +1,59 @@
+// Datasets for the Bayesian-regression playground. Each is a hidden curve plus a layout of noisy
+// observations that deliberately leaves some of the domain *unobserved* — an empty edge, a gap in the
+// middle, or just sparse coverage — so you can watch the model's error bars stay wide exactly where it
+// has no evidence. The playground reveals the points one at a time and refits after each.
+
+export interface BayesianScenario {
+    id: string;
+    label: string;
+    blurb: string;
+    domain: [number, number];
+    yRange: [number, number];
+    truth: (x: number) => number;
+    /** A fixed layout of observations (already noisy), revealed incrementally by the playground. */
+    generate: (seed: number) => { x: number; y: number }[];
+}
+
+function noisyPoints(seed: number, xs: number[], truth: (x: number) => number, noise: number) {
+    let s = seed;
+    const rand = () => (s = (s * 48271) % 2147483647) / 2147483647;
+    return xs.map(x => ({ x, y: truth(x) + (rand() - 0.5) * 2 * noise }));
+}
+
+function spread(seed: number, count: number, lo: number, hi: number): number[] {
+    let s = seed * 7 + 1;
+    const rand = () => (s = (s * 48271) % 2147483647) / 2147483647;
+    return Array.from({ length: count }, () => lo + rand() * (hi - lo)).sort((a, b) => a - b);
+}
+
+const WAVE = (x: number) => Math.sin(2 * Math.PI * x) * 0.6;
+
+export const BAYESIAN_SCENARIOS: BayesianScenario[] = [
+    {
+        id: 'unseen-edges',
+        label: 'Unseen edges',
+        blurb: 'All the data sits in the middle; the model has never seen the edges. Watch the error band collapse onto the points but flare out as soon as it has to extrapolate past them.',
+        domain: [0, 1],
+        yRange: [-1.4, 1.4],
+        truth: WAVE,
+        generate: (seed) => noisyPoints(seed, spread(seed, 28, 0.22, 0.72), WAVE, 0.08),
+    },
+    {
+        id: 'the-gap',
+        label: 'The gap',
+        blurb: 'Two clusters of data with a hole between them. The band stays tight on each cluster and balloons across the gap — honest that it is guessing where it has no points, even surrounded by data.',
+        domain: [0, 1],
+        yRange: [-1.4, 1.4],
+        truth: WAVE,
+        generate: (seed) => noisyPoints(seed, [...spread(seed, 13, 0.05, 0.32), ...spread(seed + 1, 13, 0.68, 0.95)], WAVE, 0.08),
+    },
+    {
+        id: 'sparse',
+        label: 'Sparse evidence',
+        blurb: 'Only a handful of points across the whole range. The band pinches in at each one and bulges between them — more data anywhere will tighten it there.',
+        domain: [0, 1],
+        yRange: [-1.2, 1.2],
+        truth: (x) => 0.75 * Math.exp(-((x - 0.45) ** 2) / 0.05) - 0.35,
+        generate: (seed) => noisyPoints(seed, spread(seed, 9, 0.05, 0.95), (x) => 0.75 * Math.exp(-((x - 0.45) ** 2) / 0.05) - 0.35, 0.06),
+    },
+];

--- a/site/src/viz/bayesian.ts
+++ b/site/src/viz/bayesian.ts
@@ -1,0 +1,87 @@
+import { fitCanvas } from './canvas';
+
+// A 1-D regression plot built to make *uncertainty* the star: a shaded 95% credible band (mean ± 2σ)
+// that pinches onto the data and flares where there's none, a few posterior sample curves threading
+// through it, the posterior-mean fit, the revealed observations, and the hidden truth for reference.
+
+export interface BayesianView {
+    domain: [number, number];
+    yRange: [number, number];
+    gridX: number[];
+    meanY: number[];
+    stdY: number[];
+    samples: number[][];      // posterior function samples over gridX
+    trueY: number[];          // hidden truth over gridX
+    points: { x: number; y: number }[];
+    showSamples: boolean;
+    showTruth: boolean;
+}
+
+export function drawBayesian(canvas: HTMLCanvasElement, view: BayesianView): void {
+    const { ctx, width, height } = fitCanvas(canvas);
+    ctx.fillStyle = '#0b1120';
+    ctx.fillRect(0, 0, width, height);
+
+    const padL = 8, padR = 8, padT = 10, padB = 10;
+    const plotW = width - padL - padR;
+    const plotH = height - padT - padB;
+    const [x0, x1] = view.domain;
+    const [y0, y1] = view.yRange;
+    const px = (x: number) => padL + ((x - x0) / (x1 - x0)) * plotW;
+    const py = (y: number) => padT + (1 - (y - y0) / (y1 - y0)) * plotH;
+
+    // Zero line.
+    ctx.strokeStyle = 'rgba(148,163,184,0.18)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(padL, py(0));
+    ctx.lineTo(width - padR, py(0));
+    ctx.stroke();
+
+    const n = view.gridX.length;
+
+    // 95% credible band: mean ± 2σ.
+    ctx.beginPath();
+    for (let i = 0; i < n; i++) { const x = px(view.gridX[i]); const y = py(view.meanY[i] + 2 * view.stdY[i]); i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y); }
+    for (let i = n - 1; i >= 0; i--) ctx.lineTo(px(view.gridX[i]), py(view.meanY[i] - 2 * view.stdY[i]));
+    ctx.closePath();
+    ctx.fillStyle = 'rgba(56, 189, 248, 0.16)';
+    ctx.fill();
+
+    // Posterior sample curves.
+    if (view.showSamples) {
+        ctx.strokeStyle = 'rgba(56, 189, 248, 0.4)';
+        ctx.lineWidth = 1;
+        for (const sample of view.samples) {
+            ctx.beginPath();
+            for (let i = 0; i < n; i++) { const x = px(view.gridX[i]), y = py(sample[i]); i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y); }
+            ctx.stroke();
+        }
+    }
+
+    // Hidden truth (dashed).
+    if (view.showTruth) {
+        ctx.strokeStyle = 'rgba(148, 163, 184, 0.55)';
+        ctx.lineWidth = 1.5;
+        ctx.setLineDash([5, 5]);
+        ctx.beginPath();
+        for (let i = 0; i < n; i++) { const x = px(view.gridX[i]), y = py(view.trueY[i]); i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y); }
+        ctx.stroke();
+        ctx.setLineDash([]);
+    }
+
+    // Posterior mean fit.
+    ctx.strokeStyle = '#38bdf8';
+    ctx.lineWidth = 2.5;
+    ctx.beginPath();
+    for (let i = 0; i < n; i++) { const x = px(view.gridX[i]), y = py(view.meanY[i]); i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y); }
+    ctx.stroke();
+
+    // Observations.
+    ctx.fillStyle = '#fb923c';
+    for (const point of view.points) {
+        ctx.beginPath();
+        ctx.arc(px(point.x), py(point.y), 3.5, 0, Math.PI * 2);
+        ctx.fill();
+    }
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,7 @@
 export { default as AnomalyDetector } from "./machine-learning/unsupervised/AnomalyDetector";
 export { default as AssociationRules } from "./machine-learning/unsupervised/AssociationRules";
+export { default as BayesianLinearRegression } from "./machine-learning/supervised/BayesianLinearRegression";
+export type { BayesianBasis } from "./machine-learning/supervised/BayesianLinearRegression";
 export { default as Autoencoder } from "./machine-learning/unsupervised/Autoencoder";
 export type { AssociationRule, FrequentItemset } from "./machine-learning/unsupervised/AssociationRules";
 export { default as ContextualBandit } from "./machine-learning/reinforcement/ContextualBandit";

--- a/src/lib/machine-learning/supervised/BayesianLinearRegression.ts
+++ b/src/lib/machine-learning/supervised/BayesianLinearRegression.ts
@@ -1,0 +1,192 @@
+import Matrix from "../../math/linear-algebra/Matrix";
+import mulberry32 from "../../math/random/mulberry32";
+
+/** Which basis functions the regression expands its single input into before fitting a linear model. */
+export type BayesianBasis = "gaussian" | "polynomial";
+
+/**
+ * **Bayesian linear regression** — the course finale, and the model that finally admits what it
+ * *doesn't* know. Every regressor so far returned a single best-fit line; this one keeps a whole
+ * **distribution** over the possible lines and reports, for any input, not just a prediction but how
+ * *sure* it is. Near your data it's confident; far from it — extrapolating past the edge, or in a gap —
+ * the uncertainty fans out, exactly as honesty demands before a big bet.
+ *
+ * The machinery is conjugate Bayesian inference, in closed form (no sampling needed to fit). The input
+ * `x` is expanded through basis functions `φ(x)` (Gaussian bumps or polynomial powers) so the "line" can
+ * curve. A Gaussian **prior** `w ~ N(0, α⁻¹I)` on the weights meets the data through a Gaussian noise
+ * model (precision `β`), and the **posterior** over weights is again Gaussian:
+ *
+ * ```
+ * Sₙ = (α·I + β·ΦᵀΦ)⁻¹           // posterior covariance — shrinks as data accumulates
+ * mₙ = β·Sₙ·Φᵀy                  // posterior mean weights (the best-fit curve)
+ * ```
+ *
+ * For a new input the **predictive distribution** is Gaussian too, with variance `1/β + φ(x)ᵀSₙφ(x)`:
+ * the noise floor `1/β` plus an *epistemic* term that grows wherever the data didn't pin the weights
+ * down. {@link predict} returns the mean curve, {@link predictiveStandardDeviation} the error bars, and
+ * {@link sample} draws whole plausible curves from the posterior — tight bundles near data, spreading
+ * wildly where there's none.
+ *
+ * @example
+ * const model = new BayesianLinearRegression().setBasis('gaussian').setNumberOfBases(6);
+ * model.train(x, y);
+ * model.predict(grid);                          // the mean fit
+ * model.predictiveStandardDeviation(grid);      // ± how sure, point by point
+ */
+export default class BayesianLinearRegression {
+
+    private basis: BayesianBasis = "gaussian";
+    private degree = 4;          // polynomial basis: highest power
+    private numberOfBases = 6;    // gaussian basis: number of bumps
+    private basisWidth = 0.15;    // gaussian bump width (in input units)
+    private alpha = 1;            // prior precision — larger ⇒ stronger pull toward a flat line
+    private beta = 25;            // noise precision (1/variance); noise std = 1/√β
+    private seed = 0;
+
+    private centers: number[] = [];
+    private meanWeights: Matrix;     // M × 1
+    private covariance: Matrix;      // M × M (posterior Sₙ)
+
+    public constructor () {}
+
+    /** Fit the posterior over weights from inputs (N × 1) and targets (N × 1). */
+    public train (inputs: Matrix, targets: Matrix) {
+        this.prepareCenters(inputs);
+        const phi = this.designMatrix(inputs);          // N × M
+        const phiT = Matrix.transpose(phi);
+        const m = phi.getColumnCount();
+
+        // A = α·I + β·ΦᵀΦ ; posterior covariance Sₙ = A⁻¹.
+        const a = Matrix.add(Matrix.multiply(Matrix.identity(m), this.alpha), Matrix.multiply(Matrix.multiply(phiT, phi), this.beta));
+        this.covariance = a.getInverse();
+        // Posterior mean mₙ = β·Sₙ·Φᵀ·y.
+        this.meanWeights = Matrix.multiply(Matrix.multiply(Matrix.multiply(this.covariance, phiT), targets), this.beta);
+        return this;
+    }
+
+    /** The posterior-mean prediction for each input (N × 1). */
+    public predict (inputs: Matrix) {
+        return Matrix.multiply(this.designMatrix(inputs), this.meanWeights);
+    }
+
+    /** The predictive standard deviation at each input — the error bar that grows away from the data. */
+    public predictiveStandardDeviation (inputs: Matrix): number[] {
+        const phi = this.designMatrix(inputs);
+        const sPhiT = Matrix.multiply(this.covariance, Matrix.transpose(phi)); // M × N
+        const noiseVariance = 1 / this.beta;
+        const result: number[] = [];
+        for (let r = 0; r < phi.getRowCount(); r++) {
+            let epistemic = 0; // φ(x)ᵀ Sₙ φ(x)
+            for (let c = 0; c < phi.getColumnCount(); c++) epistemic += phi.getElement(r, c) * sPhiT.getElement(c, r);
+            result.push(Math.sqrt(Math.max(0, noiseVariance + epistemic)));
+        }
+        return result;
+    }
+
+    /** Draw `count` whole curves from the posterior over functions, evaluated at `inputs` (count × N). */
+    public sample (inputs: Matrix, count: number, seed?: number): number[][] {
+        const random = mulberry32(seed === undefined ? this.seed : seed);
+        const phi = this.designMatrix(inputs);
+        const lower = cholesky(this.covariance.toArray()); // Sₙ = L·Lᵀ
+        const mean = this.meanWeights.toArray().map(row => row[0]);
+        const m = mean.length;
+
+        const curves: number[][] = [];
+        for (let s = 0; s < count; s++) {
+            const z = Array.from({ length: m }, () => gaussian(random));
+            const weights = mean.map((mu, i) => {
+                let lz = 0;
+                for (let j = 0; j <= i; j++) lz += lower[i][j] * z[j]; // (L·z)_i, L lower-triangular
+                return mu + lz;
+            });
+            const curve: number[] = [];
+            for (let r = 0; r < phi.getRowCount(); r++) {
+                let value = 0;
+                for (let c = 0; c < m; c++) value += phi.getElement(r, c) * weights[c];
+                curve.push(value);
+            }
+            curves.push(curve);
+        }
+        return curves;
+    }
+
+    /* Parameter setters */
+
+    public setBasis (basis: BayesianBasis) { this.basis = basis; return this; }
+    public setDegree (degree: number) { this.degree = degree; return this; }
+    public setNumberOfBases (numberOfBases: number) { this.numberOfBases = numberOfBases; return this; }
+    public setBasisWidth (basisWidth: number) { this.basisWidth = basisWidth; return this; }
+    public setAlpha (alpha: number) { this.alpha = alpha; return this; }
+    public setBeta (beta: number) { this.beta = beta; return this; }
+    public setSeed (seed: number) { this.seed = seed; return this; }
+
+    /* Parameter getters */
+
+    public getBasis () { return this.basis; }
+    public getDegree () { return this.degree; }
+    public getNumberOfBases () { return this.numberOfBases; }
+    public getBasisWidth () { return this.basisWidth; }
+    public getAlpha () { return this.alpha; }
+    public getBeta () { return this.beta; }
+    public getSeed () { return this.seed; }
+    /** The posterior-mean weight vector. */
+    public getWeights () { return this.meanWeights.toArray().map(row => row[0]); }
+
+    /* Private methods */
+
+    private prepareCenters (inputs: Matrix) {
+        if (this.basis !== "gaussian") return;
+        let min = Infinity, max = -Infinity;
+        for (let r = 0; r < inputs.getRowCount(); r++) {
+            min = Math.min(min, inputs.getElement(r, 0));
+            max = Math.max(max, inputs.getElement(r, 0));
+        }
+        if (!isFinite(min)) { min = 0; max = 1; }
+        this.centers = [];
+        for (let i = 0; i < this.numberOfBases; i++) {
+            this.centers.push(this.numberOfBases === 1 ? (min + max) / 2 : min + (max - min) * (i / (this.numberOfBases - 1)));
+        }
+    }
+
+    /** Expand each input row into its basis-function features (N × M, including a bias column). */
+    private designMatrix (inputs: Matrix): Matrix {
+        const rows: number[][] = [];
+        for (let r = 0; r < inputs.getRowCount(); r++) rows.push(this.features(inputs.getElement(r, 0)));
+        return new Matrix(rows);
+    }
+
+    private features (x: number): number[] {
+        if (this.basis === "polynomial") {
+            const row = [1];
+            for (let d = 1; d <= this.degree; d++) row.push(x ** d);
+            return row;
+        }
+        const row = [1]; // bias
+        for (const center of this.centers) row.push(Math.exp(-((x - center) ** 2) / (2 * this.basisWidth ** 2)));
+        return row;
+    }
+}
+
+/** Cholesky decomposition of a symmetric positive-definite matrix: returns lower-triangular L with L·Lᵀ = A. */
+function cholesky (a: number[][]): number[][] {
+    const n = a.length;
+    const l: number[][] = Array.from({ length: n }, () => new Array<number>(n).fill(0));
+    for (let i = 0; i < n; i++) {
+        for (let j = 0; j <= i; j++) {
+            let sum = 0;
+            for (let k = 0; k < j; k++) sum += l[i][k] * l[j][k];
+            if (i === j) l[i][j] = Math.sqrt(Math.max(1e-12, a[i][i] - sum));
+            else l[i][j] = (a[i][j] - sum) / l[j][j];
+        }
+    }
+    return l;
+}
+
+/** One standard-normal sample via Box–Muller. */
+function gaussian (random: () => number): number {
+    let u = 0;
+    while (u === 0) u = random();
+    let v = 0;
+    while (v === 0) v = random();
+    return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}

--- a/src/test/BayesianLinearRegression.test.ts
+++ b/src/test/BayesianLinearRegression.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import BayesianLinearRegression from '../lib/machine-learning/supervised/BayesianLinearRegression';
+import Matrix from '../lib/math/linear-algebra/Matrix';
+
+// A hidden sine, sampled (with a little noise) only over the middle of the range — leaving the edges
+// unobserved, so we can watch the model stay confident where it has data and grow unsure where it doesn't.
+const f = (x: number) => Math.sin(2 * Math.PI * x) * 0.5;
+function dataset(count: number, seed = 1): { X: Matrix; Y: Matrix } {
+    let s = seed;
+    const rand = () => (s = (s * 48271) % 2147483647) / 2147483647;
+    const xs: number[][] = [], ys: number[][] = [];
+    for (let i = 0; i < count; i++) {
+        const x = 0.2 + rand() * 0.45; // observed only within [0.2, 0.65]
+        xs.push([x]);
+        ys.push([f(x) + (rand() - 0.5) * 0.1]);
+    }
+    return { X: new Matrix(xs), Y: new Matrix(ys) };
+}
+
+const std = (model: BayesianLinearRegression, x: number) => model.predictiveStandardDeviation(new Matrix([[x]]))[0];
+
+describe('BayesianLinearRegression', () => {
+
+    it('fits the mean curve through the data', () => {
+        const { X, Y } = dataset(30);
+        const model = new BayesianLinearRegression().setBasis('gaussian').setNumberOfBases(6).setBasisWidth(0.15).setBeta(40).setSeed(0);
+        model.train(X, Y);
+
+        for (const x of [0.3, 0.45, 0.6]) {
+            const predicted = model.predict(new Matrix([[x]])).getElement(0, 0);
+            expect(Math.abs(predicted - f(x))).toBeLessThan(0.12); // close to the true sine within the data
+        }
+    });
+
+    it('grows less certain away from the data (the error bars fan out)', () => {
+        const { X, Y } = dataset(30);
+        const model = new BayesianLinearRegression().setBasis('gaussian').setNumberOfBases(6).setBasisWidth(0.15).setBeta(40).setSeed(0);
+        model.train(X, Y);
+
+        expect(std(model, 0.0)).toBeGreaterThan(std(model, 0.4));   // extrapolating left
+        expect(std(model, 0.95)).toBeGreaterThan(std(model, 0.4));  // extrapolating right
+    });
+
+    it('gets more certain as more data arrives (the posterior contracts)', () => {
+        const train = (count: number) => {
+            const { X, Y } = dataset(count);
+            const model = new BayesianLinearRegression().setBasis('gaussian').setNumberOfBases(6).setBasisWidth(0.15).setBeta(40).setSeed(0);
+            return model.train(X, Y);
+        };
+        expect(std(train(40), 0.4)).toBeLessThan(std(train(4), 0.4));
+    });
+
+    it('draws posterior curves that bunch up on the data and spread off it', () => {
+        const { X, Y } = dataset(30);
+        const model = new BayesianLinearRegression().setBasis('gaussian').setNumberOfBases(6).setBasisWidth(0.15).setBeta(40).setSeed(0);
+        model.train(X, Y);
+
+        const curves = model.sample(new Matrix([[0.4], [0.95]]), 150, 3);
+        expect(curves.length).toBe(150);
+        const spread = (col: number) => {
+            const values = curves.map(c => c[col]);
+            const mean = values.reduce((a, b) => a + b, 0) / values.length;
+            return Math.sqrt(values.reduce((a, b) => a + (b - mean) ** 2, 0) / values.length);
+        };
+        expect(spread(1)).toBeGreaterThan(spread(0) * 2); // far-from-data curves vary much more
+    });
+
+    it('also fits with a polynomial basis', () => {
+        const { X, Y } = dataset(30);
+        const model = new BayesianLinearRegression().setBasis('polynomial').setDegree(4).setAlpha(0.5).setBeta(40);
+        model.train(X, Y);
+
+        expect(Math.abs(model.predict(new Matrix([[0.45]])).getElement(0, 0) - f(0.45))).toBeLessThan(0.15);
+        expect(std(model, 1.1)).toBeGreaterThan(std(model, 0.45)); // polynomials extrapolate very unsurely
+    });
+
+    it('is deterministic and shaped correctly', () => {
+        const { X, Y } = dataset(20);
+        const model = new BayesianLinearRegression().setNumberOfBases(5).setSeed(7).train(X, Y);
+        const grid = new Matrix([[0.1], [0.5], [0.9]]);
+
+        expect(model.predict(grid).getRowCount()).toBe(3);
+        expect(model.predictiveStandardDeviation(grid).length).toBe(3);
+        expect(model.sample(grid, 4, 2)).toEqual(model.sample(grid, 4, 2)); // same seed → same curves
+    });
+
+    it('round-trips its hyperparameters and chains setters', () => {
+        const model = new BayesianLinearRegression();
+        expect(model.getBasis()).toBe('gaussian');
+
+        const returned = model.setBasis('polynomial').setDegree(3).setNumberOfBases(8).setBasisWidth(0.2).setAlpha(2).setBeta(10).setSeed(5);
+        expect(returned).toBe(model);
+        expect(model.getBasis()).toBe('polynomial');
+        expect(model.getDegree()).toBe(3);
+        expect(model.getNumberOfBases()).toBe(8);
+        expect(model.getBasisWidth()).toBe(0.2);
+        expect(model.getAlpha()).toBe(2);
+        expect(model.getBeta()).toBe(10);
+        expect(model.getSeed()).toBe(5);
+    });
+});


### PR DESCRIPTION
Chapter 30 — **Bayesian inference**, the **finale** of Part 6 and of the whole course. The model that finally reports its own uncertainty: a full posterior over the weights, so predictions come with error bars — tight where there's data, fanning wide open where there isn't.

## Library
- `BayesianLinearRegression` (in `src/lib/machine-learning/supervised/`): closed-form conjugate Bayesian regression over a Gaussian or polynomial basis. `predict` (posterior mean), `predictiveStandardDeviation` (noise floor + epistemic term), `sample` (draw whole curves from the posterior, via a Cholesky of the covariance). Seeded, chainable.
- 7 tests: fits the mean, error bars fan out off the data, posterior contracts with evidence, sample spread, polynomial basis, determinism + shapes, setter round-trip. (215 total pass.)
- Demo block (ASCII error-bar plot), README section + keywords.

## Site
- `ml/bayesianDatasets.ts` — three layouts (Unseen edges / The gap / Sparse evidence) that leave part of the domain unobserved.
- `viz/bayesian.ts` — 95% credible band, posterior sample curves, mean fit, observations, hidden truth.
- `BayesianLinearRegressionPlayground.tsx` + MDX tutorial — reveals points one by one; the band collapses onto evidence and stays wide where there's none. Registered as Ch 30.
- `docs/course-plan.md` flipped Ch 30 ✅ — **course complete**.

## 🎉 Course complete
This release finishes the story-driven course: **all 31 chapters (Ch 0–30) across all six parts**, every algorithm built from scratch with tests, a playground, and a tutorial — from the baseline predictors to reasoning under uncertainty.

## Release
- Version bumped 0.16.0 → **0.17.0** (minor bump per new-algorithm batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)