### PR TITLE
fix(site): playground metrics row overflowed into the cards

### DIFF
--- a/site/src/components/PlaygroundLayout.module.css
+++ b/site/src/components/PlaygroundLayout.module.css
@@ -21,12 +21,12 @@
     align-items: start;
 }
 
-/* Metrics + explainer cards flow into as many ~220px+ columns as fit. */
+/* Metrics + explainer cards flow into as many ~220px+ columns as fit.
+   Items stretch to equal height per row so mixed-length cards don't stagger. */
 .side {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 16px;
-    align-items: start;
 }
 
 @media (max-width: 900px) {

--- a/site/src/components/controls/Controls.module.css
+++ b/site/src/components/controls/Controls.module.css
@@ -114,6 +114,7 @@
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 10px;
+    grid-column: 1 / -1; /* in the playground card row, the metrics strip gets a full row to itself */
 }
 
 .metric {
@@ -141,6 +142,8 @@
 
 .badge {
     align-self: flex-start;
+    grid-column: 1 / -1; /* same: a pill shouldn't sit in (and overflow) a card-sized cell */
+    justify-self: start;
     background: rgba(52, 211, 153, 0.12);
     border: 1px solid rgba(52, 211, 153, 0.4);
     color: var(--good);


### PR DESCRIPTION
Follow-up to #22, fixing the regressions it shipped:

- **Metrics overlapped neighbouring cards** (visible on deep-rl, cnn): `MetricsRow` is a rigid `repeat(3, 1fr)` grid whose min-content width exceeds a ~228px card cell, so it overflowed under the card next to it; the CNN "Gradients verified" badge likewise painted over the accuracy metric. The metrics strip and badge now span the full card row.
- **Ragged card rows** (visible on generative-models): cards of very different heights staggered with `align-items: start`; rows now stretch to equal height.

Verified on the rebuilt site at 1400px across deep-rl, cnn, generative-models, and bandits: no overlaps, even card rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)