### PR TITLE
fix(site): chart-first playground layout

### DIFF
--- a/site/src/components/AnomalyDetectionPlayground.module.css
+++ b/site/src/components/AnomalyDetectionPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .boundaryWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
 }
 
 .boundary {
@@ -40,9 +35,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -52,12 +45,3 @@
     line-height: 1.5;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/AssociationRulesPlayground.module.css
+++ b/site/src/components/AssociationRulesPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .boundaryWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
 }
 
 .boundary {
@@ -27,9 +22,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -70,12 +63,3 @@
     font-variant-numeric: tabular-nums;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/AutoencoderPlayground.module.css
+++ b/site/src/components/AutoencoderPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 420px) minmax(240px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .gridWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
     background: #0b1120;
 }
 
@@ -41,9 +36,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .triptychWrap {
@@ -66,12 +59,3 @@
     line-height: 1.5;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/BanditPlayground.module.css
+++ b/site/src/components/BanditPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .chartWrap {
@@ -42,9 +36,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -54,12 +46,3 @@
     line-height: 1.5;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/BaselinePlayground.module.css
+++ b/site/src/components/BaselinePlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(220px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .plotWrap {
@@ -40,9 +34,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -52,12 +44,3 @@
     line-height: 1.6;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/BayesianLinearRegressionPlayground.module.css
+++ b/site/src/components/BayesianLinearRegressionPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 520px) minmax(220px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .plotWrap {
@@ -42,9 +36,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -54,12 +46,3 @@
     line-height: 1.5;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/CNNPlayground.module.css
+++ b/site/src/components/CNNPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(220px, 280px);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .vizWrap {
@@ -27,9 +21,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -45,12 +37,3 @@
     height: 130px;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/ContextualBanditPlayground.module.css
+++ b/site/src/components/ContextualBanditPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 520px) minmax(240px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .chartWrap {
@@ -28,9 +22,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .legend {
@@ -61,12 +53,3 @@
     line-height: 1.5;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/DBSCANPlayground.module.css
+++ b/site/src/components/DBSCANPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .boundaryWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
 }
 
 .boundary {
@@ -40,9 +35,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -52,12 +45,3 @@
     line-height: 1.5;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/DecisionTreePlayground.module.css
+++ b/site/src/components/DecisionTreePlayground.module.css
@@ -1,20 +1,15 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .boundaryWrap {
     position: relative;
     aspect-ratio: 1 / 1;
+    max-width: 620px;
     border: 1px solid var(--border);
     border-radius: var(--radius);
     overflow: hidden;
@@ -41,9 +36,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -89,12 +82,3 @@
     font-style: italic;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/DeepQNetworkPlayground.module.css
+++ b/site/src/components/DeepQNetworkPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(240px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .gridWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
     background: #0b1120;
 }
 
@@ -56,9 +51,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -68,12 +61,3 @@
     line-height: 1.5;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/GradientBoostingPlayground.module.css
+++ b/site/src/components/GradientBoostingPlayground.module.css
@@ -1,20 +1,15 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .boundaryWrap {
     position: relative;
     aspect-ratio: 1 / 1;
+    max-width: 620px;
     border: 1px solid var(--border);
     border-radius: var(--radius);
     overflow: hidden;
@@ -41,9 +36,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -53,12 +46,3 @@
     line-height: 1.6;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/HierarchicalClusteringPlayground.module.css
+++ b/site/src/components/HierarchicalClusteringPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .boundaryWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
 }
 
 .boundary {
@@ -40,9 +35,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -58,12 +51,3 @@
     height: 190px;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/Layout.module.css
+++ b/site/src/components/Layout.module.css
@@ -124,6 +124,7 @@
 .content {
     padding: 28px 28px 80px;
     min-width: 0;
+    container-type: inline-size; /* lets .breakout size itself to the content area via cqw */
 }
 
 .loading {

--- a/site/src/components/LinearRegressionPlayground.module.css
+++ b/site/src/components/LinearRegressionPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .plotWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
 }
 
 .plot {
@@ -40,9 +35,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .equation {
@@ -58,12 +51,3 @@
     height: 150px;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/LogisticRegressionPlayground.module.css
+++ b/site/src/components/LogisticRegressionPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .boundaryWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
 }
 
 .boundary {
@@ -40,9 +35,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -58,12 +51,3 @@
     height: 150px;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/ManyFeaturesPlayground.module.css
+++ b/site/src/components/ManyFeaturesPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .plotWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
 }
 
 .plot {
@@ -40,9 +35,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .recipe {
@@ -72,12 +65,3 @@
     height: 150px;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/NaiveBayesPlayground.module.css
+++ b/site/src/components/NaiveBayesPlayground.module.css
@@ -1,14 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .textarea {
@@ -112,8 +107,3 @@
     color: var(--muted);
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/NeuralNetworkPlayground.module.css
+++ b/site/src/components/NeuralNetworkPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(280px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .boundaryWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
 }
 
 .boundary {
@@ -40,9 +35,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .diagramCanvas {
@@ -57,12 +50,3 @@
     height: 140px;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/OverfittingPlayground.module.css
+++ b/site/src/components/OverfittingPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .plotWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
 }
 
 .plot {
@@ -40,9 +35,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -58,12 +51,3 @@
     height: 150px;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/PCAPlayground.module.css
+++ b/site/src/components/PCAPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .boundaryWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
 }
 
 .boundary {
@@ -40,9 +35,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -52,12 +45,3 @@
     line-height: 1.5;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/PerceptronPlayground.module.css
+++ b/site/src/components/PerceptronPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .boundaryWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
 }
 
 .boundary {
@@ -40,9 +35,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -52,12 +45,3 @@
     line-height: 1.5;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/PlaygroundLayout.module.css
+++ b/site/src/components/PlaygroundLayout.module.css
@@ -1,0 +1,36 @@
+/*
+ * Shared playground layout, composed by every *Playground.module.css. Chart-first:
+ * a sticky controls rail on the left, the visualization filling all remaining
+ * width, and the metrics/explainer cards flowing in a row beneath it — the cards
+ * yield space, never the chart. Layout changes belong here, not in the
+ * per-playground files (those should only style the charts themselves).
+ */
+
+.playground {
+    display: grid;
+    grid-template-columns: 260px minmax(0, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+/* Single column: the chart on top at full width, the card row underneath. */
+.stage {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 20px;
+    align-items: start;
+}
+
+/* Metrics + explainer cards flow into as many ~220px+ columns as fit. */
+.side {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+    align-items: start;
+}
+
+@media (max-width: 900px) {
+    .playground {
+        grid-template-columns: 1fr;
+    }
+}

--- a/site/src/components/QLearningPlayground.module.css
+++ b/site/src/components/QLearningPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(240px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .gridWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
     background: #0b1120;
 }
 
@@ -56,9 +51,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -68,12 +61,3 @@
     line-height: 1.5;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/RNNPlayground.module.css
+++ b/site/src/components/RNNPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .boundaryWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
 }
 
 .boundary {
@@ -40,9 +35,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .sampleList {
@@ -72,12 +65,3 @@
     height: 130px;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/RandomForestPlayground.module.css
+++ b/site/src/components/RandomForestPlayground.module.css
@@ -1,20 +1,15 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .boundaryWrap {
     position: relative;
     aspect-ratio: 1 / 1;
+    max-width: 620px;
     border: 1px solid var(--border);
     border-radius: var(--radius);
     overflow: hidden;
@@ -41,9 +36,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -53,12 +46,3 @@
     line-height: 1.6;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/RecommenderPlayground.module.css
+++ b/site/src/components/RecommenderPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(220px, 280px);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .gridWrap {
@@ -93,9 +87,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -126,12 +118,3 @@
     font-variant-numeric: tabular-nums;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/SupportVectorMachinePlayground.module.css
+++ b/site/src/components/SupportVectorMachinePlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 460px) minmax(260px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .boundaryWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
 }
 
 .boundary {
@@ -40,9 +35,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -58,12 +51,3 @@
     height: 150px;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/TimeSeriesPlayground.module.css
+++ b/site/src/components/TimeSeriesPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(220px, 280px);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .chartWrap {
@@ -40,9 +34,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -52,12 +44,3 @@
     line-height: 1.5;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/TransformerPlayground.module.css
+++ b/site/src/components/TransformerPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(220px, 280px);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .attnWrap {
@@ -27,9 +21,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .note {
@@ -45,12 +37,3 @@
     height: 130px;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/components/VariationalAutoencoderPlayground.module.css
+++ b/site/src/components/VariationalAutoencoderPlayground.module.css
@@ -1,15 +1,9 @@
 .playground {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 20px;
-    align-items: start;
+    composes: playground from './PlaygroundLayout.module.css';
 }
 
 .stage {
-    display: grid;
-    grid-template-columns: minmax(0, 420px) minmax(240px, 1fr);
-    gap: 20px;
-    align-items: start;
+    composes: stage from './PlaygroundLayout.module.css';
 }
 
 .gridWrap {
@@ -19,6 +13,7 @@
     border: 1px solid var(--border);
     box-shadow: 0 20px 60px -30px rgba(56, 189, 248, 0.5);
     aspect-ratio: 1 / 1;
+    max-width: 620px;
     background: #0b1120;
 }
 
@@ -41,9 +36,7 @@
 }
 
 .side {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    composes: side from './PlaygroundLayout.module.css';
 }
 
 .galleryWrap {
@@ -66,12 +59,3 @@
     line-height: 1.5;
 }
 
-@media (max-width: 900px) {
-    .playground {
-        grid-template-columns: 1fr;
-    }
-
-    .stage {
-        grid-template-columns: 1fr;
-    }
-}

--- a/site/src/styles/prose.css
+++ b/site/src/styles/prose.css
@@ -91,8 +91,10 @@
     padding: 4px 0;
 }
 
-/* Let an embedded playground break out of the narrow prose column. */
+/* Let an embedded playground break out of the narrow prose column and span the
+   full content area (100cqw = the .content container's inner width). A plain
+   max-width: none can't do it — the prose column itself is only 760px wide. */
 .prose .breakout {
     max-width: none;
-    margin: 28px 0;
+    margin: 28px min(0px, calc((760px - 100cqw) / 2));
 }


### PR DESCRIPTION
## Problem

Every playground rendered its visualization tiny (~200–440px) even on wide monitors, because:

1. `.breakout` never actually broke out of the 760px prose column — `max-width: none` on a child can't exceed its parent's width, so the whole playground (controls + chart + cards) was crammed into the text column.
2. Inside that space, all 30 playgrounds used the same 3-across grid in which the chart was the only flexible column, so it absorbed 100% of the squeeze while the 260px controls rail and ~260px card column kept their width.

## Fix

- `.breakout` now spans the full content area using container-query units (`100cqw` of `.content`), giving playgrounds ~996px instead of 760px.
- New shared `PlaygroundLayout.module.css`, composed by all 30 per-playground stylesheets: controls rail left, chart filling all remaining width (~716px), metrics + explainer cards flowing in a responsive row *below* the chart. Square charts are width-capped at 620px so they don't grow overly tall.
- Net dedupe: 147 insertions, 574 deletions; no TSX changes.

## Verified

Served the built site and measured rendered geometry from headless-Chromium screenshots at 1400/1000/760px viewports across bandits, logistic-regression, autoencoders, naive-bayes, cnn, and recommender-systems: chart full-width everywhere, cards reflow below, single-column collapse at narrow widths, no overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)